### PR TITLE
Rename inventory.yaml to ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To use the Enterprise SONiC collection in Ansible 2.9, it is required to add one
 Option 1: Add the environment variable while running the playbook.
 
 
-      ANSIBLE_NETWORK_GROUP_MODULES=sonic ansible-playbook sample_playbook.yaml -i inventory.yaml
+      ANSIBLE_NETWORK_GROUP_MODULES=sonic ansible-playbook sample_playbook.yaml -i inventory.ini
       
       
 Option 2: Add the environment variable in user profile.
@@ -217,7 +217,7 @@ Sample playbooks
     ansible_httpapi_use_ssl: true
     ansible_httpapi_validate_certs: false
 
-***inventory.yaml***
+***inventory.ini***
 
     [sonic_sw1]
     sonic_sw1 ansible_host=100.104.28.119


### PR DESCRIPTION
The suggested content is in INI format, so reflect that with the file extension so Ansible is happy.

##### SUMMARY

The suggested `inventory.yaml` is not using Ansible YAML inventory format but rather the INI format.


##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

README

