### PR TITLE
Fixed bgp as path and authentication radius and tacacs bugs for 3.4

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_as_paths/bgp_as_paths.py
@@ -37,7 +37,7 @@ class Bgp_as_pathsArgs(object):  # pylint: disable=R0903
         pass
 
     argument_spec = {'config': {'elements': 'dict',
-                                'options': {'permit': { 'required': False, 'type': 'bool'},
+                                'options': {'permit': {'required': False, 'type': 'bool'},
                                             'members': {'elements': 'str',
                                                         'required': False,
                                                         'type': 'list'},

--- a/plugins/module_utils/network/sonic/argspec/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_as_paths/bgp_as_paths.py
@@ -37,7 +37,8 @@ class Bgp_as_pathsArgs(object):  # pylint: disable=R0903
         pass
 
     argument_spec = {'config': {'elements': 'dict',
-                                'options': {'members': {'elements': 'str',
+                                'options': {'permit': { 'required': False, 'type': 'bool'},
+                                            'members': {'elements': 'str',
                                                         'required': False,
                                                         'type': 'list'},
                                             'name': {'required': True, 'type': 'str'}},

--- a/plugins/module_utils/network/sonic/config/aaa/aaa.py
+++ b/plugins/module_utils/network/sonic/config/aaa/aaa.py
@@ -215,7 +215,7 @@ class Aaa(ConfigBase):
     def get_delete_all_aaa_request(self, have):
         requests = []
         if "authentication" in have and have["authentication"]:
-            if "local" or "group" in have["authentication"]["data"]:
+            if "local" in have["authentication"]["data"] or "group" in have["authentication"]["data"]:
                 request = self.get_authentication_method_delete_request()
                 requests.append(request)
             if "fail_through" in have["authentication"]["data"]:

--- a/plugins/module_utils/network/sonic/config/bgp/bgp.py
+++ b/plugins/module_utils/network/sonic/config/bgp/bgp.py
@@ -564,7 +564,7 @@ class Bgp(ConfigBase):
                 if 'keepalive_interval' in conf['timers']:
                     keepalive_interval = conf['timers']['keepalive_interval']
 
-            if not any([cfg for cfg in have if cfg['vrf_name'] == vrf_name and (cfg['bgp_as'] == as_val)]):
+            if not any(cfg for cfg in have if cfg['vrf_name'] == vrf_name and (cfg['bgp_as'] == as_val)):
                 new_bgp_req = self.get_new_bgp_request(vrf_name, as_val)
                 if new_bgp_req:
                     requests.append(new_bgp_req)

--- a/plugins/module_utils/network/sonic/config/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/config/bgp_as_paths/bgp_as_paths.py
@@ -255,7 +255,8 @@ class Bgp_as_paths(ConfigBase):
         return request
 
     def get_delete_single_as_path_action_requests(self, name):
-        url = "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set={}/openconfig-bgp-policy-ext:action"
+        url = "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set={}"
+        url = url + "/openconfig-bgp-policy-ext:action"
         method = "DELETE"
         request = {"path": url.format(name), "method": method}
         return request

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -540,7 +540,7 @@ class Bgp_neighbors(ConfigBase):
                         want_pg_match = next((cfg for cfg in want_peer_group if cfg['name'] == name), None)
                     if want_pg_match:
                         keys = ['remote_as', 'timers', 'advertisement_interval', 'bfd', 'capability', 'address_family']
-                        if not any([want_pg_match.get(key, None) for key in keys]):
+                        if not any(want_pg_match.get(key, None) for key in keys):
                             requests.append(self.get_delete_vrf_specific_peergroup_request(vrf_name, name))
                 else:
                     requests.extend(self.delete_specific_peergroup_param_request(vrf_name, each))
@@ -624,7 +624,7 @@ class Bgp_neighbors(ConfigBase):
                         want_nei_match = next(cfg for cfg in want_neighbors if cfg['neighbor'] == neighbor)
                     if want_nei_match:
                         keys = ['remote_as', 'peer_group', 'timers', 'advertisement_interval', 'bfd', 'capability']
-                        if not any([want_nei_match.get(key, None) for key in keys]):
+                        if not any(want_nei_match.get(key, None) for key in keys):
                             requests.append(self.delete_neighbor_whole_request(vrf_name, neighbor))
                 else:
                     requests.extend(self.delete_specific_param_request(vrf_name, each))

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -405,7 +405,7 @@ class Bgp_neighbors_af(ConfigBase):
                 if conf_route_map and mat_route_map:
                     del_routes = []
                     for route in conf_route_map:
-                        if any([e_route for e_route in mat_route_map if route['direction'] == e_route['direction']]):
+                        if any(e_route for e_route in mat_route_map if route['direction'] == e_route['direction']):
                             del_routes.append(route)
                     if del_routes:
                         requests.extend(self.get_delete_neighbor_af_routemaps_requests(vrf_name, conf_neighbor_val, conf_afi, conf_safi, del_routes))

--- a/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
@@ -232,6 +232,8 @@ class Radius_server(ConfigBase):
                     radius_port_key_cfg['auth-port'] = host['port']
                 if host.get('key', None):
                     radius_port_key_cfg['secret-key'] = host['key']
+                if host.get('retransmit', None):
+                    radius_port_key_cfg['retransmit-attempts'] = host['retransmit']
                 if host.get('source_interface', None):
                     radius_port_key_cfg['openconfig-aaa-radius-ext:source-interface'] = host['source_interface']
 

--- a/plugins/module_utils/network/sonic/facts/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_as_paths/bgp_as_paths.py
@@ -65,8 +65,13 @@ class Bgp_as_pathsFacts(object):
             as_name = as_path["as-path-set-name"]
             member_config = as_path['config']
             members = member_config.get("as-path-set-member", [])
+            permit_str = member_config.get("openconfig-bgp-policy-ext:action", None)
             result['name'] = as_name
             result['members'] = members
+            if permit_str and permit_str == "PERMIT":
+                result['permit'] = True
+            else:
+                result['permit'] = False
             as_path_list_configs.append(result)
         # with open('/root/ansible_log.log', 'a+') as fp:
         #     fp.write('as_path_list: ' + str(as_path_list_configs) + '\n')
@@ -116,7 +121,9 @@ class Bgp_as_pathsFacts(object):
         try:
             config['name'] = str(conf['name'])
             config['members'] = conf['members']
+            config['permit'] = conf['permit']
         except TypeError:
             config['name'] = None
             config['members'] = None
+            config['permit'] = None
         return utils.remove_empties(config)

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors_af/bgp_neighbors_af.py
@@ -63,7 +63,7 @@ class Bgp_neighbors_afFacts(object):
             if route_map_key in data:
                 route_map = data['route_map']
                 for e_route in data[route_map_key]:
-                    direction = route_map_key.split('_')[0]
+                    direction = route_map_key.split('_', maxsplit=1)[0]
                     route_map.append({'name': e_route, 'direction': direction})
                 data.pop(route_map_key)
 

--- a/plugins/module_utils/network/sonic/facts/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/facts/tacacs_server/tacacs_server.py
@@ -133,8 +133,8 @@ class Tacacs_serverFacts(object):
                         host_data['priority'] = cfg['openconfig-system-ext:priority']
                     if 'openconfig-system-ext:vrf' in cfg:
                         host_data['vrf'] = cfg['openconfig-system-ext:vrf']
-                    if 'timout' in cfg:
-                        host_data['timout'] = cfg['timout']
+                    if 'timeout' in cfg:
+                        host_data['timeout'] = cfg['timeout']
                 if tacacs_host.get('tacacs', None) and tacacs_host['tacacs'].get('config', None):
                     tacas_cfg = tacacs_host['tacacs']['config']
                     if tacas_cfg.get('port', None):

--- a/plugins/modules/sonic_bgp_as_paths.py
+++ b/plugins/modules/sonic_bgp_as_paths.py
@@ -58,6 +58,11 @@ options:
         elements: str
         description:
         - Members of this BGP as-path; regular expression string can be provided.
+      permit:
+        required: False
+        type: bool
+        description:
+        - Permits or denies this as path.
   state:
     description:
     - The state of the configuration after module completion.

--- a/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
@@ -57,7 +57,7 @@ tests:
             - "101.101"
             - "201.201"
             - "301.301"
-          permit: False
+          permit: True
         - name: test_2
           members:
             - '111\\:'

--- a/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
@@ -16,9 +16,11 @@ tests:
       - name: test
         members:
           - "11"
+        permit: True
       - name: test_1
         members:
           - "101.101"
+        permit: False
   - name: test_case_02
     description: Update created BGP properties
     state: merged
@@ -29,17 +31,20 @@ tests:
             - "22"
             - "33"
             - 44
+          permit: True
         - name: test_1
           members:
             - "101.101"
             - "201.201"
             - "301.301"
+          permit: False
         - name: test_2
           members:
             - '111\\:'
             - '11\\d+'
             - '113\\*'
             - '114\\'
+          permit: True
   - name: test_case_03
     description: Delete BGP properties
     state: deleted
@@ -52,19 +57,22 @@ tests:
             - "101.101"
             - "201.201"
             - "301.301"
+          permit: False
         - name: test_2
           members:
             - '111\\:'
             - '11\\d+'
             - '113\\*'
             - '114\\'
+          permit: True
   - name: test_case_04
     description: Delete BGP properties
     state: deleted
     input:
         - name: test
-          members:          
+          members:
+          permit:          
   - name: test_case_05
     description: Delete BGP properties
     state: deleted
-    input: []        
+    input: []

--- a/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
@@ -31,13 +31,13 @@ tests:
             - "22"
             - "33"
             - 44
-          permit: True
+          permit: False
         - name: test_1
           members:
             - "101.101"
             - "201.201"
             - "301.301"
-          permit: False
+          permit: True
         - name: test_2
           members:
             - '111\\:'

--- a/tests/regression/roles/sonic_radius_server/defaults/main.yml
+++ b/tests/regression/roles/sonic_radius_server/defaults/main.yml
@@ -14,7 +14,6 @@ tests:
     state: merged
     input:
       auth_type: chap
-      key: chap
       timeout: 12
       nas_ip: 10.11.12.13
       retransmit: 5
@@ -26,7 +25,6 @@ tests:
             priority: 3
             vrf: mgmt
             timeout: 12
-            key: chap
             port: 55
             source_interface: "{{ interface1 }}"
             retransmit: 7
@@ -35,7 +33,6 @@ tests:
             priority: 4
             vrf: mgmt
             timeout: 15
-            key: pap
             port: 56
             source_interface: "{{ interface2 }}"
             retransmit: 8
@@ -44,7 +41,6 @@ tests:
             priority: 6
             vrf: mgmt
             timeout: 20
-            key: mschapv2
             port: 57
             source_interface: "{{ interface3 }}"
             retransmit: 9
@@ -53,13 +49,11 @@ tests:
     state: merged
     input:
       auth_type: mschapv2
-      key: login
       timeout: 24
       servers:
         host:
           - name: my_host
             auth_type: mschapv2
-            key: mschapv2
             port: 45
             timeout: 9
             vrf: mgmt
@@ -83,7 +77,6 @@ tests:
     state: merged
     input:
       auth_type: chap
-      key: chap
       timeout: 12
       nas_ip: 10.11.12.13
       retransmit: 5
@@ -95,7 +88,6 @@ tests:
             priority: 3
             vrf: mgmt
             timeout: 12
-            key: chap
             port: 55
             source_interface: "{{ interface1 }}"
             retransmit: 7
@@ -104,7 +96,6 @@ tests:
             priority: 4
             vrf: mgmt
             timeout: 15
-            key: pap
             port: 56
             source_interface: "{{ interface2 }}"
             retransmit: 8
@@ -113,7 +104,6 @@ tests:
             priority: 6
             vrf: mgmt
             timeout: 20
-            key: mschapv2
             port: 57
             source_interface: "{{ interface3 }}"
             retransmit: 9

--- a/tests/regression/roles/sonic_tacacs_server/defaults/main.yml
+++ b/tests/regression/roles/sonic_tacacs_server/defaults/main.yml
@@ -14,26 +14,22 @@ tests:
     state: merged
     input:
       auth_type: chap
-      key: chap
       source_interface: "{{ interface1 }}"
       timeout: 12
       servers:
         host:
           - name: my_host
             auth_type: chap
-            key: chap
             port: 55
             timeout: 12
             priority: 3
           - name: my_host1
             auth_type: login
-            key: login
             port: 60
             timeout: 14
             priority: 4
           - name: my_host2
             auth_type: login
-            key: login
             port: 60
             timeout: 14
             priority: 4
@@ -42,14 +38,12 @@ tests:
     state: merged
     input:
       auth_type: login
-      key: login
       source_interface: "{{ interface2 }}"
       timeout: 24
       servers:
         host:
           - name: my_host
             auth_type: mschap
-            key: mschap
             port: 45
             timeout: 9
             priority: 5
@@ -77,19 +71,16 @@ tests:
         host:
           - name: my_host
             auth_type: chap
-            key: chap
             port: 55
             timeout: 12
             priority: 3
           - name: my_host1
             auth_type: login
-            key: login
             port: 60
             timeout: 14
             priority: 4
           - name: my_host2
             auth_type: login
-            key: login
             port: 60
             timeout: 14
             priority: 4

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,0 +1,1 @@
+plugins/action/sonic.py action-plugin-docs #action plugin for base class


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Added a permit attribute to the bgp_as_paths module and updated argspec, config, facts, and test cases accordingly
- Fixed retransmit-attempts bug for radius_server
- Fixed timeout bug for tacacs server
- Removed key attribute from server testcases since there is no key decryption

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- Fixes #SNC-14120
- Fixes #SNC-13726
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- sonic_bgp_as_paths
- sonic_radius_server
- sonic_tacacs_server

[logs.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/7463989/logs.pdf)

Final pre-merge passing regression results:


[shade_bgp_pr_regression_log_2021_1109_1138.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/7507653/shade_bgp_pr_regression_log_2021_1109_1138.txt)

