### PR TITLE
Double commit to "main" branch: CLI command prompt/answer fix

### DIFF
--- a/plugins/module_utils/network/sonic/utils/utils.py
+++ b/plugins/module_utils/network/sonic/utils/utils.py
@@ -10,9 +10,9 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import socket
 import re
 import json
+import ast
 from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     is_masklen,
@@ -466,3 +466,34 @@ def get_breakout_mode(module, name):
                     speed = speed.replace('GB', 'G')
                     mode = str(num_channels) + 'x' + speed
     return mode
+
+
+def command_list_str_to_dict(module, warnings, cmd_list_in, exec_cmd=False):
+    cmd_list_out = []
+    for cmd in cmd_list_in:
+        cmd_out = dict()
+        nested_cmd_is_dict = False
+        if isinstance(cmd, dict):
+            cmd_out = cmd
+        else:
+            try:
+                nest_dict = ast.literal_eval(cmd)
+                nested_cmd_is_dict = isinstance(nest_dict, dict)
+            except Exception:
+                nested_cmd_is_dict = False
+
+            if nested_cmd_is_dict:
+                for key, value in nest_dict.items():
+                    cmd_out[key] = value
+            else:
+                cmd_out = cmd
+
+        if exec_cmd and module.check_mode and not cmd_out['command'].startswith('show'):
+            warnings.append(
+                'Only show commands are supported when using check mode, not '
+                'executing %s' % cmd_out['command']
+            )
+        else:
+            cmd_list_out.append(cmd_out)
+
+    return cmd_list_out

--- a/plugins/modules/sonic_command.py
+++ b/plugins/modules/sonic_command.py
@@ -141,24 +141,33 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.p
     Conditional,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    transform_commands,
+    EntityCollection,
     to_lines,
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import run_commands
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import command_list_str_to_dict
+
+
+def transform_commands_dict(module, commands_dict):
+    transform = EntityCollection(
+        module,
+        dict(
+            command=dict(key=True),
+            output=dict(),
+            prompt=dict(type="list"),
+            answer=dict(type="list"),
+            newline=dict(type="bool", default=True),
+            sendonly=dict(type="bool", default=False),
+            check_all=dict(type="bool", default=False),
+        ),
+    )
+
+    return transform(commands_dict)
 
 
 def parse_commands(module, warnings):
-    commands = transform_commands(module)
-
-    if module.check_mode:
-        for item in list(commands):
-            if not item['command'].startswith('show'):
-                warnings.append(
-                    'Only show commands are supported when using check mode, not '
-                    'executing %s' % item['command']
-                )
-                commands.remove(item)
-
+    commands_dict = command_list_str_to_dict(module, warnings, module.params["commands"])
+    commands = transform_commands_dict(module, commands_dict)
     return commands
 
 

--- a/plugins/modules/sonic_config.py
+++ b/plugins/modules/sonic_config.py
@@ -191,12 +191,14 @@ saved:
   type: bool
   sample: True
 """
+
 from ansible.module_utils.connection import ConnectionError
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import get_config, get_sublevel_config
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import edit_config, run_commands
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import command_list_str_to_dict
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import NetworkConfig, dumps
 
 
@@ -293,6 +295,9 @@ def main():
                 commands = [cmd]
             else:
                 commands = commands.split('\n')
+                cmd_list_out = command_list_str_to_dict(module, warnings, commands)
+                if cmd_list_out and cmd_list_out != []:
+                    commands = cmd_list_out
 
             if module.params['before']:
                 commands[:0] = module.params['before']

--- a/tests/regression/roles/sonic_config/defaults/main.yml
+++ b/tests/regression/roles/sonic_config/defaults/main.yml
@@ -38,12 +38,12 @@ preparations_tests:
     - no interface PortChannel 11
     - no interface PortChannel 1
     - no interface PortChannel 2
-    - no snmp-server community 111
-    - no snmp-server community 112
-    - no snmp-server community 114
-    - no snmp-server community 115
-    - no snmp-server community 116
-    - no snmp-server community 117
+    - no snmp-server community abcd
+    - no snmp-server community efgh
+    - no snmp-server community ijkl
+    - no snmp-server community mnop
+    - no snmp-server community qrst
+    - no snmp-server community uvwx
     - no snmp-server location
     - no snmp-server contact
     - interface Vlan 11
@@ -60,17 +60,17 @@ tests:
       lines:
         - mtu 4444
       parents: ['interface PortChannel 11']
-      before: ['snmp-server community 111']
-      after: ['snmp-server community 112']
+      before: ['snmp-server community abcd']
+      after: ['snmp-server community efgh']
   - name: test_case_02
     description: Test sonic config module with single CLI
     input:
-       before: 'snmp-server community 114'
-       commands: 'snmp-server community 115'
+       before: 'snmp-server community ijkl'
+       commands: 'snmp-server community mnop'
   - name: test_case_03
     description: Test sonic config module with multiple CLI
     input:
-      commands: ['snmp-server community 116', 'snmp-server community 117']
+      commands: ['snmp-server community qrst', 'snmp-server community uvwx']
   - name: test_case_04
     description: Configure interface description using parents option on SONIC device
     input:

--- a/tests/regression/roles/sonic_config/tasks/backup.yaml
+++ b/tests/regression/roles/sonic_config/tasks/backup.yaml
@@ -3,7 +3,7 @@
     backup: yes
     backup_options:
       filename: backup.cfg
-      dir_path: /home/
+      dir_path: /tmp/
   register: backup_file
 
 - name: Verify file is created or not


### PR DESCRIPTION
REF: Branch 1.x PR:

 https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/71

Root cause analysis:

Commands containing a "prompt/answer" sequence require
the user to specify a dictionary containing the command, prompt,
and "answer" (for the prompt). The previously existing handling enclosed the
entire command dictionary (containing the "command", "prompt",
and "answer" key/value pairs) in quotes as the value for an
unintended outer "command" key. The other items in the
dictionary input to the "send_command" API (for sending
commands to a device) were set to defaults (for exec commands)
or left unspecified (for configuration commands).

For example:

- Ansible "module" contents from parsing a playbook that specified
an exec command "list" containing a single command/prompt/answer sequence:

```
["{'command': 'image remove all', 'prompt': '\\[y/N\\]:', 'answer': 'N'}"]
```
- Incorrect result of formatting the "raw" single command list shown
    above to prepare for invoking the "send_command" API:

```
{'command': "{'command': 'image remove all', 'prompt': '\\[y/N\\]:', 'answer': 'N'}", 'output': None, 'prompt': None, 'answer': None, 'newline': True, 'sendonly': False, 'check_all': False}
```
- Instead of the incorrect dictionary shown above, the desired dictionary is:

```
{'command': 'image remove all', 'prompt': '\\[y/N\\]:', 'answer': 'N', 'newline': True, 'sendonly': False, 'check_all': False}
```

Fix:

- Create a utility function to generate the correct dictionary
entries from the input command list parsed from the user
playbook.
- Use the resulting dictionary instead of the "raw" list
of quoted command strings provided by the "AnsibleModule"
parsing invocation to formulate the correct arguments
for the "send_command" API.
- (sonic-config test suite only): Fix problems preventing execution of sonic-config test cases:
    - Change the names for snmp community list entries to valid names.
    - Use /tmp directory instead of /home directory to avoid a permissions failure for
        the "backup" test.




##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_command, sonic_cli
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Unit and Regression Test Results:

- sonic-config test suite output comparison before and after the fix: (The Failing "prompt_test_case" was removed for the second pass of the base comparison because it aborted the test suite, as shown below. That test passes with the fix.)

[prompt_fix_sonic_command_regression_comparison_main.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8655020/prompt_fix_sonic_command_regression_comparison_main.txt)

- Base regression test results:

[regression-prompt_fix_main_V2_base_full_regression-2022-05-08-15-20-53.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8655035/regression-prompt_fix_main_V2_base_full_regression-2022-05-08-15-20-53.pdf)


- Fix regression test results:

[prompt_fix_main_V2_full_regression-2022-05-08-15-20-53.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8655038/prompt_fix_main_V2_full_regression-2022-05-08-15-20-53.pdf)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
