### PR TITLE
Fixed BGP regression failure bugs

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/bgp_af/bgp_af.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_af/bgp_af.py
@@ -48,22 +48,6 @@ class Bgp_afArgs(object):  # pylint: disable=R0903
                             'options': {
                                 'advertise_all_vni': {'type': 'bool'},
                                 'advertise_default_gw': {'type': 'bool'},
-                                'advertise_prefix': {
-                                    'elements': 'dict',
-                                    'options': {
-                                        'afi': {
-                                            'choices': ['ipv4', 'ipv6', 'l2vpn'],
-                                            'type': 'str'
-                                        },
-                                        'safi': {
-                                            'choices': ['unicast', 'evpn'],
-                                            'default': 'unicast',
-                                            'type': 'str'
-                                        }
-                                    },
-                                    'required_together': [['afi', 'safi']],
-                                    'type': 'list'
-                                },
                                 'afi': {
                                     'choices': ['ipv4', 'ipv6', 'l2vpn'],
                                     'required': True,

--- a/plugins/module_utils/network/sonic/config/bgp_af/bgp_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_af/bgp_af.py
@@ -49,7 +49,6 @@ TEST_KEYS = [
     {'config': {'vrf_name': '', 'bgp_as': ''}},
     {'afis': {'afi': '', 'safi': ''}},
     {'redistribute': {'protocol': ''}},
-    {'advertise_prefix': {'afi': '', 'safi': ''}},
 ]
 
 
@@ -211,7 +210,6 @@ class Bgp_af(ConfigBase):
         request = None
         conf_adv_all_vni = conf_addr_fam.get('advertise_all_vni', None)
         conf_adv_default_gw = conf_addr_fam.get('advertise_default_gw', None)
-        conf_advt_list = conf_addr_fam.get('advertise_prefix', None)
         afi_safi = ("%s_%s" % (conf_afi, conf_safi)).upper()
         evpn_cfg = {}
         if conf_adv_all_vni:
@@ -219,13 +217,6 @@ class Bgp_af(ConfigBase):
 
         if conf_adv_default_gw:
             evpn_cfg['advertise-default-gw'] = conf_adv_default_gw
-
-        adv_prefix_cfg = []
-        if conf_advt_list is not None:
-            for adv_prefix in conf_advt_list:
-                adv_prefix_cfg.append("openconfig-bgp-types:" + ("%s_%s" % (adv_prefix['afi'], adv_prefix['safi'])).upper())
-            if adv_prefix_cfg:
-                evpn_cfg['advertise-list'] = adv_prefix_cfg
 
         if evpn_cfg:
             url = '%s=%s/%s/global' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
@@ -463,32 +454,6 @@ class Bgp_af(ConfigBase):
 
         return requests
 
-    def get_delete_advertise_list_request(self, vrf_name, conf_afi, conf_safi, conf_advt_list=None, mat_advt_list=None):
-        requests = []
-        afi_safi = ("%s_%s" % (conf_afi, conf_safi)).upper()
-        url = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
-        url += '/%s=%s/%s/advertise-list' % (self.afi_safi_path, afi_safi, self.l2vpn_evpn_config_path)
-
-        if conf_advt_list and mat_advt_list:
-            del_adv_list = []
-            existing_list_len = len(mat_advt_list)
-            for adv in conf_advt_list:
-                diff = get_diff({'advertise_prefix': [adv]}, {'advertise_prefix': mat_advt_list}, [{'advertise_prefix': {'afi': '', 'safi': ''}}])
-                if not diff:
-                    del_adv_list.append(adv)
-            del_adv_list_len = len(del_adv_list)
-            if existing_list_len > 0 and existing_list_len == del_adv_list_len:
-                requests.append({"path": url, "method": DELETE})
-            else:
-                for del_adv in del_adv_list:
-                    del_afi_safi = ("=%s_%s" % (del_adv['afi'], del_adv['safi'])).upper()
-                    url += del_afi_safi
-                    requests.append({"path": url, "method": DELETE})
-        else:
-            requests.append({"path": url, "method": DELETE})
-
-        return requests
-
     def get_delete_advertise_default_gw_request(self, vrf_name, conf_afi, conf_safi):
         afi_safi = ("%s_%s" % (conf_afi, conf_safi)).upper()
         url = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
@@ -548,7 +513,6 @@ class Bgp_af(ConfigBase):
             conf_redis_arr = conf_addr_fam.get('redistribute', [])
             conf_adv_all_vni = conf_addr_fam.get('advertise_all_vni', None)
             conf_adv_default_gw = conf_addr_fam.get('advertise_default_gw', None)
-            conf_advt_list = conf_addr_fam.get('advertise_prefix', [])
             conf_max_path = conf_addr_fam.get('max_path', None)
             conf_dampening = conf_addr_fam.get('dampening', None)
             conf_network = conf_addr_fam.get('network', [])
@@ -561,8 +525,6 @@ class Bgp_af(ConfigBase):
                     requests.extend(self.get_delete_network_request(vrf_name, conf_afi, conf_safi, conf_network, is_delete_all, None))
                 if conf_adv_default_gw:
                     requests.append(self.get_delete_advertise_default_gw_request(vrf_name, conf_afi, conf_safi))
-                if conf_advt_list:
-                    requests.extend(self.get_delete_advertise_list_request(vrf_name, conf_afi, conf_safi))
                 if conf_redis_arr:
                     requests.extend(self.get_delete_redistribute_requests(vrf_name, conf_afi, conf_safi, conf_redis_arr, is_delete_all, None))
                 if conf_max_path:
@@ -583,20 +545,17 @@ class Bgp_af(ConfigBase):
                         mat_advt_all_vni = match_addr_fam.get('advertise_all_vni', None)
                         mat_redis_arr = match_addr_fam.get('redistribute', [])
                         mat_advt_defaut_gw = match_addr_fam.get('advertise_default_gw', None)
-                        mat_advt_list = match_addr_fam.get('advertise_prefix', [])
                         mat_max_path = match_addr_fam.get('max_path', None)
                         mat_dampening = match_addr_fam.get('dampening', None)
                         mat_network = match_addr_fam.get('network', [])
                         if (conf_adv_all_vni is None and not conf_redis_arr and conf_adv_default_gw is None
-                                and not conf_advt_list and not conf_max_path and conf_dampening is None and not conf_network):
+                                and not conf_max_path and conf_dampening is None and not conf_network):
                             if mat_advt_all_vni is not None:
                                 requests.append(self.get_delete_advertise_all_vni_request(vrf_name, conf_afi, conf_safi))
                             if mat_dampening is not None:
                                 requests.append(self.get_delete_dampening_request(vrf_name, conf_afi, conf_safi))
                             if mat_advt_defaut_gw:
                                 requests.append(self.get_delete_advertise_default_gw_request(vrf_name, conf_afi, conf_safi))
-                            if mat_advt_list:
-                                requests.extend(self.get_delete_advertise_list_request(vrf_name, conf_afi, conf_safi))
                             if mat_redis_arr:
                                 requests.extend(self.get_delete_redistribute_requests(vrf_name, conf_afi, conf_safi, mat_redis_arr, False, mat_redis_arr))
                             if mat_max_path:
@@ -613,8 +572,6 @@ class Bgp_af(ConfigBase):
                                 requests.append(self.get_delete_dampening_request(vrf_name, conf_afi, conf_safi))
                             if conf_adv_default_gw and mat_advt_defaut_gw:
                                 requests.append(self.get_delete_advertise_default_gw_request(vrf_name, conf_afi, conf_safi))
-                            if conf_advt_list is not None and mat_advt_list is not None:
-                                requests.extend(self.get_delete_advertise_list_request(vrf_name, conf_afi, conf_safi, conf_advt_list, mat_advt_list))
                             if conf_redis_arr and mat_redis_arr:
                                 requests.extend(self.get_delete_redistribute_requests(vrf_name, conf_afi, conf_safi, conf_redis_arr, False, mat_redis_arr))
                             if conf_max_path and mat_max_path:

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -329,16 +329,16 @@ class Bgp_neighbors(ConfigBase):
                     bgp_peer_group.update({'enable-bfd': {'config': {'enabled': peer_group['bfd']}}})
                 if peer_group.get('timers', None) is not None:
                     if peer_group['timers'].get('holdtime', None) is not None:
-                        tmp_timers.update({'hold-time': str(peer_group['timers']['holdtime'])})
+                        tmp_timers.update({'hold-time': peer_group['timers']['holdtime']})
                     if peer_group['timers'].get('keepalive', None) is not None:
-                        tmp_timers.update({'keepalive-interval': str(peer_group['timers']['keepalive'])})
+                        tmp_timers.update({'keepalive-interval': peer_group['timers']['keepalive']})
                 if peer_group.get('capability', None) is not None:
                     if peer_group['capability'].get('dynamic', None) is not None:
                         tmp_capability.update({'capability-dynamic': peer_group['capability']['dynamic']})
                     if peer_group['capability'].get('extended_nexthop', None) is not None:
                         tmp_capability.update({'capability-extended-nexthop': peer_group['capability']['extended_nexthop']})
                 if peer_group.get('advertisement_interval', None) is not None:
-                    tmp_timers.update({'minimum-advertisement-interval': str(peer_group['advertisement_interval'])})
+                    tmp_timers.update({'minimum-advertisement-interval': peer_group['advertisement_interval']})
                 if peer_group.get('remote_as', None) is not None:
                     have_nei = self.find_pg(have, bgp_as, vrf_name, peer_group)
                     if peer_group['remote_as'].get('peer_as', None) is not None:
@@ -453,16 +453,16 @@ class Bgp_neighbors(ConfigBase):
                     bgp_neighbor.update({'enable-bfd': {'config': {'enabled': neighbor['bfd']}}})
                 if neighbor.get('timers', None) is not None:
                     if neighbor['timers'].get('holdtime', None) is not None:
-                        tmp_timers.update({'hold-time': str(neighbor['timers']['holdtime'])})
+                        tmp_timers.update({'hold-time': neighbor['timers']['holdtime']})
                     if neighbor['timers'].get('keepalive', None) is not None:
-                        tmp_timers.update({'keepalive-interval': str(neighbor['timers']['keepalive'])})
+                        tmp_timers.update({'keepalive-interval': neighbor['timers']['keepalive']})
                 if neighbor.get('capability', None) is not None:
                     if neighbor['capability'].get('dynamic', None) is not None:
                         tmp_capability.update({'capability-dynamic': neighbor['capability']['dynamic']})
                     if neighbor['capability'].get('extended_nexthop', None) is not None:
                         tmp_capability.update({'capability-extended-nexthop': neighbor['capability']['extended_nexthop']})
                 if neighbor.get('advertisement_interval', None) is not None:
-                    tmp_timers.update({'minimum-advertisement-interval': str(neighbor['advertisement_interval'])})
+                    tmp_timers.update({'minimum-advertisement-interval': neighbor['advertisement_interval']})
                 if neighbor.get('neighbor', None) is not None:
                     bgp_neighbor.update({'neighbor-address': neighbor['neighbor']})
                     neighbor_cfg.update({'neighbor-address': neighbor['neighbor']})

--- a/plugins/module_utils/network/sonic/facts/bgp_af/bgp_af.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_af/bgp_af.py
@@ -55,7 +55,6 @@ class Bgp_afFacts(object):
         'activate': 'enabled',
         'advertise_all_vni': ['l2vpn-evpn', 'openconfig-bgp-evpn-ext:config', 'advertise-all-vni'],
         'advertise_default_gw': ['l2vpn-evpn', 'openconfig-bgp-evpn-ext:config', 'advertise-default-gw'],
-        'advertise_list': ['l2vpn-evpn', 'openconfig-bgp-evpn-ext:config', 'advertise-list'],
         'ebgp': ['use-multiple-paths', 'ebgp', 'maximum-paths'],
         'ibgp': ['use-multiple-paths', 'ibgp', 'maximum-paths'],
         'network': ['network-config', 'network'],
@@ -97,7 +96,6 @@ class Bgp_afFacts(object):
         if not data:
             data = get_bgp_af_data(self._module, self.af_params_map)
             vrf_list = [e_bgp_af['vrf_name'] for e_bgp_af in data]
-            self.normalize_af_advertise_prefix(data)
             self.update_max_paths(data)
             self.update_network(data)
             bgp_redis_data = get_all_bgp_af_redistribute(self._module, vrf_list, self.af_redis_params_map)
@@ -242,16 +240,3 @@ class Bgp_afFacts(object):
                 advertise_default_gw = af.get('advertise_default_gw', None)
                 if advertise_default_gw is None:
                     af['advertise_default_gw'] = False
-
-                if 'advertise_list' not in af:
-                    continue
-                advertise_list = af.get('advertise_list', [])
-                af.pop('advertise_list')
-                advertise_prefix_list = []
-                for advertise in advertise_list:
-                    if advertise in self.afi_safi_types_map:
-                        afi_safi = self.afi_safi_types_map[advertise].split('_')
-                        advertise_prefix_list.append({'afi': afi_safi[0], 'safi': afi_safi[1]})
-
-                if advertise_prefix_list:
-                    af['advertise_prefix'] = advertise_prefix_list

--- a/plugins/modules/sonic_bgp_af.py
+++ b/plugins/modules/sonic_bgp_af.py
@@ -117,29 +117,6 @@ options:
                     description:
                       - Specifies the route map reference.
                     type: str
-              advertise_prefix:
-                description:
-                  - Specifies the prefix of the advertise.
-                  - afi and safi are required together.
-                type: list
-                elements: dict
-                suboptions:
-                  afi:
-                    description:
-                      - Specifies afi of the advertise.
-                    type: str
-                    choices:
-                      - ipv4
-                      - ipv6
-                      - l2vpn
-                  safi:
-                    description:
-                      - Specifies safi of the advertise.
-                    type: str
-                    choices:
-                      - unicast
-                      - evpn
-                    default: unicast
               advertise_default_gw:
                 description:
                   - Specifies the advertise default gateway flag.
@@ -207,7 +184,6 @@ EXAMPLES = """
                safi: evpn
                advertise_all_vni: False
                advertise_default_gw: False
-               advertise_prefix:
              - afi: ipv4
                safi: unicast
              - afi: ipv6
@@ -293,7 +269,6 @@ EXAMPLES = """
                safi: evpn
                advertise_all_vni: False
                advertise_default_gw: False
-               advertise_prefix:
              - afi: ipv4
                safi: unicast
                network:

--- a/tests/regression/roles/sonic_bgp_af/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_af/defaults/main.yml
@@ -89,11 +89,6 @@ tests:
             - afi: l2vpn
               safi: evpn
               advertise_all_vni: True
-              advertise_prefix:
-                - afi: ipv4
-                  safi: unicast
-                - afi: ipv6
-                  safi: unicast
       - bgp_as: "{{bgp_as_2}}"
         vrf_name: "{{vrf_1}}"
         address_family:
@@ -130,11 +125,6 @@ tests:
                   route_map: rmap_reg2
             - afi: l2vpn
               safi: evpn
-              advertise_prefix:
-                - afi: ipv4
-                  safi: unicast
-                - afi: ipv6
-                  safi: unicast
   - name: test_case_03
     description: Update2 created BGP AF properties
     state: merged
@@ -298,7 +288,3 @@ tests:
         vrf_name: default
         address_family:
           afis:
-  - name: test_case_07
-    description: Delete3 BGP AF properties
-    state: deleted
-    input: []

--- a/tests/regression/roles/sonic_bgp_af/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_af/defaults/main.yml
@@ -270,16 +270,6 @@ tests:
             - afi: ipv6
               safi: unicast
               redistribute:
-      - bgp_as: "{{ bgp_as_2 }}"
-        vrf_name: "{{vrf_1}}"
-        address_family:
-          afis:
-            - afi: ipv4
-              safi: unicast
-              redistribute:
-            - afi: ipv6
-              safi: unicast
-              redistribute:
   - name: test_case_06
     description: Delete2 BGP AF properties
     state: deleted
@@ -288,3 +278,7 @@ tests:
         vrf_name: default
         address_family:
           afis:
+  - name: test_case_07
+    description: Delete3 BGP AF properties
+    state: deleted
+    input: []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

- The advertise-list in the OC yang was removed so the advertise_prefix in the sonic_bgp_af module needed to be removed.
- Attributes in the actioner were changed to int so those attributes were changed to int in the sonic_bgp_neighbors module


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_bgp_af, sonic_bgp_neighbors

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
[regression-2022-02-03-10-45-58.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8006609/regression-2022-02-03-10-45-58.pdf)
[bgp_af_regression_report.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8007057/bgp_af_regression_report.pdf)
