### PR TITLE
Added attributes to bgp_neighbors module

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
@@ -57,7 +57,7 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                         'peer_group': {'type': 'str'},
                         'bfd': {
                             'options': {
-                                'enabled': { 'type': 'bool'},
+                                'enabled': {'type': 'bool'},
                                 'check_failure': {'type': 'bool'},
                                 'profile': {'type': 'str'}
                             },

--- a/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
@@ -78,7 +78,34 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                             },
                             'type': 'dict'
                         },
-                        'nbr_description': {'type': 'str'}
+                        'nbr_description': {'type': 'str'},
+                        'disable_connected_check': {'type': 'bool'},
+                        'dont_negotiate_capability': {'type': 'bool'},
+                        'ebgp_multihop': {
+                            'options': {
+                                'enabled': {'default': 'False', 'type': 'bool'},
+                                'multihop_ttl': {'type': 'int'}
+                            },
+                            'type': 'dict'
+                        },
+                        'enforce_first_as': {'type': 'bool'},
+                        'enforce_multihop': {'type': 'bool'},
+                        'local_address': {'type': 'str'},
+                        'local_as': {
+                            'options': {
+                                'as': {'required': True, 'type': 'int'},
+                                'no_prepend': {'type': 'bool'},
+                                'replace_as': {'type': 'bool'},
+                            },
+                            'type': 'dict'
+                        },
+                        'override_capability': {'type': 'bool'},
+                        'passive': {'default': 'False', 'type': 'bool'},
+                        'port': {'type': 'int'},
+                        'solo': {'type': 'bool'},
+                        'strict_capability_match': {'type': 'bool'},
+                        'ttl_security': {'type': 'int'},
+                        'v6only': {'type': 'bool'}
                     },
                     'type': 'list'
                 },

--- a/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
@@ -55,12 +55,20 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                             'type': 'dict'
                         },
                         'peer_group': {'type': 'str'},
-                        'bfd': {'type': 'bool'},
+                        'bfd': {
+                            'options': {
+                                'enabled': { 'type': 'bool'},
+                                'check_failure': {'type': 'bool'},
+                                'profile': {'type': 'str'}
+                            },
+                            'type': 'dict'
+                        },
                         'advertisement_interval': {'type': 'int'},
                         'timers': {
                             'options': {
                                 'holdtime': {'type': 'int'},
                                 'keepalive': {'type': 'int'},
+                                'connect_retry': {'type': 'int'}
                             },
                             'type': 'dict'
                         },
@@ -73,7 +81,7 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                         },
                         'auth_pwd': {
                             'options': {
-                                'pwd': {'type': 'str'},
+                                'pwd': {'required': True, 'type': 'str'},
                                 'encrypted': {'default': 'False', 'type': 'bool'},
                             },
                             'type': 'dict'
@@ -102,6 +110,7 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                         'override_capability': {'type': 'bool'},
                         'passive': {'default': 'False', 'type': 'bool'},
                         'port': {'type': 'int'},
+                        'shutdown_msg': {'type': 'str'},
                         'solo': {'type': 'bool'},
                         'strict_capability_match': {'type': 'bool'},
                         'ttl_security': {'type': 'int'},

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -449,6 +449,7 @@ class Bgp_neighbors(ConfigBase):
                 tmp_timers = {}
                 tmp_capability = {}
                 tmp_remote = {}
+                tmp_transport = {}
                 if neighbor.get('bfd', None) is not None:
                     bgp_neighbor.update({'enable-bfd': {'config': {'enabled': neighbor['bfd']}}})
                 if neighbor.get('auth_pwd', None) is not None:
@@ -456,6 +457,11 @@ class Bgp_neighbors(ConfigBase):
                             neighbor['auth_pwd'].get('encrypted', None) is not None):
                         bgp_neighbor.update({'auth-password': {'config': {'password': neighbor['auth_pwd']['pwd'],
                                                                           'encrypted': neighbor['auth_pwd']['encrypted']}}})
+                if neighbor.get('ebgp_multihop', None) is not None:
+                    if (neighbor['ebgp_multihop'].get('enabled', None) is not None and
+                            neighbor['ebgp_multihop'].get('multihop_ttl', None) is not None):
+                        bgp_neighbor.update({'ebgp-multihop': {'config': {'enabled': neighbor['ebgp_multihop']['enabled'],
+                                                                          'multihop-ttl': neighbor['ebgp_multihop']['multihop_ttl']}}})
                 if neighbor.get('timers', None) is not None:
                     if neighbor['timers'].get('holdtime', None) is not None:
                         tmp_timers.update({'hold-time': neighbor['timers']['holdtime']})
@@ -475,6 +481,37 @@ class Bgp_neighbors(ConfigBase):
                     neighbor_cfg.update({'peer-group': neighbor['peer_group']})
                 if neighbor.get('nbr_description', None) is not None:
                     neighbor_cfg.update({'description': neighbor['nbr_description']})
+                if neighbor.get('disable_connected_check', None) is not None:
+                    neighbor_cfg.update({'disable-ebgp-connected-route-check': neighbor['disable_connected_check']})
+                if neighbor.get('dont_negotiate_capability', None) is not None:
+                    neighbor_cfg.update({'dont-negotiate-capability': neighbor['dont_negotiate_capability']})
+                if neighbor.get('enforce_first_as', None) is not None:
+                    neighbor_cfg.update({'enforce-first-as': neighbor['enforce_first_as']})
+                if neighbor.get('enforce_multihop', None) is not None:
+                    neighbor_cfg.update({'enforce-multihop': neighbor['enforce_multihop']})
+                if neighbor.get('override_capability', None) is not None:
+                    neighbor_cfg.update({'override-capability': neighbor['override_capability']})
+                if neighbor.get('port', None) is not None:
+                    neighbor_cfg.update({'peer-port': neighbor['port']})
+                if neighbor.get('solo', None) is not None:
+                    neighbor_cfg.update({'solo-peer': neighbor['solo']})
+                if neighbor.get('strict_capability_match', None) is not None:
+                    neighbor_cfg.update({'strict-capability-match': neighbor['strict_capability_match']})
+                if neighbor.get('ttl_security', None) is not None:
+                    neighbor_cfg.update({'ttl-security-hops': neighbor['ttl_security']})
+                if neighbor.get('v6only', None) is not None:
+                    neighbor_cfg.update({'openconfig-bgp-ext:v6only': neighbor['v6only']})
+                if neighbor.get('local_as', None) is not None:
+                    if neighbor['local_as'].get('as', None) is not None:
+                        neighbor_cfg.update({'local-as': neighbor['local_as']['as']})
+                    if neighbor['local_as'].get('no_prepend', None) is not None:
+                        neighbor_cfg.update({'local-as-no-prepend': neighbor['local_as']['no_prepend']})
+                    if neighbor['local_as'].get('replace_as', None) is not None:
+                        neighbor_cfg.update({'local-as-replace-as': neighbor['local_as']['replace_as']})
+                if neighbor.get('local_address', None) is not None:
+                    tmp_transport.update({'local-address': neighbor['local_address']})
+                if neighbor.get('passive', None) is not None:
+                    tmp_transport.update({'passive-mode': neighbor['passive']})
                 if neighbor.get('remote_as', None) is not None:
                     have_nei = self.find_nei(have, bgp_as, vrf_name, neighbor)
                     if neighbor['remote_as'].get('peer_as', None) is not None:
@@ -497,6 +534,8 @@ class Bgp_neighbors(ConfigBase):
                         tmp_remote.update({'peer-type': neighbor['remote_as']['peer_type'].upper()})
                 if tmp_timers:
                     bgp_neighbor.update({'timers': {'config': tmp_timers}})
+                if tmp_transport:
+                    bgp_neighbor.update({'transport': {'config': tmp_transport}})
                 if tmp_capability:
                     neighbor_cfg.update(tmp_capability)
                 if tmp_remote:
@@ -659,6 +698,52 @@ class Bgp_neighbors(ConfigBase):
         if cmd.get('nbr_description', None) is not None:
             delete_path = delete_static_path + '/config/description'
             requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('disable_connected_check', None) is not None:
+            delete_path = delete_static_path + '/config/disable-ebgp-connected-route-check'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('dont_negotiate_capability', None) is not None:
+            delete_path = delete_static_path + '/config/dont-negotiate-capability'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('enforce_first_as', None) is not None:
+            delete_path = delete_static_path + '/config/enforce-first-as'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('enforce_multihop', None) is not None:
+            delete_path = delete_static_path + '/config/enforce-multihop'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('override_capability', None) is not None:
+            delete_path = delete_static_path + '/config/override-capability'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('port', None) is not None:
+            delete_path = delete_static_path + '/config/peer-port'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('solo', None) is not None:
+            delete_path = delete_static_path + '/config/solo-peer'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('strict_capability_match', None) is not None:
+            delete_path = delete_static_path + '/config/strict-capability-match'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('ttl_security', None) is not None:
+            delete_path = delete_static_path + '/config/ttl-security-hops'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('v6only', None) is not None:
+            delete_path = delete_static_path + '/config/openconfig-bgp-ext:v6only'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('local_as', None) is not None:
+            if cmd['local_as'].get('as', None) is not None:
+                delete_path = delete_static_path + '/config/local-as'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['local_as'].get('no_prepend', None) is not None:
+                delete_path = delete_static_path + '/config/local-as-no-prepend'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['local_as'].get('replace_as', None) is not None:
+                delete_path = delete_static_path + '/config/local-as-replace-as'
+                requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('local_address', None) is not None:
+            delete_path = delete_static_path + '/transport/config/local-address'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('passive', None) is not None:
+            delete_path = delete_static_path + '/transport/config/passive-mode'
+            requests.append({'path': delete_path, 'method': DELETE})
         if cmd.get('advertisement_interval', None) is not None:
             delete_path = delete_static_path + '/timers/config/minimum-advertisement-interval'
             requests.append({'path': delete_path, 'method': DELETE})
@@ -685,6 +770,13 @@ class Bgp_neighbors(ConfigBase):
                 requests.append({'path': delete_path, 'method': DELETE})
             if cmd['auth_pwd'].get('encrypted', None) is not None:
                 delete_path = delete_static_path + '/auth-password/config/encrypted'
+                requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('ebgp_multihop', None) is not None:
+            if cmd['ebgp_multihop'].get('enabled', None) is not None:
+                delete_path = delete_static_path + '/ebgp-multihop/config/enabled'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['ebgp_multihop'].get('multihop_ttl', None) is not None:
+                delete_path = delete_static_path + '/ebgp-multihop/config/multihop_ttl'
                 requests.append({'path': delete_path, 'method': DELETE})
 
         return requests

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
@@ -196,7 +196,6 @@ class Bgp_neighborsFacts(object):
                     if replace_as is not None:
                         local_as['replace_as'] = replace_as
                         fil_neighbor.pop('replace_as')
-
                     if auth_pwd:
                         fil_neighbor['auth_pwd'] = auth_pwd
                     if ebgp_multihop:

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
@@ -48,6 +48,23 @@ class Bgp_neighborsFacts(object):
         'pwd': ['auth-password', 'password'],
         'encrypted': ['auth-password', 'encrypted'],
         'nbr_description': 'description',
+        'disable_connected_check': 'disable-ebgp-connected-route-check',
+        'dont_negotiate_capability': 'dont-negotiate-capability',
+        'enforce_first_as': 'enforce-first-as',
+        'enforce_multihop': 'enforce-multihop',
+        'local_address': ['transport', 'config', 'local-address'],
+        'as': 'local-as',
+        'no_prepend': 'local-as-no-prepend',
+        'replace_as': 'local-as-replace-as',
+        'override_capability': 'override-capability',
+        'port': 'peer-port',
+        'solo': 'solo-peer',
+        'strict_capability_match': 'strict-capability-match',
+        'ttl_security': 'ttl-security-hops',
+        'enabled': ['ebgp-multihop', 'enabled'],
+        'multihop_ttl': ['ebgp-multihop', 'multihop-ttl'],
+        'v6only': 'openconfig-bgp-ext:v6only',
+        'passive': ['transport', 'config', 'passive-mode']
     }
 
     def __init__(self, module, subspec='config', options='options'):
@@ -157,8 +174,35 @@ class Bgp_neighborsFacts(object):
                     if encrypted is not None:
                         auth_pwd['encrypted'] = encrypted
                         fil_neighbor.pop('encrypted')
+                    ebgp_multihop = {}
+                    enabled = fil_neighbor.get('enabled', None)
+                    if enabled is not None:
+                        ebgp_multihop['enabled'] = enabled
+                        fil_neighbor.pop('enabled')
+                    multihop_ttl = fil_neighbor.get('multihop_ttl', None)
+                    if multihop_ttl is not None:
+                        ebgp_multihop['multihop_ttl'] = multihop_ttl
+                        fil_neighbor.pop('multihop_ttl')
+                    local_as = {}
+                    asn = fil_neighbor.get('as', None)
+                    if asn is not None:
+                        local_as['as'] = asn
+                        fil_neighbor.pop('as')
+                    no_prepend = fil_neighbor.get('no_prepend', None)
+                    if no_prepend is not None:
+                        local_as['no_prepend'] = no_prepend
+                        fil_neighbor.pop('no_prepend')
+                    replace_as = fil_neighbor.get('replace_as', None)
+                    if replace_as is not None:
+                        local_as['replace_as'] = replace_as
+                        fil_neighbor.pop('replace_as')
+
                     if auth_pwd:
                         fil_neighbor['auth_pwd'] = auth_pwd
+                    if ebgp_multihop:
+                        fil_neighbor['ebgp_multihop'] = ebgp_multihop
+                    if local_as:
+                        fil_neighbor['local_as'] = local_as
                     if fil_neighbor:
                         fil_neighbors.append(fil_neighbor)
             if fil_neighbors:

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
@@ -41,8 +41,11 @@ class Bgp_neighborsFacts(object):
         'peer_group': 'peer-group',
         'keepalive': 'keepalive-interval',
         'holdtime': 'hold-time',
+        'connect_retry': 'connect-retry',
         'advertisement_interval': 'minimum-advertisement-interval',
-        'bfd': ['enable-bfd', 'enabled'],
+        'bfd_enabled': ['enable-bfd', 'enabled'],
+        'check_failure': ['enable-bfd', 'check-control-plane-failure'],
+        'profile': ['enable-bfd', 'bfd-profile'],
         'dynamic': 'capability-dynamic',
         'extended_nexthop': 'capability-extended-nexthop',
         'pwd': ['auth-password', 'password'],
@@ -58,6 +61,7 @@ class Bgp_neighborsFacts(object):
         'replace_as': 'local-as-replace-as',
         'override_capability': 'override-capability',
         'port': 'peer-port',
+        'shutdown_msg': 'shutdown-message',
         'solo': 'solo-peer',
         'strict_capability_match': 'strict-capability-match',
         'ttl_security': 'ttl-security-hops',
@@ -196,12 +200,27 @@ class Bgp_neighborsFacts(object):
                     if replace_as is not None:
                         local_as['replace_as'] = replace_as
                         fil_neighbor.pop('replace_as')
+                    bfd = {}
+                    bfd_enabled = fil_neighbor.get('bfd_enabled', None)
+                    if bfd_enabled is not None:
+                        bfd['enabled'] = bfd_enabled
+                        fil_neighbor.pop('bfd_enabled')
+                    check_failure = fil_neighbor.get('check_failure', None)
+                    if check_failure is not None:
+                        bfd['check_failure'] = check_failure
+                        fil_neighbor.pop('check_failure')
+                    profile = fil_neighbor.get('profile', None)
+                    if profile is not None:
+                        bfd['profile'] = profile
+                        fil_neighbor.pop('profile')
                     if auth_pwd:
                         fil_neighbor['auth_pwd'] = auth_pwd
                     if ebgp_multihop:
                         fil_neighbor['ebgp_multihop'] = ebgp_multihop
                     if local_as:
                         fil_neighbor['local_as'] = local_as
+                    if bfd:
+                        fil_neighbor['bfd'] = bfd
                     if fil_neighbor:
                         fil_neighbors.append(fil_neighbor)
             if fil_neighbors:

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -279,7 +279,7 @@ options:
             description:
               - Enforces the first AS for EBGP routes.
             type: bool
-          enforce_multihop
+          enforce_multihop:
             description:
               - Enforces EBGP multihop performance for neighbor.
             type: bool

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -522,7 +522,6 @@ EXAMPLES = """
 #  v6only
 #  password U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg= encrypted
 #  strict-capability-match
-
 # !
 # neighbor 192.168.1.4
 #!

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -546,7 +546,6 @@ EXAMPLES = """
 #  timers connect 25
 #  bfd check-control-plane-failure profile "profile 1"
 #  advertisement-interval 15
-#  bfd
 #  capability extended-nexthop
 #  capability dynamic
 #  v6only

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -262,6 +262,7 @@ options:
                 description:
                   - Authentication password for the neighbor group.
                 type: str
+                required: True
               encrypted:
                 description:
                   - Indicates whether the password is encrypted text.

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -703,6 +703,8 @@ EXAMPLES = """
 # !
 # neighbor interface Eth1/3
 # !
+# neighbor interface Eth1/2
+# neighbor 1.1.1.1
 
 """
 RETURN = """

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -296,6 +296,7 @@ options:
                 description:
                   - Local autonomous system number.
                 type: int
+                required: True
               no_prepend:
                 description:
                   - Do not prepend the local-as number in AS-Path advertisements.
@@ -304,7 +305,6 @@ options:
                 description:
                   - Replace the configured AS Number with the local-as number in AS-Path advertisements.
                 type: bool
-                required: True
           override_capability:
             description:
               - Override capability negotiation result.

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -197,7 +197,20 @@ options:
           bfd:
             description:
               - Enables or disables BFD.
-            type: bool
+            type: dict
+            suboptions:
+              enabled:
+                description:
+                  - Enables BFD liveliness check for a BGP neighbor.
+                type: bool
+              check_failure:
+                description:
+                  - Link dataplane status with control plane.
+                type: bool
+              profile:
+                description:
+                  - BFD Profile name format.
+                type: str
           advertisement_interval:
             description:
               - Specifies the minimum interval between sending BGP routing updates.
@@ -221,6 +234,11 @@ options:
                 description:
                   - Interval after not receiving a keepalive message that SONiC declares a peer dead, in seconds.
                   - The range is from 0 to 65535.
+                type: int
+              connect_retry:
+                description:
+                  - Time interval in seconds between attempts to establish a session with the peer.
+                  - The range is from 1 to 65535.
                 type: int
           capability:
             description:
@@ -318,6 +336,10 @@ options:
             description:
               - Neighbor's BGP port.
             type: int
+          shutdown_msg:
+            description:
+              - Add a shutdown message.
+            type: str
           solo:
             description:
               - Indicates that routes advertised by the peer should not be reflected back to the peer.
@@ -436,6 +458,7 @@ EXAMPLES = """
            override_capability: true
            passive: true
            port: 3
+           shutdown_msg: 'msg1'
            solo: true
          - neighbor: 1.1.1.1
            disable_connected_check: true
@@ -471,7 +494,11 @@ EXAMPLES = """
            timers:
              keepalive: 30
              holdtime: 15
-           bfd: true
+             connect_retry: 25
+           bfd:
+             check_failure: true
+             enabled: true
+             profile: 'profile 1'
            capability:
              dynamic: true
              extended_nexthop: true
@@ -515,6 +542,8 @@ EXAMPLES = """
 #  peer-group SPINE
 #  remote-as 10
 #  timers 15 30
+#  timers connect 25
+#  bfd check-control-plane-failure profile "profile 1"
 #  advertisement-interval 15
 #  bfd
 #  capability extended-nexthop
@@ -529,6 +558,7 @@ EXAMPLES = """
 #  timers 60 180
 # neighbor interface Eth1/2
 #  description "description 1"
+#  shutdown message msg1
 #  ebgp-multihop 1
 #  remote-as external
 #  update-source interface Ethernet4
@@ -659,6 +689,7 @@ EXAMPLES = """
            override_capability: true
            passive: true
            port: 3
+           shutdown_msg: 'msg1'
            solo: true
          - neighbor: 1.1.1.1
            disable_connected_check: true
@@ -679,7 +710,11 @@ EXAMPLES = """
            timers:
              keepalive: 30
              holdtime: 15
-           bfd: true
+             connect_retry: 25
+           bfd:
+             check_failure: true
+             enabled: true
+             profile: 'profile 1'
            capability:
              dynamic: true
              extended_nexthop: true

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -437,9 +437,9 @@ EXAMPLES = """
            passive: true
            port: 3
            solo: true
-          - neighbor: 1.1.1.1
-            disable_connected_check: true
-            ttl_security: 5
+         - neighbor: 1.1.1.1
+           disable_connected_check: true
+           ttl_security: 5
      - bgp_as: 51
        vrf_name: VrfReg1
        peer_group:
@@ -478,9 +478,9 @@ EXAMPLES = """
            auth_pwd:
                pwd: 'U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg='
                encrypted: true
-            nbr_description: 'description 2'
-            strict_capability_match: true
-            v6only: true
+           nbr_description: 'description 2'
+           strict_capability_match: true
+           v6only: true
          - neighbor: 192.168.1.4
     state: merged
 #

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -42,6 +42,42 @@ action_tests:
 
 deleted_tests:
   - name: test_case_del_01
+    description: Delete BGP NEIGHBORS additional attributes
+    state: deleted
+    input:
+      - bgp_as: "{{bgp_as_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            auth_pwd:
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+            nbr_description: "description 2"
+            override_capability: false
+            passive: false
+            port: 4
+            solo: false
+          - neighbor: 192.168.1.5
+            disable_connected_check: false
+            shutdown_msg: "msg 2"
+            ttl_security: 8
+      - bgp_as: "{{bgp_as_1}}"
+        vrf_name: "{{vrf_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            auth_pwd:
+               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
+               encrypted: true
+            nbr_description: 'description 3'
+            strict_capability_match: false
+            v6only: false
+
+  - name: test_case_del_02
     description: BGP NEIGHBORS remote-as properties
     state: deleted
     input:
@@ -87,28 +123,38 @@ deleted_tests:
             remote_as:
               peer_type: external
 
-  - name: test_case_del_02
+  - name: test_case_del_03
     description: BGP NEIGHBORS remote-as properties
     state: deleted
     input:
       - bgp_as: "{{bgp_as_1}}"
         neighbors:
+          - neighbor: "{{ interface1 }}"
           - neighbor: 11::11
           - neighbor: 67.1.1.1
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
         neighbors:
+          - neighbor: "{{ interface1 }}"
           - neighbor: 11::11
           - neighbor: 67.1.1.1
 
-  - name: test_case_del_03
-    description: BGP NEIGHBORS delete neighbor peergroup
+  - name: test_case_del_04
+    description: BGP NEIGHBORS delete neighbor peergroup, bfd, and timers
     state: deleted
     input:
       - bgp_as: "{{bgp_as_1}}"
         neighbors:
           - neighbor: "{{ interface2 }}"
             peer_group: SPINE
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 3"
+            timers:
+              keepalive: 41
+              holdtime: 51
+              connect_retry: 61
           - neighbor: 3::3
             peer_group: SPINE
           - neighbor: 192.168.1.5
@@ -120,10 +166,18 @@ deleted_tests:
             peer_group: SPINE
           - neighbor: "{{ interface3 }}"
             peer_group: SPINE1
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 4"
+            timers:
+              keepalive: 55
+              holdtime: 44
+              connect_retry: 33
           - neighbor: 3::3
             peer_group: SPINE
 
-  - name: test_case_del_04
+  - name: test_case_del_05
     description: Delete peer group BGP NEIGHBORS properties
     state: deleted
     input:
@@ -135,41 +189,6 @@ deleted_tests:
         peer_group:
           - name: SPINE
           - name: SPINE1
-
-  - name: test_case_del_05
-    description: Delete BGP NEIGHBORS additional attributes
-    state: deleted
-    input:
-      - bgp_as: "{{bgp_as_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-            dont_negotiate_capability: false
-            ebgp_multihop:
-               enabled: false
-               multihop_ttl: 2
-            enforce_first_as: false
-            enforce_multihop: false
-            local_address: 'Ethernet6'
-            local_as:
-            nbr_description: "description 2"
-            override_capability: false
-            passive: false
-            port: 4
-            solo: false
-          - neighbor: 1.1.1.1
-            disable_connected_check: false
-            ttl_security: 8
-      - bgp_as: "{{bgp_as_1}}"
-        vrf_name: "{{vrf_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
-               encrypted: true
-            nbr_description: 'description 3'
-            strict_capability_match: false
-            v6only: false
 
   - name: test_case_del_06
     description: BGP NEIGHBORS remote-as properties
@@ -209,7 +228,11 @@ merged_tests:
             timers:
               keepalive: 40
               holdtime: 50
-            bfd: true
+              connect_retry: 60
+            bfd:
+              enabled: true
+              check_failure: true
+              profile: "profile 1"
             capability:
               dynamic: true
               extended_nexthop: true
@@ -224,6 +247,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
           - neighbor: 3::3
@@ -234,6 +258,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
       - bgp_as: "{{bgp_as_1}}"
@@ -265,7 +290,11 @@ merged_tests:
             timers:
               keepalive: 40
               holdtime: 50
-            bfd: true
+              connect_retry: 60
+            bfd:
+              enabled: true
+              check_failure: true
+              profile: "profile 2"
             capability:
               dynamic: true
               extended_nexthop: true
@@ -278,6 +307,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
   - name: test_case_02
@@ -313,7 +343,11 @@ merged_tests:
             timers:
               keepalive: 41
               holdtime: 51
-            bfd: false
+              connect_retry: 61
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 3"
             capability:
               dynamic: false
               extended_nexthop: false
@@ -327,6 +361,7 @@ merged_tests:
             timers:
               keepalive: 22
               holdtime: 23
+              connect_retry: 24
             capability:
               dynamic: true
       - bgp_as: "{{bgp_as_1}}"
@@ -359,7 +394,11 @@ merged_tests:
             timers:
               keepalive: 55
               holdtime: 44
-            bfd: false
+              connect_retry: 33
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 4"
             capability:
               dynamic: false
               extended_nexthop: false
@@ -372,6 +411,7 @@ merged_tests:
             timers:
               keepalive: 33
               holdtime: 34
+              connect_retry: 35
             capability:
               dynamic: false
           - neighbor: 3::3
@@ -382,6 +422,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
   - name: test_case_03
@@ -403,6 +444,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
           - neighbor: 3::3
@@ -413,6 +455,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
       - bgp_as: "{{bgp_as_1}}"
@@ -437,6 +480,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
   - name: test_case_04
@@ -541,8 +585,9 @@ merged_tests:
             passive: true
             port: 3
             solo: true
-          - neighbor: 1.1.1.1
+          - neighbor: 192.168.1.5
             disable_connected_check: true
+            shutdown_msg : "msg 1"
             ttl_security: 5
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -577,8 +622,9 @@ merged_tests:
             passive: false
             port: 4
             solo: false
-          - neighbor: 1.1.1.1
+          - neighbor: 192.168.1.5
             disable_connected_check: false
+            shutdown_msg: "msg 2"
             ttl_security: 8
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -587,3 +633,4 @@ merged_tests:
             nbr_description: 'description 3'
             strict_capability_match: false
             v6only: false
+

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -562,8 +562,6 @@ merged_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
-               encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
                enabled: false
@@ -572,9 +570,6 @@ merged_tests:
             enforce_multihop: false
             local_address: 'Ethernet6'
             local_as:
-               as: 3
-               no_prepend: false
-               replace_as: false
             nbr_description: "description 2"
             override_capability: false
             passive: false

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -64,7 +64,7 @@ deleted_tests:
             solo: false
           - neighbor: 192.168.1.5
             disable_connected_check: false
-            shutdown_msg: "msg 2"
+            shutdown_msg: "msg2"
             ttl_security: 8
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -587,7 +587,7 @@ merged_tests:
             solo: true
           - neighbor: 192.168.1.5
             disable_connected_check: true
-            shutdown_msg : "msg 1"
+            shutdown_msg: "msg1"
             ttl_security: 5
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -624,7 +624,7 @@ merged_tests:
             solo: false
           - neighbor: 192.168.1.5
             disable_connected_check: false
-            shutdown_msg: "msg 2"
+            shutdown_msg: "msg2"
             ttl_security: 8
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -633,4 +633,3 @@ merged_tests:
             nbr_description: 'description 3'
             strict_capability_match: false
             v6only: false
-

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -93,13 +93,11 @@ deleted_tests:
     input:
       - bgp_as: "{{bgp_as_1}}"
         neighbors:
-          - neighbor: "{{ interface1 }}"
           - neighbor: 11::11
           - neighbor: 67.1.1.1
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
         neighbors:
-          - neighbor: "{{ interface1 }}"
           - neighbor: 11::11
           - neighbor: 67.1.1.1
 
@@ -139,6 +137,41 @@ deleted_tests:
           - name: SPINE1
 
   - name: test_case_del_05
+    description: Delete BGP NEIGHBORS additional attributes
+    state: deleted
+    input:
+      - bgp_as: "{{bgp_as_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            auth_pwd:
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+            nbr_description: "description 2"
+            override_capability: false
+            passive: false
+            port: 4
+            solo: false
+          - neighbor: 1.1.1.1
+            disable_connected_check: false
+            ttl_security: 8
+      - bgp_as: "{{bgp_as_1}}"
+        vrf_name: "{{vrf_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            auth_pwd:
+               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
+               encrypted: true
+            nbr_description: 'description 3'
+            strict_capability_match: false
+            v6only: false
+
+  - name: test_case_del_06
     description: BGP NEIGHBORS remote-as properties
     state: deleted
     input: []
@@ -551,40 +584,6 @@ merged_tests:
         vrf_name: "{{vrf_1}}"
         neighbors:
           - neighbor: "{{ interface1 }}"
-            nbr_description: 'description 3'
-            strict_capability_match: false
-            v6only: false
-  - name: test_case_08
-    description: Delete BGP NEIGHBORS additional attributes
-    state: deleted
-    input:
-      - bgp_as: "{{bgp_as_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-            dont_negotiate_capability: false
-            ebgp_multihop:
-               enabled: false
-               multihop_ttl: 2
-            enforce_first_as: false
-            enforce_multihop: false
-            local_address: 'Ethernet6'
-            local_as:
-            nbr_description: "description 2"
-            override_capability: false
-            passive: false
-            port: 4
-            solo: false
-          - neighbor: 1.1.1.1
-            disable_connected_check: false
-            ttl_security: 8
-      - bgp_as: "{{bgp_as_1}}"
-        vrf_name: "{{vrf_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
-               encrypted: true
             nbr_description: 'description 3'
             strict_capability_match: false
             v6only: false

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -561,6 +561,9 @@ merged_tests:
       - bgp_as: "{{bgp_as_1}}"
         neighbors:
           - neighbor: "{{ interface1 }}"
+            auth_pwd:
+               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
+               encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
                enabled: false
@@ -584,6 +587,9 @@ merged_tests:
         vrf_name: "{{vrf_1}}"
         neighbors:
           - neighbor: "{{ interface1 }}"
+            auth_pwd:
+               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
+               encrypted: true
             nbr_description: 'description 3'
             strict_capability_match: false
             v6only: false

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -483,7 +483,7 @@ merged_tests:
             remote_as:
                peer_as: 1123
   - name: test_case_06
-    description: BGP NEIGHBORS auth-password and description properties
+    description: BGP NEIGHBORS configure additional attributes
     state: merged
     input:
       - bgp_as: "{{bgp_as_1}}"
@@ -492,26 +492,25 @@ merged_tests:
             auth_pwd:
                pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
                encrypted: true
+            dont_negotiate_capability: true
+            ebgp_multihop:
+               enabled: true
+               multihop_ttl: 1
+            enforce_first_as: true
+            enforce_multihop: true
+            local_address: 'Ethernet4'
+            local_as:
+               as: 2
+               no_prepend: true
+               replace_as: true
             nbr_description: "description 1"
-      - bgp_as: "{{bgp_as_1}}"
-        vrf_name: "{{vrf_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
-               encrypted: true
-            nbr_description: "description 2"
-  - name: test_case_07
-    description: Delete BGP NEIGHBORS auth-password and description properties
-    state: deleted
-    input:
-      - bgp_as: "{{bgp_as_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
-               encrypted: true
-            nbr_description: "description 1"
+            override_capability: true
+            passive: true
+            port: 3
+            solo: true
+          - neighbor: 1.1.1.1
+            disable_connected_check: true
+            ttl_security: 5
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
         neighbors:
@@ -520,3 +519,71 @@ merged_tests:
                pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
                encrypted: true
             nbr_description: 'description 2'
+            strict_capability_match: true
+            v6only: true
+  - name: test_case_07
+    description: BGP NEIGHBORS modify additional attributes
+    state: merged
+    input:
+      - bgp_as: "{{bgp_as_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+               as: 3
+               no_prepend: false
+               replace_as: false
+            nbr_description: "description 2"
+            override_capability: false
+            passive: false
+            port: 4
+            solo: false
+          - neighbor: 1.1.1.1
+            disable_connected_check: false
+            ttl_security: 8
+      - bgp_as: "{{bgp_as_1}}"
+        vrf_name: "{{vrf_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            nbr_description: 'description 3'
+            strict_capability_match: false
+            v6only: false
+  - name: test_case_08
+    description: Delete BGP NEIGHBORS additional attributes
+    state: deleted
+    input:
+      - bgp_as: "{{bgp_as_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+               as: 3
+               no_prepend: false
+               replace_as: false
+            nbr_description: "description 2"
+            override_capability: false
+            passive: false
+            port: 4
+            solo: false
+          - neighbor: 1.1.1.1
+            disable_connected_check: false
+            ttl_security: 8
+      - bgp_as: "{{bgp_as_1}}"
+        vrf_name: "{{vrf_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            nbr_description: 'description 3'
+            strict_capability_match: false
+            v6only: false


### PR DESCRIPTION
##### SUMMARY
I added the following OC attributes to the bgp_neighbors module:

bfd: check-control-plane-failure, enabled, bfd-profile
disable-ebgp-connected-route-check
dont-negotiate-capability
ebgp-multihop : enabled, multihop-ttl
enforce-first-as 
enforce-multihop 
local-as
local-as-no-prepend
local-as-replace-as
override-capability 
passive-mode
peer-port
shutdown-message
solo-peer
strict-capability-match
timers: connect-retry
ttl-security-hops
v6only


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bgp_neighbors
##### ADDITIONAL INFORMATION


[bgp_neighbors_output (3).log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8653529/bgp_neighbors_output.3.log)
[bgp_neighbors_facts_UT (1).log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8653421/bgp_neighbors_facts_UT.1.log)
[regression-2022-05-06-14-33-56.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8653393/regression-2022-05-06-14-33-56.html.pdf)
[show_running_configuration_bgp_output.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8653395/show_running_configuration_bgp_output.txt)

