### PR TITLE
Cli prompt and answer fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ We plan to regularly release new minor or bugfix versions once new features or b
 
 Enterprise SONiC Ansible Modules deprecation cycle is aligned with [Ansible](https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html).
 
+Source control branches on Github:
+  - Released code versions are located on "release" branches with names of the form "M.x", where "M" specifies the "major" release version for releases residing on the branch.
+  - Unreleased and pre-release code versions are located on sub-branches of the "main" branch. This is a development branch, and is not intended for use in production environments.
+
 Code of Conduct
 ---------------
 

--- a/plugins/module_utils/network/sonic/argspec/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_as_paths/bgp_as_paths.py
@@ -37,7 +37,8 @@ class Bgp_as_pathsArgs(object):  # pylint: disable=R0903
         pass
 
     argument_spec = {'config': {'elements': 'dict',
-                                'options': {'members': {'elements': 'str',
+                                'options': {'permit': {'required': False, 'type': 'bool'},
+                                            'members': {'elements': 'str',
                                                         'required': False,
                                                         'type': 'list'},
                                             'name': {'required': True, 'type': 'str'}},

--- a/plugins/module_utils/network/sonic/config/aaa/aaa.py
+++ b/plugins/module_utils/network/sonic/config/aaa/aaa.py
@@ -215,7 +215,7 @@ class Aaa(ConfigBase):
     def get_delete_all_aaa_request(self, have):
         requests = []
         if "authentication" in have and have["authentication"]:
-            if "local" or "group" in have["authentication"]["data"]:
+            if "local" in have["authentication"]["data"] or "group" in have["authentication"]["data"]:
                 request = self.get_authentication_method_delete_request()
                 requests.append(request)
             if "fail_through" in have["authentication"]["data"]:

--- a/plugins/module_utils/network/sonic/config/bgp/bgp.py
+++ b/plugins/module_utils/network/sonic/config/bgp/bgp.py
@@ -564,7 +564,7 @@ class Bgp(ConfigBase):
                 if 'keepalive_interval' in conf['timers']:
                     keepalive_interval = conf['timers']['keepalive_interval']
 
-            if not any([cfg for cfg in have if cfg['vrf_name'] == vrf_name and (cfg['bgp_as'] == as_val)]):
+            if not any(cfg for cfg in have if cfg['vrf_name'] == vrf_name and (cfg['bgp_as'] == as_val)):
                 new_bgp_req = self.get_new_bgp_request(vrf_name, as_val)
                 if new_bgp_req:
                     requests.append(new_bgp_req)

--- a/plugins/module_utils/network/sonic/config/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/config/bgp_as_paths/bgp_as_paths.py
@@ -215,10 +215,16 @@ class Bgp_as_paths(ConfigBase):
     def get_new_add_request(self, conf):
         request = None
         members = conf.get('members', None)
+        permit = conf.get('permit', None)
+        permit_str = ""
+        if permit:
+            permit_str = "PERMIT"
+        else:
+            permit_str = "DENY"
         if members:
             url = "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
             method = "PATCH"
-            cfg = {'as-path-set-name': conf['name'], 'as-path-set-member': members}
+            cfg = {'as-path-set-name': conf['name'], 'as-path-set-member': members, 'openconfig-bgp-policy-ext:action': permit_str}
             as_path_set = {'as-path-set-name': conf['name'], 'config': cfg}
             payload = {'openconfig-bgp-policy:as-path-sets': {'as-path-set': [as_path_set]}}
             request = {"path": url, "method": method, "data": payload}
@@ -248,6 +254,13 @@ class Bgp_as_paths(ConfigBase):
         request = {"path": url.format(name), "method": method}
         return request
 
+    def get_delete_single_as_path_action_requests(self, name):
+        url = "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set={}"
+        url = url + "/openconfig-bgp-policy-ext:action"
+        method = "DELETE"
+        request = {"path": url.format(name), "method": method}
+        return request
+
     def get_delete_as_path_requests(self, commands, have, is_delete_all):
         requests = []
         if is_delete_all:
@@ -256,6 +269,7 @@ class Bgp_as_paths(ConfigBase):
             for cmd in commands:
                 name = cmd['name']
                 members = cmd['members']
+                permit = cmd['permit']
                 if members:
                     diff_members = []
                     for item in have:
@@ -266,6 +280,11 @@ class Bgp_as_paths(ConfigBase):
                                         diff_members.append(member_want)
                     if diff_members:
                         requests.append(self.get_delete_single_as_path_member_requests(name, diff_members))
+
+                elif permit:
+                    for item in have:
+                        if item['name'] == name:
+                            requests.append(self.get_delete_single_as_path_action_requests(name))
                 else:
                     for item in have:
                         if item['name'] == name:

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -540,7 +540,7 @@ class Bgp_neighbors(ConfigBase):
                         want_pg_match = next((cfg for cfg in want_peer_group if cfg['name'] == name), None)
                     if want_pg_match:
                         keys = ['remote_as', 'timers', 'advertisement_interval', 'bfd', 'capability', 'address_family']
-                        if not any([want_pg_match.get(key, None) for key in keys]):
+                        if not any(want_pg_match.get(key, None) for key in keys):
                             requests.append(self.get_delete_vrf_specific_peergroup_request(vrf_name, name))
                 else:
                     requests.extend(self.delete_specific_peergroup_param_request(vrf_name, each))
@@ -624,7 +624,7 @@ class Bgp_neighbors(ConfigBase):
                         want_nei_match = next(cfg for cfg in want_neighbors if cfg['neighbor'] == neighbor)
                     if want_nei_match:
                         keys = ['remote_as', 'peer_group', 'timers', 'advertisement_interval', 'bfd', 'capability']
-                        if not any([want_nei_match.get(key, None) for key in keys]):
+                        if not any(want_nei_match.get(key, None) for key in keys):
                             requests.append(self.delete_neighbor_whole_request(vrf_name, neighbor))
                 else:
                     requests.extend(self.delete_specific_param_request(vrf_name, each))

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -405,7 +405,7 @@ class Bgp_neighbors_af(ConfigBase):
                 if conf_route_map and mat_route_map:
                     del_routes = []
                     for route in conf_route_map:
-                        if any([e_route for e_route in mat_route_map if route['direction'] == e_route['direction']]):
+                        if any(e_route for e_route in mat_route_map if route['direction'] == e_route['direction']):
                             del_routes.append(route)
                     if del_routes:
                         requests.extend(self.get_delete_neighbor_af_routemaps_requests(vrf_name, conf_neighbor_val, conf_afi, conf_safi, del_routes))

--- a/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
@@ -232,6 +232,8 @@ class Radius_server(ConfigBase):
                     radius_port_key_cfg['auth-port'] = host['port']
                 if host.get('key', None):
                     radius_port_key_cfg['secret-key'] = host['key']
+                if host.get('retransmit', None):
+                    radius_port_key_cfg['retransmit-attempts'] = host['retransmit']
                 if host.get('source_interface', None):
                     radius_port_key_cfg['openconfig-aaa-radius-ext:source-interface'] = host['source_interface']
 

--- a/plugins/module_utils/network/sonic/facts/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_as_paths/bgp_as_paths.py
@@ -65,8 +65,13 @@ class Bgp_as_pathsFacts(object):
             as_name = as_path["as-path-set-name"]
             member_config = as_path['config']
             members = member_config.get("as-path-set-member", [])
+            permit_str = member_config.get("openconfig-bgp-policy-ext:action", None)
             result['name'] = as_name
             result['members'] = members
+            if permit_str and permit_str == "PERMIT":
+                result['permit'] = True
+            else:
+                result['permit'] = False
             as_path_list_configs.append(result)
         # with open('/root/ansible_log.log', 'a+') as fp:
         #     fp.write('as_path_list: ' + str(as_path_list_configs) + '\n')
@@ -116,7 +121,9 @@ class Bgp_as_pathsFacts(object):
         try:
             config['name'] = str(conf['name'])
             config['members'] = conf['members']
+            config['permit'] = conf['permit']
         except TypeError:
             config['name'] = None
             config['members'] = None
+            config['permit'] = None
         return utils.remove_empties(config)

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors_af/bgp_neighbors_af.py
@@ -63,7 +63,7 @@ class Bgp_neighbors_afFacts(object):
             if route_map_key in data:
                 route_map = data['route_map']
                 for e_route in data[route_map_key]:
-                    direction = route_map_key.split('_')[0]
+                    direction = route_map_key.split('_', maxsplit=1)[0]
                     route_map.append({'name': e_route, 'direction': direction})
                 data.pop(route_map_key)
 

--- a/plugins/module_utils/network/sonic/facts/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/facts/tacacs_server/tacacs_server.py
@@ -133,8 +133,8 @@ class Tacacs_serverFacts(object):
                         host_data['priority'] = cfg['openconfig-system-ext:priority']
                     if 'openconfig-system-ext:vrf' in cfg:
                         host_data['vrf'] = cfg['openconfig-system-ext:vrf']
-                    if 'timout' in cfg:
-                        host_data['timout'] = cfg['timout']
+                    if 'timeout' in cfg:
+                        host_data['timeout'] = cfg['timeout']
                 if tacacs_host.get('tacacs', None) and tacacs_host['tacacs'].get('config', None):
                     tacas_cfg = tacacs_host['tacacs']['config']
                     if tacas_cfg.get('port', None):

--- a/plugins/modules/sonic_bgp_as_paths.py
+++ b/plugins/modules/sonic_bgp_as_paths.py
@@ -58,6 +58,11 @@ options:
         elements: str
         description:
         - Members of this BGP as-path; regular expression string can be provided.
+      permit:
+        required: False
+        type: bool
+        description:
+        - Permits or denies this as path.
   state:
     description:
     - The state of the configuration after module completion.

--- a/plugins/modules/sonic_command.py
+++ b/plugins/modules/sonic_command.py
@@ -24,7 +24,7 @@ description:
     argument that causes the module to wait for a specific condition
     before returning or time out if the condition is not met.
   - This module does not support running commands in configuration mode.
-    To configure SONiC devices, use M(sonic_config).
+    To configure SONiC devices, use the "sonic_config" module.
 options:
   commands:
     description:

--- a/plugins/modules/sonic_command.py
+++ b/plugins/modules/sonic_command.py
@@ -141,24 +141,31 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.p
     Conditional,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    transform_commands,
+    EntityCollection,
     to_lines,
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import run_commands
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import command_list_str_to_dict
 
+def transform_commands_dict(module, commands_dict):
+    transform = EntityCollection(
+        module,
+        dict(
+            command=dict(key=True),
+            output=dict(),
+            prompt=dict(type="list"),
+            answer=dict(type="list"),
+            newline=dict(type="bool", default=True),
+            sendonly=dict(type="bool", default=False),
+            check_all=dict(type="bool", default=False),
+        ),
+    )
+
+    return transform(commands_dict)
 
 def parse_commands(module, warnings):
-    commands = transform_commands(module)
-
-    if module.check_mode:
-        for item in list(commands):
-            if not item['command'].startswith('show'):
-                warnings.append(
-                    'Only show commands are supported when using check mode, not '
-                    'executing %s' % item['command']
-                )
-                commands.remove(item)
-
+    commands_dict = command_list_str_to_dict(module, warnings, module.params["commands"])
+    commands = transform_commands_dict(module, commands_dict)
     return commands
 
 

--- a/plugins/modules/sonic_config.py
+++ b/plugins/modules/sonic_config.py
@@ -191,12 +191,14 @@ saved:
   type: bool
   sample: True
 """
+
 from ansible.module_utils.connection import ConnectionError
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import get_config, get_sublevel_config
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import edit_config, run_commands
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import command_list_str_to_dict
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import NetworkConfig, dumps
 
 
@@ -293,6 +295,9 @@ def main():
                 commands = [cmd]
             else:
                 commands = commands.split('\n')
+                cmd_list_out = command_list_str_to_dict(module, warnings, commands)
+                if cmd_list_out and cmd_list_out != []:
+                    commands = cmd_list_out
 
             if module.params['before']:
                 commands[:0] = module.params['before']

--- a/plugins/modules/sonic_facts.py
+++ b/plugins/modules/sonic_facts.py
@@ -32,10 +32,11 @@ options:
     description:
       - When supplied, this argument restricts the facts collected
         to a given subset. Possible values for this argument include
-        all, min, hardware, config, legacy, and interfaces. Can specify a
-        list of values to include a larger subset. Values can also be used
-        with an initial C(M(!)) to specify that a specific subset should
-        not be collected.
+        all, min, hardware, config, legacy, and interfaces. It can also
+        specify a list of values to include a larger subset. A value
+        can also be enclosed in double quotes and preceded by an
+        exclamation mark to indicate that the corresponding
+        information should not be collected.
     required: false
     type: list
     elements: str
@@ -43,11 +44,15 @@ options:
   gather_network_resources:
     description:
       - When supplied, this argument restricts the facts collected
-        to a given subset. Possible values for this argument include
-        all and the resources like 'all', 'interfaces', 'vlans', 'lag_interfaces', 'l2_interfaces', 'l3_interfaces'.
-        Can specify a list of values to include a larger subset. Values
-        can also be used with an initial C(M(!)) to specify that a
-        specific subset should not be collected.
+        to a given network resource or a given list of network
+        resources. Possible values for this argument include
+        'all' and specific network resource names such as
+        'interfaces', 'vlans', 'lag_interfaces', 'l2_interfaces',
+        and 'l3_interfaces'. Multiple resources can be specified by
+        placing them in a comma-separated list. A given value
+        can also be enclosed in double quotes and preceded by an
+        exclamation mark to indicate that the information for the
+        corresponding resource should not be collected.
     required: false
     type: list
     elements: str

--- a/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
@@ -16,9 +16,11 @@ tests:
       - name: test
         members:
           - "11"
+        permit: True
       - name: test_1
         members:
           - "101.101"
+        permit: False
   - name: test_case_02
     description: Update created BGP properties
     state: merged
@@ -29,17 +31,20 @@ tests:
             - "22"
             - "33"
             - 44
+          permit: False
         - name: test_1
           members:
             - "101.101"
             - "201.201"
             - "301.301"
+          permit: True
         - name: test_2
           members:
             - '111\\:'
             - '11\\d+'
             - '113\\*'
             - '114\\'
+          permit: True
   - name: test_case_03
     description: Delete BGP properties
     state: deleted
@@ -52,19 +57,22 @@ tests:
             - "101.101"
             - "201.201"
             - "301.301"
+          permit: True
         - name: test_2
           members:
             - '111\\:'
             - '11\\d+'
             - '113\\*'
             - '114\\'
+          permit: True
   - name: test_case_04
     description: Delete BGP properties
     state: deleted
     input:
         - name: test
-          members:          
+          members:
+          permit:          
   - name: test_case_05
     description: Delete BGP properties
     state: deleted
-    input: []        
+    input: []

--- a/tests/regression/roles/sonic_config/defaults/main.yml
+++ b/tests/regression/roles/sonic_config/defaults/main.yml
@@ -38,12 +38,12 @@ preparations_tests:
     - no interface PortChannel 11
     - no interface PortChannel 1
     - no interface PortChannel 2
-    - no snmp-server community 111
-    - no snmp-server community 112
-    - no snmp-server community 114
-    - no snmp-server community 115
-    - no snmp-server community 116
-    - no snmp-server community 117
+    - no snmp-server community abcd
+    - no snmp-server community efgh
+    - no snmp-server community ijkl
+    - no snmp-server community mnop
+    - no snmp-server community qrst
+    - no snmp-server community uvwx
     - no snmp-server location
     - no snmp-server contact
     - interface Vlan 11
@@ -60,17 +60,17 @@ tests:
       lines:
         - mtu 4444
       parents: ['interface PortChannel 11']
-      before: ['snmp-server community 111']
-      after: ['snmp-server community 112']
+      before: ['snmp-server community abcd']
+      after: ['snmp-server community efgh']
   - name: test_case_02
     description: Test sonic config module with single CLI
     input:
-       before: 'snmp-server community 114'
-       commands: 'snmp-server community 115'
+       before: 'snmp-server community ijkl'
+       commands: 'snmp-server community mnop'
   - name: test_case_03
     description: Test sonic config module with multiple CLI
     input:
-      commands: ['snmp-server community 116', 'snmp-server community 117']
+      commands: ['snmp-server community qrst', 'snmp-server community uvwx']
   - name: test_case_04
     description: Configure interface description using parents option on SONIC device
     input:

--- a/tests/regression/roles/sonic_config/tasks/backup.yaml
+++ b/tests/regression/roles/sonic_config/tasks/backup.yaml
@@ -3,7 +3,7 @@
     backup: yes
     backup_options:
       filename: backup.cfg
-      dir_path: /home/
+      dir_path: /tmp/
   register: backup_file
 
 - name: Verify file is created or not

--- a/tests/regression/roles/sonic_radius_server/defaults/main.yml
+++ b/tests/regression/roles/sonic_radius_server/defaults/main.yml
@@ -14,7 +14,6 @@ tests:
     state: merged
     input:
       auth_type: chap
-      key: chap
       timeout: 12
       nas_ip: 10.11.12.13
       retransmit: 5
@@ -26,7 +25,6 @@ tests:
             priority: 3
             vrf: mgmt
             timeout: 12
-            key: chap
             port: 55
             source_interface: "{{ interface1 }}"
             retransmit: 7
@@ -35,7 +33,6 @@ tests:
             priority: 4
             vrf: mgmt
             timeout: 15
-            key: pap
             port: 56
             source_interface: "{{ interface2 }}"
             retransmit: 8
@@ -44,7 +41,6 @@ tests:
             priority: 6
             vrf: mgmt
             timeout: 20
-            key: mschapv2
             port: 57
             source_interface: "{{ interface3 }}"
             retransmit: 9
@@ -53,13 +49,11 @@ tests:
     state: merged
     input:
       auth_type: mschapv2
-      key: login
       timeout: 24
       servers:
         host:
           - name: my_host
             auth_type: mschapv2
-            key: mschapv2
             port: 45
             timeout: 9
             vrf: mgmt
@@ -83,7 +77,6 @@ tests:
     state: merged
     input:
       auth_type: chap
-      key: chap
       timeout: 12
       nas_ip: 10.11.12.13
       retransmit: 5
@@ -95,7 +88,6 @@ tests:
             priority: 3
             vrf: mgmt
             timeout: 12
-            key: chap
             port: 55
             source_interface: "{{ interface1 }}"
             retransmit: 7
@@ -104,7 +96,6 @@ tests:
             priority: 4
             vrf: mgmt
             timeout: 15
-            key: pap
             port: 56
             source_interface: "{{ interface2 }}"
             retransmit: 8
@@ -113,7 +104,6 @@ tests:
             priority: 6
             vrf: mgmt
             timeout: 20
-            key: mschapv2
             port: 57
             source_interface: "{{ interface3 }}"
             retransmit: 9

--- a/tests/regression/roles/sonic_tacacs_server/defaults/main.yml
+++ b/tests/regression/roles/sonic_tacacs_server/defaults/main.yml
@@ -14,26 +14,22 @@ tests:
     state: merged
     input:
       auth_type: chap
-      key: chap
       source_interface: "{{ interface1 }}"
       timeout: 12
       servers:
         host:
           - name: my_host
             auth_type: chap
-            key: chap
             port: 55
             timeout: 12
             priority: 3
           - name: my_host1
             auth_type: login
-            key: login
             port: 60
             timeout: 14
             priority: 4
           - name: my_host2
             auth_type: login
-            key: login
             port: 60
             timeout: 14
             priority: 4
@@ -42,14 +38,12 @@ tests:
     state: merged
     input:
       auth_type: login
-      key: login
       source_interface: "{{ interface2 }}"
       timeout: 24
       servers:
         host:
           - name: my_host
             auth_type: mschap
-            key: mschap
             port: 45
             timeout: 9
             priority: 5
@@ -77,19 +71,16 @@ tests:
         host:
           - name: my_host
             auth_type: chap
-            key: chap
             port: 55
             timeout: 12
             priority: 3
           - name: my_host1
             auth_type: login
-            key: login
             port: 60
             timeout: 14
             priority: 4
           - name: my_host2
             auth_type: login
-            key: login
             port: 60
             timeout: 14
             priority: 4

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,0 +1,1 @@
+plugins/action/sonic.py action-plugin-docs #action plugin for base class


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix problems in handling of CLI "exec" mode and "config" mode commands.

Root cause analysis:

Commands with a "prompt/answer" sequence require
the user to specify a dictionary containing the command, prompt,
and prompt "answer". The previously existing handling enclosed the
entire (quoted) command entry under a single "command" dictionary
item for the dictionary that is sent to the switch instead of
setting the required specified values for each of the three
dictionary items.

Fix:
 - Create a utility function to generate the correct dictionary
   entries from the input command list parsed from the user
   playbook.
 - Use the resulting dictionary instead of the "raw" list
   of quoted command strings provided by the "AnsibleModule"
   parsing invocation.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic-cli
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
[prompt_fix_sonic_command_regression_comparison.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8544731/prompt_fix_sonic_command_regression_comparison.txt)
[prompt_fix_PR_regression-2022-04-22-00-35-17.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8544750/prompt_fix_PR_regression-2022-04-22-00-35-17.pdf)
[prompt_fix_PR_port_breakout_regression-2022-04-22-14-22-30.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8544751/prompt_fix_PR_port_breakout_regression-2022-04-22-14-22-30.pdf)
[prompt_fix_PR_regression-base-2022-04-21-23-29-14.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8544752/prompt_fix_PR_regression-base-2022-04-21-23-29-14.pdf)

