### PR TITLE
Added missing attributes to BGP neighbors peer group

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
@@ -57,7 +57,7 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                         'peer_group': {'type': 'str'},
                         'bfd': {
                             'options': {
-                                'enabled': { 'type': 'bool'},
+                                'enabled': {'type': 'bool'},
                                 'check_failure': {'type': 'bool'},
                                 'profile': {'type': 'str'}
                             },

--- a/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
@@ -78,7 +78,34 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                             },
                             'type': 'dict'
                         },
-                        'nbr_description': {'type': 'str'}
+                        'nbr_description': {'type': 'str'},
+                        'disable_connected_check': {'type': 'bool'},
+                        'dont_negotiate_capability': {'type': 'bool'},
+                        'ebgp_multihop': {
+                            'options': {
+                                'enabled': {'default': 'False', 'type': 'bool'},
+                                'multihop_ttl': {'type': 'int'}
+                            },
+                            'type': 'dict'
+                        },
+                        'enforce_first_as': {'type': 'bool'},
+                        'enforce_multihop': {'type': 'bool'},
+                        'local_address': {'type': 'str'},
+                        'local_as': {
+                            'options': {
+                                'as': {'required': True, 'type': 'int'},
+                                'no_prepend': {'type': 'bool'},
+                                'replace_as': {'type': 'bool'},
+                            },
+                            'type': 'dict'
+                        },
+                        'override_capability': {'type': 'bool'},
+                        'passive': {'default': 'False', 'type': 'bool'},
+                        'port': {'type': 'int'},
+                        'solo': {'type': 'bool'},
+                        'strict_capability_match': {'type': 'bool'},
+                        'ttl_security': {'type': 'int'},
+                        'v6only': {'type': 'bool'}
                     },
                     'type': 'list'
                 },

--- a/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
@@ -55,12 +55,20 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                             'type': 'dict'
                         },
                         'peer_group': {'type': 'str'},
-                        'bfd': {'type': 'bool'},
+                        'bfd': {
+                            'options': {
+                                'enabled': { 'type': 'bool'},
+                                'check_failure': {'type': 'bool'},
+                                'profile': {'type': 'str'}
+                            },
+                            'type': 'dict'
+                        },
                         'advertisement_interval': {'type': 'int'},
                         'timers': {
                             'options': {
                                 'holdtime': {'type': 'int'},
                                 'keepalive': {'type': 'int'},
+                                'connect_retry': {'type': 'int'}
                             },
                             'type': 'dict'
                         },
@@ -73,7 +81,7 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                         },
                         'auth_pwd': {
                             'options': {
-                                'pwd': {'type': 'str'},
+                                'pwd': {'required': True, 'type': 'str'},
                                 'encrypted': {'default': 'False', 'type': 'bool'},
                             },
                             'type': 'dict'
@@ -102,6 +110,7 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                         'override_capability': {'type': 'bool'},
                         'passive': {'default': 'False', 'type': 'bool'},
                         'port': {'type': 'int'},
+                        'shutdown_msg': {'type': 'str'},
                         'solo': {'type': 'bool'},
                         'strict_capability_match': {'type': 'bool'},
                         'ttl_security': {'type': 'int'},

--- a/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
@@ -159,12 +159,20 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                             },
                             'type': 'dict'
                         },
-                        'bfd': {'type': 'bool'},
+                        'bfd': {
+                            'options': {
+                                'enabled': {'type': 'bool'},
+                                'check_failure': {'type': 'bool'},
+                                'profile': {'type': 'str'}
+                            },
+                            'type': 'dict'
+                        },
                         'advertisement_interval': {'type': 'int'},
                         'timers': {
                             'options': {
                                 'holdtime': {'type': 'int'},
                                 'keepalive': {'type': 'int'},
+                                'connect_retry': {'type': 'int'}
                             },
                             'type': 'dict'
                         },
@@ -175,6 +183,40 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                             },
                             'type': 'dict'
                         },
+                        'auth_pwd': {
+                            'options': {
+                                'pwd': {'required': True, 'type': 'str'},
+                                'encrypted': {'default': 'False', 'type': 'bool'},
+                            },
+                            'type': 'dict'
+                        },
+                        'pg_description': {'type': 'str'},
+                        'disable_connected_check': {'type': 'bool'},
+                        'dont_negotiate_capability': {'type': 'bool'},
+                        'ebgp_multihop': {
+                            'options': {
+                                'enabled': {'default': 'False', 'type': 'bool'},
+                                'multihop_ttl': {'type': 'int'}
+                            },
+                            'type': 'dict'
+                        },
+                        'enforce_first_as': {'type': 'bool'},
+                        'enforce_multihop': {'type': 'bool'},
+                        'local_address': {'type': 'str'},
+                        'local_as': {
+                            'options': {
+                                'as': {'required': True, 'type': 'int'},
+                                'no_prepend': {'type': 'bool'},
+                                'replace_as': {'type': 'bool'},
+                            },
+                            'type': 'dict'
+                        },
+                        'override_capability': {'type': 'bool'},
+                        'passive': {'default': 'False', 'type': 'bool'},
+                        'shutdown_msg': {'type': 'str'},
+                        'solo': {'type': 'bool'},
+                        'strict_capability_match': {'type': 'bool'},
+                        'ttl_security': {'type': 'int'}
                     },
                     'type': 'list'
                 },

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -223,11 +223,13 @@ class Bgp_neighbors(ConfigBase):
                     if timers:
                         keepalive = timers.get('keepalive', None)
                         holdtime = timers.get('holdtime', None)
+                        connect_retry = timers.get('connect_retry', None)
                         if keepalive is not None and keepalive != 60:
                             new_timers['keepalive'] = keepalive
                         if holdtime is not None and holdtime != 180:
                             new_timers['holdtime'] = holdtime
-
+                        if connect_retry is not None and connect_retry != 30:
+                            new_timers['connect_retry'] = connect_retry
                     if new_timers:
                         new_pg['timers'] = new_timers
                     advertisement_interval = pg.get('advertisement_interval', None)
@@ -322,25 +324,76 @@ class Bgp_neighbors(ConfigBase):
             if peer_group:
                 bgp_peer_group = {}
                 peer_group_cfg = {}
+                tmp_bfd = {}
+                tmp_ebgp = {}
                 tmp_timers = {}
                 tmp_capability = {}
                 tmp_remote = {}
+                tmp_transport = {}
                 afi = []
                 if peer_group.get('name', None) is not None:
                     peer_group_cfg.update({'peer-group-name': peer_group['name']})
                     bgp_peer_group.update({'peer-group-name': peer_group['name']})
                 if peer_group.get('bfd', None) is not None:
-                    bgp_peer_group.update({'enable-bfd': {'config': {'enabled': peer_group['bfd']}}})
+                    if peer_group['bfd'].get('enabled', None) is not None:
+                        tmp_bfd.update({'enabled': peer_group['bfd']['enabled']})
+                    if peer_group['bfd'].get('check_failure', None) is not None:
+                        tmp_bfd.update({'check-control-plane-failure': peer_group['bfd']['check_failure']})
+                    if peer_group['bfd'].get('profile', None) is not None:
+                        tmp_bfd.update({'bfd-profile': peer_group['bfd']['profile']})
+                if peer_group.get('auth_pwd', None) is not None:
+                    if (peer_group['auth_pwd'].get('pwd', None) is not None and
+                            peer_group['auth_pwd'].get('encrypted', None) is not None):
+                        bgp_peer_group.update({'auth-password': {'config': {'password': peer_group['auth_pwd']['pwd'],
+                                                                          'encrypted': peer_group['auth_pwd']['encrypted']}}})
+                if peer_group.get('ebgp_multihop', None) is not None:
+                    if peer_group['ebgp_multihop'].get('enabled', None) is not None:
+                        tmp_ebgp.update({'enabled': peer_group['ebgp_multihop']['enabled']})
+                    if peer_group['ebgp_multihop'].get('multihop_ttl', None) is not None:
+                        tmp_ebgp.update({'multihop-ttl': peer_group['ebgp_multihop']['multihop_ttl']})
                 if peer_group.get('timers', None) is not None:
                     if peer_group['timers'].get('holdtime', None) is not None:
                         tmp_timers.update({'hold-time': peer_group['timers']['holdtime']})
                     if peer_group['timers'].get('keepalive', None) is not None:
                         tmp_timers.update({'keepalive-interval': peer_group['timers']['keepalive']})
+                    if peer_group['timers'].get('connect_retry', None) is not None:
+                        tmp_timers.update({'connect-retry': peer_group['timers']['connect_retry']})
                 if peer_group.get('capability', None) is not None:
                     if peer_group['capability'].get('dynamic', None) is not None:
                         tmp_capability.update({'capability-dynamic': peer_group['capability']['dynamic']})
                     if peer_group['capability'].get('extended_nexthop', None) is not None:
                         tmp_capability.update({'capability-extended-nexthop': peer_group['capability']['extended_nexthop']})
+                if peer_group.get('pg_description', None) is not None:
+                    peer_group_cfg.update({'description': peer_group['pg_description']})
+                if peer_group.get('disable_connected_check', None) is not None:
+                    peer_group_cfg.update({'disable-ebgp-connected-route-check': peer_group['disable_connected_check']})
+                if peer_group.get('dont_negotiate_capability', None) is not None:
+                    peer_group_cfg.update({'dont-negotiate-capability': peer_group['dont_negotiate_capability']})
+                if peer_group.get('enforce_first_as', None) is not None:
+                    peer_group_cfg.update({'enforce-first-as': peer_group['enforce_first_as']})
+                if peer_group.get('enforce_multihop', None) is not None:
+                    peer_group_cfg.update({'enforce-multihop': peer_group['enforce_multihop']})
+                if peer_group.get('override_capability', None) is not None:
+                    peer_group_cfg.update({'override-capability': peer_group['override_capability']})
+                if peer_group.get('shutdown_msg', None) is not None:
+                    peer_group_cfg.update({'shutdown-message': peer_group['shutdown_msg']})
+                if peer_group.get('solo', None) is not None:
+                    peer_group_cfg.update({'solo-peer': peer_group['solo']})
+                if peer_group.get('strict_capability_match', None) is not None:
+                    peer_group_cfg.update({'strict-capability-match': peer_group['strict_capability_match']})
+                if peer_group.get('ttl_security', None) is not None:
+                    peer_group_cfg.update({'ttl-security-hops': peer_group['ttl_security']})
+                if peer_group.get('local_as', None) is not None:
+                    if peer_group['local_as'].get('as', None) is not None:
+                        peer_group_cfg.update({'local-as': peer_group['local_as']['as']})
+                    if peer_group['local_as'].get('no_prepend', None) is not None:
+                        peer_group_cfg.update({'local-as-no-prepend': peer_group['local_as']['no_prepend']})
+                    if peer_group['local_as'].get('replace_as', None) is not None:
+                        peer_group_cfg.update({'local-as-replace-as': peer_group['local_as']['replace_as']})
+                if peer_group.get('local_address', None) is not None:
+                    tmp_transport.update({'local-address': peer_group['local_address']})
+                if peer_group.get('passive', None) is not None:
+                    tmp_transport.update({'passive-mode': peer_group['passive']})
                 if peer_group.get('advertisement_interval', None) is not None:
                     tmp_timers.update({'minimum-advertisement-interval': peer_group['advertisement_interval']})
                 if peer_group.get('remote_as', None) is not None:
@@ -410,8 +463,14 @@ class Bgp_neighbors(ConfigBase):
                                     samp.update({'allow-own-as': {'config': {'as-count': as_count, "enabled": bool("true")}}})
                             if samp:
                                 afi.append(samp)
+                if tmp_bfd:
+                    bgp_peer_group.update({'enable-bfd': {'config': tmp_bfd}})
+                if tmp_ebgp:
+                    bgp_peer_group.update({'ebgp-multihop': {'config': tmp_ebgp}})
                 if tmp_timers:
                     bgp_peer_group.update({'timers': {'config': tmp_timers}})
+                if tmp_transport:
+                    bgp_peer_group.update({'transport': {'config': tmp_transport}})
                 if afi and len(afi) > 0:
                     bgp_peer_group.update({'afi-safis': {'afi-safi': afi}})
                 if tmp_capability:
@@ -632,6 +691,9 @@ class Bgp_neighbors(ConfigBase):
             if cmd['timers'].get('keepalive', None) is not None:
                 delete_path = delete_static_path + '/timers/config/keepalive-interval'
                 requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['timers'].get('connect_retry', None) is not None:
+                delete_path = delete_static_path + '/timers/config/connect-retry'
+                requests.append({'path': delete_path, 'method': DELETE})
         if cmd.get('capability', None) is not None:
             if cmd['capability'].get('dynamic', None) is not None:
                 delete_path = delete_static_path + '/config/capability-dynamic'
@@ -639,9 +701,76 @@ class Bgp_neighbors(ConfigBase):
             if cmd['capability'].get('extended_nexthop', None) is not None:
                 delete_path = delete_static_path + '/config/capability-extended-nexthop'
                 requests.append({'path': delete_path, 'method': DELETE})
-        if cmd.get('bfd', None) is not None:
-            delete_path = delete_static_path + '/enable-bfd/config/enabled'
+        if cmd.get('pg_description', None) is not None:
+            delete_path = delete_static_path + '/config/description'
             requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('disable_connected_check', None) is not None:
+            delete_path = delete_static_path + '/config/disable-ebgp-connected-route-check'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('dont_negotiate_capability', None) is not None:
+            delete_path = delete_static_path + '/config/dont-negotiate-capability'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('enforce_first_as', None) is not None:
+            delete_path = delete_static_path + '/config/enforce-first-as'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('enforce_multihop', None) is not None:
+            delete_path = delete_static_path + '/config/enforce-multihop'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('override_capability', None) is not None:
+            delete_path = delete_static_path + '/config/override-capability'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('shutdown_msg', None) is not None:
+            delete_path = delete_static_path + '/config/shutdown-message'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('solo', None) is not None:
+            delete_path = delete_static_path + '/config/solo-peer'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('strict_capability_match', None) is not None:
+            delete_path = delete_static_path + '/config/strict-capability-match'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('ttl_security', None) is not None:
+            delete_path = delete_static_path + '/config/ttl-security-hops'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('local_as', None) is not None:
+            if cmd['local_as'].get('as', None) is not None:
+                delete_path = delete_static_path + '/config/local-as'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['local_as'].get('no_prepend', None) is not None:
+                delete_path = delete_static_path + '/config/local-as-no-prepend'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['local_as'].get('replace_as', None) is not None:
+                delete_path = delete_static_path + '/config/local-as-replace-as'
+                requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('local_address', None) is not None:
+            delete_path = delete_static_path + '/transport/config/local-address'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('passive', None) is not None:
+            delete_path = delete_static_path + '/transport/config/passive-mode'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('bfd', None) is not None:
+            if cmd['bfd'].get('enabled', None) is not None:
+                delete_path = delete_static_path + '/enable-bfd/config/enabled'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['bfd'].get('check_failure', None) is not None:
+                delete_path = delete_static_path + '/enable-bfd/config/check-control-plane-failure'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['bfd'].get('profile', None) is not None:
+                delete_path = delete_static_path + '/enable-bfd/config/bfd-profile'
+                requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('auth_pwd', None) is not None:
+            if cmd['auth_pwd'].get('pwd', None) is not None:
+                delete_path = delete_static_path + '/auth-password/config/password'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['auth_pwd'].get('encrypted', None) is not None:
+                delete_path = delete_static_path + '/auth-password/config/encrypted'
+                requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('ebgp_multihop', None) is not None:
+            if cmd['ebgp_multihop'].get('enabled', None) is not None:
+                delete_path = delete_static_path + '/ebgp-multihop/config/enabled'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['ebgp_multihop'].get('multihop_ttl', None) is not None:
+                delete_path = delete_static_path + '/ebgp-multihop/config/multihop_ttl'
+                requests.append({'path': delete_path, 'method': DELETE})
         if cmd.get('address_family', None) is not None:
             if cmd['address_family'].get('afis', None) is None:
                 delete_path = delete_static_path + '/afi-safis/afi-safi'

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -449,6 +449,7 @@ class Bgp_neighbors(ConfigBase):
                 tmp_timers = {}
                 tmp_capability = {}
                 tmp_remote = {}
+                tmp_transport = {}
                 if neighbor.get('bfd', None) is not None:
                     bgp_neighbor.update({'enable-bfd': {'config': {'enabled': neighbor['bfd']}}})
                 if neighbor.get('auth_pwd', None) is not None:
@@ -456,6 +457,11 @@ class Bgp_neighbors(ConfigBase):
                             neighbor['auth_pwd'].get('encrypted', None) is not None):
                         bgp_neighbor.update({'auth-password': {'config': {'password': neighbor['auth_pwd']['pwd'],
                                                                           'encrypted': neighbor['auth_pwd']['encrypted']}}})
+                if neighbor.get('ebgp_multihop', None) is not None:
+                    if (neighbor['ebgp_multihop'].get('enabled', None) is not None and
+                            neighbor['ebgp_multihop'].get('multihop_ttl', None) is not None):
+                        bgp_neighbor.update({'ebgp-multihop': {'config': {'enabled': neighbor['ebgp_multihop']['enabled'],
+                                                                          'multihop-ttl': neighbor['ebgp_multihop']['multihop_ttl']}}})
                 if neighbor.get('timers', None) is not None:
                     if neighbor['timers'].get('holdtime', None) is not None:
                         tmp_timers.update({'hold-time': neighbor['timers']['holdtime']})
@@ -475,6 +481,37 @@ class Bgp_neighbors(ConfigBase):
                     neighbor_cfg.update({'peer-group': neighbor['peer_group']})
                 if neighbor.get('nbr_description', None) is not None:
                     neighbor_cfg.update({'description': neighbor['nbr_description']})
+                if neighbor.get('disable_connected_check', None) is not None:
+                    neighbor_cfg.update({'disable-ebgp-connected-route-check': neighbor['disable_connected_check']})
+                if neighbor.get('dont_negotiate_capability', None) is not None:
+                    neighbor_cfg.update({'dont-negotiate-capability': neighbor['dont_negotiate_capability']})
+                if neighbor.get('enforce_first_as', None) is not None:
+                    neighbor_cfg.update({'enforce-first-as': neighbor['enforce_first_as']})
+                if neighbor.get('enforce_multihop', None) is not None:
+                    neighbor_cfg.update({'enforce-multihop': neighbor['enforce_multihop']})
+                if neighbor.get('override_capability', None) is not None:
+                    neighbor_cfg.update({'override-capability': neighbor['override_capability']})
+                if neighbor.get('port', None) is not None:
+                    neighbor_cfg.update({'peer-port': neighbor['port']})
+                if neighbor.get('solo', None) is not None:
+                    neighbor_cfg.update({'solo-peer': neighbor['solo']})
+                if neighbor.get('strict_capability_match', None) is not None:
+                    neighbor_cfg.update({'strict-capability-match': neighbor['strict_capability_match']})
+                if neighbor.get('ttl_security', None) is not None:
+                    neighbor_cfg.update({'ttl-security-hops': neighbor['ttl_security']})
+                if neighbor.get('v6only', None) is not None:
+                    neighbor_cfg.update({'openconfig-bgp-ext:v6only': neighbor['v6only']})
+                if neighbor.get('local_as', None) is not None:
+                    if neighbor['local_as'].get('as', None) is not None:
+                        neighbor_cfg.update({'local-as': neighbor['local_as']['as']})
+                    if neighbor['local_as'].get('no_prepend', None) is not None:
+                        neighbor_cfg.update({'local-as-no-prepend': neighbor['local_as']['no_prepend']})
+                    if neighbor['local_as'].get('replace_as', None) is not None:
+                        neighbor_cfg.update({'local-as-replace-as': neighbor['local_as']['replace_as']})
+                if neighbor.get('local_address', None) is not None:
+                    tmp_transport.update({'local-address': neighbor['local_address']})
+                if neighbor.get('passive', None) is not None:
+                    tmp_transport.update({'passive-mode': neighbor['passive']})
                 if neighbor.get('remote_as', None) is not None:
                     have_nei = self.find_nei(have, bgp_as, vrf_name, neighbor)
                     if neighbor['remote_as'].get('peer_as', None) is not None:
@@ -497,6 +534,8 @@ class Bgp_neighbors(ConfigBase):
                         tmp_remote.update({'peer-type': neighbor['remote_as']['peer_type'].upper()})
                 if tmp_timers:
                     bgp_neighbor.update({'timers': {'config': tmp_timers}})
+                if tmp_transport:
+                    bgp_neighbor.update({'transport': {'config': tmp_transport}})
                 if tmp_capability:
                     neighbor_cfg.update(tmp_capability)
                 if tmp_remote:
@@ -659,6 +698,52 @@ class Bgp_neighbors(ConfigBase):
         if cmd.get('nbr_description', None) is not None:
             delete_path = delete_static_path + '/config/description'
             requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('disable_connected_check', None) is not None:
+            delete_path = delete_static_path + '/config/disable-ebgp-connected-route-check'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('dont_negotiate_capability', None) is not None:
+            delete_path = delete_static_path + '/config/dont-negotiate-capability'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('enforce_first_as', None) is not None:
+            delete_path = delete_static_path + '/config/enforce-first-as'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('enforce_multihop', None) is not None:
+            delete_path = delete_static_path + '/config/enforce-multihop'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('override_capability', None) is not None:
+            delete_path = delete_static_path + '/config/override-capability'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('port', None) is not None:
+            delete_path = delete_static_path + '/config/peer-port'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('solo', None) is not None:
+            delete_path = delete_static_path + '/config/solo-peer'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('strict_capability_match', None) is not None:
+            delete_path = delete_static_path + '/config/strict-capability-match'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('ttl_security', None) is not None:
+            delete_path = delete_static_path + '/config/ttl-security-hops'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('v6only', None) is not None:
+            delete_path = delete_static_path + '/config/openconfig-bgp-ext:v6only'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('local_as', None) is not None:
+            if cmd['local_as'].get('as', None) is not None:
+                delete_path = delete_static_path + '/config/local-as'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['local_as'].get('no_prepend', None) is not None:
+                delete_path = delete_static_path + '/config/local-as-no-prepend'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['local_as'].get('replace_as', None) is not None:
+                delete_path = delete_static_path + '/config/local-as-replace-as'
+                requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('local_address', None) is not None:
+            delete_path = delete_static_path + '/transport/config/local-address'
+            requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('passive', None) is not None:
+            delete_path = delete_static_path + '/transport/config/passive-mode'
+            requests.append({'path': delete_path, 'method': DELETE})
         if cmd.get('advertisement_interval', None) is not None:
             delete_path = delete_static_path + '/timers/config/minimum-advertisement-interval'
             requests.append({'path': delete_path, 'method': DELETE})
@@ -685,6 +770,13 @@ class Bgp_neighbors(ConfigBase):
                 requests.append({'path': delete_path, 'method': DELETE})
             if cmd['auth_pwd'].get('encrypted', None) is not None:
                 delete_path = delete_static_path + '/auth-password/config/encrypted'
+                requests.append({'path': delete_path, 'method': DELETE})
+        if cmd.get('ebgp_multihop', None) is not None:
+            if cmd['ebgp_multihop'].get('enabled', None) is not None:
+                delete_path = delete_static_path + '/ebgp-multihop/config/enabled'
+                requests.append({'path': delete_path, 'method': DELETE})
+            if cmd['ebgp_multihop'].get('multihop_ttl', None) is not None:
+                delete_path = delete_static_path + '/ebgp-multihop/config/multihop_ttl'
                 requests.append({'path': delete_path, 'method': DELETE})
 
         return requests

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -345,7 +345,7 @@ class Bgp_neighbors(ConfigBase):
                     if (peer_group['auth_pwd'].get('pwd', None) is not None and
                             peer_group['auth_pwd'].get('encrypted', None) is not None):
                         bgp_peer_group.update({'auth-password': {'config': {'password': peer_group['auth_pwd']['pwd'],
-                                                                          'encrypted': peer_group['auth_pwd']['encrypted']}}})
+                                                                            'encrypted': peer_group['auth_pwd']['encrypted']}}})
                 if peer_group.get('ebgp_multihop', None) is not None:
                     if peer_group['ebgp_multihop'].get('enabled', None) is not None:
                         tmp_ebgp.update({'enabled': peer_group['ebgp_multihop']['enabled']})

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
@@ -196,7 +196,6 @@ class Bgp_neighborsFacts(object):
                     if replace_as is not None:
                         local_as['replace_as'] = replace_as
                         fil_neighbor.pop('replace_as')
-
                     if auth_pwd:
                         fil_neighbor['auth_pwd'] = auth_pwd
                     if ebgp_multihop:

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
@@ -48,6 +48,23 @@ class Bgp_neighborsFacts(object):
         'pwd': ['auth-password', 'password'],
         'encrypted': ['auth-password', 'encrypted'],
         'nbr_description': 'description',
+        'disable_connected_check': 'disable-ebgp-connected-route-check',
+        'dont_negotiate_capability': 'dont-negotiate-capability',
+        'enforce_first_as': 'enforce-first-as',
+        'enforce_multihop': 'enforce-multihop',
+        'local_address': ['transport', 'config', 'local-address'],
+        'as': 'local-as',
+        'no_prepend': 'local-as-no-prepend',
+        'replace_as': 'local-as-replace-as',
+        'override_capability': 'override-capability',
+        'port': 'peer-port',
+        'solo': 'solo-peer',
+        'strict_capability_match': 'strict-capability-match',
+        'ttl_security': 'ttl-security-hops',
+        'enabled': ['ebgp-multihop', 'enabled'],
+        'multihop_ttl': ['ebgp-multihop', 'multihop-ttl'],
+        'v6only': 'openconfig-bgp-ext:v6only',
+        'passive': ['transport', 'config', 'passive-mode']
     }
 
     def __init__(self, module, subspec='config', options='options'):
@@ -157,8 +174,35 @@ class Bgp_neighborsFacts(object):
                     if encrypted is not None:
                         auth_pwd['encrypted'] = encrypted
                         fil_neighbor.pop('encrypted')
+                    ebgp_multihop = {}
+                    enabled = fil_neighbor.get('enabled', None)
+                    if enabled is not None:
+                        ebgp_multihop['enabled'] = enabled
+                        fil_neighbor.pop('enabled')
+                    multihop_ttl = fil_neighbor.get('multihop_ttl', None)
+                    if multihop_ttl is not None:
+                        ebgp_multihop['multihop_ttl'] = multihop_ttl
+                        fil_neighbor.pop('multihop_ttl')
+                    local_as = {}
+                    asn = fil_neighbor.get('as', None)
+                    if asn is not None:
+                        local_as['as'] = asn
+                        fil_neighbor.pop('as')
+                    no_prepend = fil_neighbor.get('no_prepend', None)
+                    if no_prepend is not None:
+                        local_as['no_prepend'] = no_prepend
+                        fil_neighbor.pop('no_prepend')
+                    replace_as = fil_neighbor.get('replace_as', None)
+                    if replace_as is not None:
+                        local_as['replace_as'] = replace_as
+                        fil_neighbor.pop('replace_as')
+
                     if auth_pwd:
                         fil_neighbor['auth_pwd'] = auth_pwd
+                    if ebgp_multihop:
+                        fil_neighbor['ebgp_multihop'] = ebgp_multihop
+                    if local_as:
+                        fil_neighbor['local_as'] = local_as
                     if fil_neighbor:
                         fil_neighbors.append(fil_neighbor)
             if fil_neighbors:

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
@@ -41,8 +41,11 @@ class Bgp_neighborsFacts(object):
         'peer_group': 'peer-group',
         'keepalive': 'keepalive-interval',
         'holdtime': 'hold-time',
+        'connect_retry': 'connect-retry',
         'advertisement_interval': 'minimum-advertisement-interval',
-        'bfd': ['enable-bfd', 'enabled'],
+        'bfd_enabled': ['enable-bfd', 'enabled'],
+        'check_failure': ['enable-bfd', 'check-control-plane-failure'],
+        'profile': ['enable-bfd', 'bfd-profile'],
         'dynamic': 'capability-dynamic',
         'extended_nexthop': 'capability-extended-nexthop',
         'pwd': ['auth-password', 'password'],
@@ -58,6 +61,7 @@ class Bgp_neighborsFacts(object):
         'replace_as': 'local-as-replace-as',
         'override_capability': 'override-capability',
         'port': 'peer-port',
+        'shutdown_msg': 'shutdown-message',
         'solo': 'solo-peer',
         'strict_capability_match': 'strict-capability-match',
         'ttl_security': 'ttl-security-hops',
@@ -196,12 +200,27 @@ class Bgp_neighborsFacts(object):
                     if replace_as is not None:
                         local_as['replace_as'] = replace_as
                         fil_neighbor.pop('replace_as')
+                    bfd = {}
+                    bfd_enabled = fil_neighbor.get('bfd_enabled', None)
+                    if bfd_enabled is not None:
+                        bfd['enabled'] = bfd_enabled
+                        fil_neighbor.pop('bfd_enabled')
+                    check_failure = fil_neighbor.get('check_failure', None)
+                    if check_failure is not None:
+                        bfd['check_failure'] = check_failure
+                        fil_neighbor.pop('check_failure')
+                    profile = fil_neighbor.get('profile', None)
+                    if profile is not None:
+                        bfd['profile'] = profile
+                        fil_neighbor.pop('profile')
                     if auth_pwd:
                         fil_neighbor['auth_pwd'] = auth_pwd
                     if ebgp_multihop:
                         fil_neighbor['ebgp_multihop'] = ebgp_multihop
                     if local_as:
                         fil_neighbor['local_as'] = local_as
+                    if bfd:
+                        fil_neighbor['bfd'] = bfd
                     if fil_neighbor:
                         fil_neighbors.append(fil_neighbor)
             if fil_neighbors:

--- a/plugins/module_utils/network/sonic/utils/bgp_utils.py
+++ b/plugins/module_utils/network/sonic/utils/bgp_utils.py
@@ -73,21 +73,71 @@ def get_peergroups(module, vrf_name):
         if 'peer-group' in data:
             for peer_group in data['peer-group']:
                 pg = {}
-                if 'config' in peer_group and 'peer-group-name' in peer_group['config']:
-                    pg.update({'name': peer_group['config']['peer-group-name']})
+                if 'config' in peer_group:
+                    if 'peer-group-name' in peer_group['config']:
+                        pg.update({'name': peer_group['config']['peer-group-name']})
+                    if 'description' in peer_group['config']:
+                        pg.update({'pg_description': peer_group['config']['description']})
+                    if 'disable-ebgp-connected-route-check' in peer_group['config']:
+                        pg.update({'disable_connected_check': peer_group['config']['disable-ebgp-connected-route-check']})
+                    if 'dont-negotiate-capability' in peer_group['config']:
+                        pg.update({'dont_negotiate_capability': peer_group['config']['dont-negotiate-capability']})
+                    if 'enforce-first-as' in peer_group['config']:
+                        pg.update({'enforce_first_as': peer_group['config']['enforce-first-as']})
+                    if 'enforce-multihop' in peer_group['config']:
+                        pg.update({'enforce_multihop': peer_group['config']['enforce-multihop']})
+                    local_as = {}
+                    if 'local-as' in peer_group['config']:
+                        local_as.update({'as': peer_group['config']['local-as']})
+                    if 'local-as-no-prepend' in peer_group['config']:
+                        local_as.update({'no_prepend': peer_group['config']['local-as-no-prepend']})
+                    if 'local-as-replace-as' in peer_group['config']:
+                        local_as.update({'replace_as': peer_group['config']['local-as-replace-as']})
+                    if 'override-capability' in peer_group['config']:
+                        pg.update({'override_capability': peer_group['config']['override-capability']})
+                    if 'shutdown-message' in peer_group['config']:
+                        pg.update({'shutdown_msg': peer_group['config']['shutdown-message']})
+                    if 'solo-peer' in peer_group['config']:
+                        pg.update({'solo': peer_group['config']['solo-peer']})
+                    if 'strict-capability-match' in peer_group['config']:
+                        pg.update({'strict_capability_match': peer_group['config']['strict-capability-match']})
+                    if 'ttl-security-hops' in peer_group['config']:
+                        pg.update({'ttl_security': peer_group['config']['ttl-security-hops']})
+                auth_pwd = {}
+                if 'auth-password' in peer_group and 'config' in peer_group['auth-password']:
+                    if 'encrypted' in peer_group['auth-password']['config']:
+                            auth_pwd.update({'encrypted': peer_group['auth-password']['config']['encrypted']})
+                    if 'password' in peer_group['auth-password']['config']:
+                            auth_pwd.update({'pwd': peer_group['auth-password']['config']['password']})
+                bfd = {}
                 if 'enable-bfd' in peer_group and 'config' in peer_group['enable-bfd']:
                     if 'enabled' in peer_group['enable-bfd']['config']:
-                        pg.update({'bfd': peer_group['enable-bfd']['config']['enabled']})
+                        bfd.update({'enabled': peer_group['enable-bfd']['config']['enabled']})
+                    if 'check-control-plane-failure' in peer_group['enable-bfd']['config']:
+                        bfd.update({'check_failure': peer_group['enable-bfd']['config']['check-control-plane-failure']})
+                    if 'bfd-profile' in peer_group['enable-bfd']['config']:
+                        bfd.update({'profile': peer_group['enable-bfd']['config']['bfd-profile']})
+                ebgp_multihop = {}
+                if 'ebgp-multihop' in peer_group and 'config' in peer_group['ebgp-multihop']:
+                    if 'enabled' in peer_group['ebgp-multihop']['config']:
+                        ebgp_multihop.update({'enabled': peer_group['ebgp-multihop']['config']['enabled']})
+                    if 'multihop-ttl' in peer_group['ebgp-multihop']['config']:
+                        ebgp_multihop.update({'multihop_ttl': peer_group['ebgp-multihop']['config']['multihop-ttl']})
+                if 'transport' in peer_group and 'config' in peer_group['transport']:
+                    if 'local-address' in peer_group['transport']['config']:
+                        pg.update({'local_address': peer_group['transport']['config']['local-address']})
+                    if 'passive-mode' in peer_group['transport']['config']:
+                        pg.update({'passive': peer_group['transport']['config']['passive-mode']})
                 if 'timers' in peer_group and 'config' in peer_group['timers']:
                     if 'minimum-advertisement-interval' in peer_group['timers']['config']:
                         pg.update({'advertisement_interval': peer_group['timers']['config']['minimum-advertisement-interval']})
                 timers = {}
-                if 'timers' in peer_group and 'config' in peer_group['timers']:
-                    if 'hold-time' in peer_group['timers']['config']:
-                        timers.update({'holdtime': peer_group['timers']['config']['hold-time']})
-                if 'timers' in peer_group and 'config' in peer_group['timers']:
-                    if 'keepalive-interval' in peer_group['timers']['config']:
-                        timers.update({'keepalive': peer_group['timers']['config']['keepalive-interval']})
+                if 'hold-time' in peer_group['timers']['config']:
+                    timers.update({'holdtime': peer_group['timers']['config']['hold-time']})
+                if 'keepalive-interval' in peer_group['timers']['config']:
+                    timers.update({'keepalive': peer_group['timers']['config']['keepalive-interval']})
+                if 'connect-retry' in peer_group['timers']['config']:
+                    timers.update({'connect_retry': peer_group['timers']['config']['connect-retry']})
                 capability = {}
                 if 'config' in peer_group and 'capability-dynamic' in peer_group['config']:
                     capability.update({'dynamic': peer_group['config']['capability-dynamic']})
@@ -125,6 +175,14 @@ def get_peergroups(module, vrf_name):
                                 samp.update({'allowas_in': allowas_in})
                         if samp:
                             afis.append(samp)
+                if auth_pwd:
+                    pg.update({'auth_pwd': auth_pwd})
+                if bfd:
+                    pg.update({'bfd': bfd})
+                if ebgp_multihop:
+                    pg.update({'ebgp_multihop': ebgp_multihop})
+                if local_as:
+                    pg.update({'local_as': local_as})
                 if timers:
                     pg.update({'timers': timers})
                 if capability:

--- a/plugins/module_utils/network/sonic/utils/bgp_utils.py
+++ b/plugins/module_utils/network/sonic/utils/bgp_utils.py
@@ -106,9 +106,9 @@ def get_peergroups(module, vrf_name):
                 auth_pwd = {}
                 if 'auth-password' in peer_group and 'config' in peer_group['auth-password']:
                     if 'encrypted' in peer_group['auth-password']['config']:
-                            auth_pwd.update({'encrypted': peer_group['auth-password']['config']['encrypted']})
+                        auth_pwd.update({'encrypted': peer_group['auth-password']['config']['encrypted']})
                     if 'password' in peer_group['auth-password']['config']:
-                            auth_pwd.update({'pwd': peer_group['auth-password']['config']['password']})
+                        auth_pwd.update({'pwd': peer_group['auth-password']['config']['password']})
                 bfd = {}
                 if 'enable-bfd' in peer_group and 'config' in peer_group['enable-bfd']:
                     if 'enabled' in peer_group['enable-bfd']['config']:

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -85,6 +85,8 @@ options:
                   - internal
                   - external
           bfd:
+            description:
+              - Enables or disables BFD.
             type: dict
             suboptions:
               enabled:

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -279,7 +279,7 @@ options:
             description:
               - Enforces the first AS for EBGP routes.
             type: bool
-          enforce_multihop
+          enforce_multihop:
             description:
               - Enforces EBGP multihop performance for neighbor.
             type: bool

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -522,7 +522,6 @@ EXAMPLES = """
 #  v6only
 #  password U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg= encrypted
 #  strict-capability-match
-
 # !
 # neighbor 192.168.1.4
 #!

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -99,7 +99,7 @@ options:
                 type: bool
               profile:
                 description:
-                  - BFD Profile name format.
+                  - BFD Profile name.
                 type: str
           advertisement_interval:
             description:
@@ -156,7 +156,7 @@ options:
                 default: False
           pg_description:
             description:
-              - A textual description of the interface.
+              - A textual description of the peer group.
             type: str
           disable_connected_check:
             description:
@@ -323,7 +323,7 @@ options:
                 type: bool
               profile:
                 description:
-                  - BFD Profile name format.
+                  - BFD Profile name.
                 type: str
           advertisement_interval:
             description:
@@ -384,7 +384,7 @@ options:
                 default: False
           nbr_description:
             description:
-              - A textual description of the interface.
+              - A textual description of the neighbor.
             type: str
           disable_connected_check:
             description:

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -546,7 +546,6 @@ EXAMPLES = """
 #  timers connect 25
 #  bfd check-control-plane-failure profile "profile 1"
 #  advertisement-interval 15
-#  bfd
 #  capability extended-nexthop
 #  capability dynamic
 #  v6only

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -262,6 +262,7 @@ options:
                 description:
                   - Authentication password for the neighbor group.
                 type: str
+                required: True
               encrypted:
                 description:
                   - Indicates whether the password is encrypted text.

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -703,6 +703,8 @@ EXAMPLES = """
 # !
 # neighbor interface Eth1/3
 # !
+# neighbor interface Eth1/2
+# neighbor 1.1.1.1
 
 """
 RETURN = """

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -296,6 +296,7 @@ options:
                 description:
                   - Local autonomous system number.
                 type: int
+                required: True
               no_prepend:
                 description:
                   - Do not prepend the local-as number in AS-Path advertisements.
@@ -304,7 +305,6 @@ options:
                 description:
                   - Replace the configured AS Number with the local-as number in AS-Path advertisements.
                 type: bool
-                required: True
           override_capability:
             description:
               - Override capability negotiation result.

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -85,9 +85,20 @@ options:
                   - internal
                   - external
           bfd:
-            description:
-              - Enables or disables BFD.
-            type: bool
+            type: dict
+            suboptions:
+              enabled:
+                description:
+                  - Enables BFD liveliness check for a BGP peer.
+                type: bool
+              check_failure:
+                description:
+                  - Link dataplane status with control plane.
+                type: bool
+              profile:
+                description:
+                  - BFD Profile name format.
+                type: str
           advertisement_interval:
             description:
               - Specifies the minimum interval between sending BGP routing updates.
@@ -108,6 +119,11 @@ options:
                   - Interval after not receiving a keepalive message that Enterprise SONiC declares a peer dead, in seconds.
                   - The range is from 0 to 65535.
                 type: int
+              connect_retry:
+                description:
+                  - Time interval in seconds between attempts to establish a session with the peer.
+                  - The range is from 1 to 65535.
+                type: int
           capability:
             description:
               - Specifies capability attributes to this peer group.
@@ -121,6 +137,102 @@ options:
                 description:
                   - Enables or disables advertise extended next-hop capability to the peer.
                 type: bool
+          auth_pwd:
+            description:
+              - Configuration for peer group authentication password.
+            type: dict
+            suboptions:
+              pwd:
+                description:
+                  - Authentication password for the peer group.
+                type: str
+                required: True
+              encrypted:
+                description:
+                  - Indicates whether the password is encrypted text.
+                type: bool
+                default: False
+          pg_description:
+            description:
+              - A textual description of the interface.
+            type: str
+          disable_connected_check:
+            description:
+              - Disables EBGP conntected route check.
+            type: bool
+          dont_negotiate_capability:
+            description:
+              - Disables capability negotiation.
+            type: bool
+          ebgp_multihop:
+            description:
+              - Allow EBGP peers not on directly connected networks.
+            type: dict
+            suboptions:
+              enabled:
+                description:
+                  - Enables the referenced group or peers to be indirectly connected.
+                type: bool
+                default: False
+              multihop_ttl:
+                description:
+                  - Time-to-live value to use when packets are sent to the referenced group or peers and ebgp-multihop is enabled.
+                type: int
+          enforce_first_as:
+            description:
+              - Enforces the first AS for EBGP routes.
+            type: bool
+          enforce_multihop:
+            description:
+              - Enforces EBGP multihop performance for peer.
+            type: bool
+          local_address:
+            description:
+              - Set the local IP address to use for the session when sending BGP update messages.
+            type: str
+          local_as:
+            description:
+              - Specifies local autonomous system number.
+            type: dict
+            suboptions:
+              as:
+                description:
+                  - Local autonomous system number.
+                type: int
+                required: True
+              no_prepend:
+                description:
+                  - Do not prepend the local-as number in AS-Path advertisements.
+                type: bool
+              replace_as:
+                description:
+                  - Replace the configured AS Number with the local-as number in AS-Path advertisements.
+                type: bool
+          override_capability:
+            description:
+              - Override capability negotiation result.
+            type: bool
+          passive:
+            description:
+              - Do not send open messages to this peer.
+            type: bool
+            default: False
+          shutdown_msg:
+            description:
+              - Add a shutdown message.
+            type: str
+          solo:
+            description:
+              - Indicates that routes advertised by the peer should not be reflected back to the peer.
+            type: bool
+          strict_capability_match:
+            description:
+              - Enables strict capability negotiation match.
+            type: bool
+          ttl_security:
+            description:
+              - Enforces only the peers that are specified number of hops away will be allowed to become peers.
+            type: int
           address_family:
             description:
               - Holds of list of address families associated to the peergroup.
@@ -468,12 +580,42 @@ EXAMPLES = """
        vrf_name: VrfReg1
        peer_group:
          - name: SPINE
-           bfd: true
+           bfd:
+             check_failure: true
+             enabled: true
+             profile: 'profile 1'
            capability:
              dynamic: true
              extended_nexthop: true
+           auth_pwd:
+             pwd: 'U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M='
+             encrypted: true
+           dont_negotiate_capability: true
+           ebgp_multihop:
+             enabled: true
+             multihop_ttl: 1
+           enforce_first_as: true
+           enforce_multihop: true
+           local_address: 'Ethernet4'
+           local_as:
+             as: 2
+             no_prepend: true
+             replace_as: true
+           pg_description: 'description 1'
+           override_capability: true
+           passive: true
+           solo: true
            remote_as:
              peer_as: 4
+         - name: SPINE1
+           disable_connected_check: true
+           shutdown_msg: "msg1"
+           strict_capability_match: true
+           timers:
+             keepalive: 30
+             holdtime: 15
+             connect_retry: 25
+           ttl_security: 5
            address_family:
              afis:
                - afi: ipv4
@@ -523,11 +665,30 @@ EXAMPLES = """
 # network import-check
 # timers 60 180
 # !
+# peer-group SPINE1
+#  timers 15 30
+#  timers connect 25
+#  shutdown message msg1
+#  disable-connected-check
+#  strict-capability-match
+#  ttl-security hops 5
+# !
 # peer-group SPINE
+#  description "description 1"
+#  ebgp-multihop 1
 #  remote-as 4
-#  bfd
+#  bfd check-control-plane-failure profile "profile 1"
+#  update-source interface Ethernet4
 #  capability dynamic
 #  capability extended-nexthop
+#  dont-capability-negotiate
+#  enforce-first-as
+#  enforce-multihop
+#  local-as 2 no-prepend replace-as
+#  override-capability
+#  passive
+#  password U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M= encrypted
+#  solo
 #  address-family ipv4 unicast
 #   activate
 #   allowas-in origin
@@ -698,9 +859,42 @@ EXAMPLES = """
        vrf_name: VrfReg1
        peer_group:
          - name: SPINE
-           bfd: true
+           bfd:
+             check_failure: true
+             enabled: true
+             profile: 'profile 1'
+           capability:
+             dynamic: true
+             extended_nexthop: true
+           auth_pwd:
+             pwd: 'U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M='
+             encrypted: true
+           dont_negotiate_capability: true
+           ebgp_multihop:
+             enabled: true
+             multihop_ttl: 1
+           enforce_first_as: true
+           enforce_multihop: true
+           local_address: 'Ethernet4'
+           local_as:
+             as: 2
+             no_prepend: true
+             replace_as: true
+           pg_description: 'description 1'
+           override_capability: true
+           passive: true
+           solo: true
            remote_as:
              peer_as: 4
+         - name: SPINE1
+           disable_connected_check: true
+           shutdown_msg: "msg1"
+           strict_capability_match: true
+           timers:
+             keepalive: 30
+             holdtime: 15
+             connect_retry: 25
+           ttl_security: 5
        neighbors:
          - neighbor: Eth1/3
            remote_as:
@@ -733,6 +927,8 @@ EXAMPLES = """
 #router bgp 51 vrf VrfReg1
 # network import-check
 # timers 60 180
+# !
+# peer-group SPINE1
 # !
 # peer-group SPINE
 # !

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -197,7 +197,20 @@ options:
           bfd:
             description:
               - Enables or disables BFD.
-            type: bool
+            type: dict
+            suboptions:
+              enabled:
+                description:
+                  - Enables BFD liveliness check for a BGP neighbor.
+                type: bool
+              check_failure:
+                description:
+                  - Link dataplane status with control plane.
+                type: bool
+              profile:
+                description:
+                  - BFD Profile name format.
+                type: str
           advertisement_interval:
             description:
               - Specifies the minimum interval between sending BGP routing updates.
@@ -221,6 +234,11 @@ options:
                 description:
                   - Interval after not receiving a keepalive message that SONiC declares a peer dead, in seconds.
                   - The range is from 0 to 65535.
+                type: int
+              connect_retry:
+                description:
+                  - Time interval in seconds between attempts to establish a session with the peer.
+                  - The range is from 1 to 65535.
                 type: int
           capability:
             description:
@@ -318,6 +336,10 @@ options:
             description:
               - Neighbor's BGP port.
             type: int
+          shutdown_msg:
+            description:
+              - Add a shutdown message.
+            type: str
           solo:
             description:
               - Indicates that routes advertised by the peer should not be reflected back to the peer.
@@ -436,6 +458,7 @@ EXAMPLES = """
            override_capability: true
            passive: true
            port: 3
+           shutdown_msg: 'msg1'
            solo: true
          - neighbor: 1.1.1.1
            disable_connected_check: true
@@ -471,7 +494,11 @@ EXAMPLES = """
            timers:
              keepalive: 30
              holdtime: 15
-           bfd: true
+             connect_retry: 25
+           bfd:
+             check_failure: true
+             enabled: true
+             profile: 'profile 1'
            capability:
              dynamic: true
              extended_nexthop: true
@@ -515,6 +542,8 @@ EXAMPLES = """
 #  peer-group SPINE
 #  remote-as 10
 #  timers 15 30
+#  timers connect 25
+#  bfd check-control-plane-failure profile "profile 1"
 #  advertisement-interval 15
 #  bfd
 #  capability extended-nexthop
@@ -529,6 +558,7 @@ EXAMPLES = """
 #  timers 60 180
 # neighbor interface Eth1/2
 #  description "description 1"
+#  shutdown message msg1
 #  ebgp-multihop 1
 #  remote-as external
 #  update-source interface Ethernet4
@@ -659,6 +689,7 @@ EXAMPLES = """
            override_capability: true
            passive: true
            port: 3
+           shutdown_msg: 'msg1'
            solo: true
          - neighbor: 1.1.1.1
            disable_connected_check: true
@@ -679,7 +710,11 @@ EXAMPLES = """
            timers:
              keepalive: 30
              holdtime: 15
-           bfd: true
+             connect_retry: 25
+           bfd:
+             check_failure: true
+             enabled: true
+             profile: 'profile 1'
            capability:
              dynamic: true
              extended_nexthop: true

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -437,9 +437,9 @@ EXAMPLES = """
            passive: true
            port: 3
            solo: true
-          - neighbor: 1.1.1.1
-            disable_connected_check: true
-            ttl_security: 5
+         - neighbor: 1.1.1.1
+           disable_connected_check: true
+           ttl_security: 5
      - bgp_as: 51
        vrf_name: VrfReg1
        peer_group:
@@ -478,9 +478,9 @@ EXAMPLES = """
            auth_pwd:
                pwd: 'U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg='
                encrypted: true
-            nbr_description: 'description 2'
-            strict_capability_match: true
-            v6only: true
+           nbr_description: 'description 2'
+           strict_capability_match: true
+           v6only: true
          - neighbor: 192.168.1.4
     state: merged
 #

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -42,6 +42,42 @@ action_tests:
 
 deleted_tests:
   - name: test_case_del_01
+    description: Delete BGP NEIGHBORS additional attributes
+    state: deleted
+    input:
+      - bgp_as: "{{bgp_as_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            auth_pwd:
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+            nbr_description: "description 2"
+            override_capability: false
+            passive: false
+            port: 4
+            solo: false
+          - neighbor: 192.168.1.5
+            disable_connected_check: false
+            shutdown_msg: "msg 2"
+            ttl_security: 8
+      - bgp_as: "{{bgp_as_1}}"
+        vrf_name: "{{vrf_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            auth_pwd:
+               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
+               encrypted: true
+            nbr_description: 'description 3'
+            strict_capability_match: false
+            v6only: false
+
+  - name: test_case_del_02
     description: BGP NEIGHBORS remote-as properties
     state: deleted
     input:
@@ -87,28 +123,38 @@ deleted_tests:
             remote_as:
               peer_type: external
 
-  - name: test_case_del_02
+  - name: test_case_del_03
     description: BGP NEIGHBORS remote-as properties
     state: deleted
     input:
       - bgp_as: "{{bgp_as_1}}"
         neighbors:
+          - neighbor: "{{ interface1 }}"
           - neighbor: 11::11
           - neighbor: 67.1.1.1
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
         neighbors:
+          - neighbor: "{{ interface1 }}"
           - neighbor: 11::11
           - neighbor: 67.1.1.1
 
-  - name: test_case_del_03
-    description: BGP NEIGHBORS delete neighbor peergroup
+  - name: test_case_del_04
+    description: BGP NEIGHBORS delete neighbor peergroup, bfd, and timers
     state: deleted
     input:
       - bgp_as: "{{bgp_as_1}}"
         neighbors:
           - neighbor: "{{ interface2 }}"
             peer_group: SPINE
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 3"
+            timers:
+              keepalive: 41
+              holdtime: 51
+              connect_retry: 61
           - neighbor: 3::3
             peer_group: SPINE
           - neighbor: 192.168.1.5
@@ -120,10 +166,18 @@ deleted_tests:
             peer_group: SPINE
           - neighbor: "{{ interface3 }}"
             peer_group: SPINE1
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 4"
+            timers:
+              keepalive: 55
+              holdtime: 44
+              connect_retry: 33
           - neighbor: 3::3
             peer_group: SPINE
 
-  - name: test_case_del_04
+  - name: test_case_del_05
     description: Delete peer group BGP NEIGHBORS properties
     state: deleted
     input:
@@ -135,41 +189,6 @@ deleted_tests:
         peer_group:
           - name: SPINE
           - name: SPINE1
-
-  - name: test_case_del_05
-    description: Delete BGP NEIGHBORS additional attributes
-    state: deleted
-    input:
-      - bgp_as: "{{bgp_as_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-            dont_negotiate_capability: false
-            ebgp_multihop:
-               enabled: false
-               multihop_ttl: 2
-            enforce_first_as: false
-            enforce_multihop: false
-            local_address: 'Ethernet6'
-            local_as:
-            nbr_description: "description 2"
-            override_capability: false
-            passive: false
-            port: 4
-            solo: false
-          - neighbor: 1.1.1.1
-            disable_connected_check: false
-            ttl_security: 8
-      - bgp_as: "{{bgp_as_1}}"
-        vrf_name: "{{vrf_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
-               encrypted: true
-            nbr_description: 'description 3'
-            strict_capability_match: false
-            v6only: false
 
   - name: test_case_del_06
     description: BGP NEIGHBORS remote-as properties
@@ -209,7 +228,11 @@ merged_tests:
             timers:
               keepalive: 40
               holdtime: 50
-            bfd: true
+              connect_retry: 60
+            bfd:
+              enabled: true
+              check_failure: true
+              profile: "profile 1"
             capability:
               dynamic: true
               extended_nexthop: true
@@ -224,6 +247,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
           - neighbor: 3::3
@@ -234,6 +258,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
       - bgp_as: "{{bgp_as_1}}"
@@ -265,7 +290,11 @@ merged_tests:
             timers:
               keepalive: 40
               holdtime: 50
-            bfd: true
+              connect_retry: 60
+            bfd:
+              enabled: true
+              check_failure: true
+              profile: "profile 2"
             capability:
               dynamic: true
               extended_nexthop: true
@@ -278,6 +307,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
   - name: test_case_02
@@ -313,7 +343,11 @@ merged_tests:
             timers:
               keepalive: 41
               holdtime: 51
-            bfd: false
+              connect_retry: 61
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 3"
             capability:
               dynamic: false
               extended_nexthop: false
@@ -327,6 +361,7 @@ merged_tests:
             timers:
               keepalive: 22
               holdtime: 23
+              connect_retry: 24
             capability:
               dynamic: true
       - bgp_as: "{{bgp_as_1}}"
@@ -359,7 +394,11 @@ merged_tests:
             timers:
               keepalive: 55
               holdtime: 44
-            bfd: false
+              connect_retry: 33
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 4"
             capability:
               dynamic: false
               extended_nexthop: false
@@ -372,6 +411,7 @@ merged_tests:
             timers:
               keepalive: 33
               holdtime: 34
+              connect_retry: 35
             capability:
               dynamic: false
           - neighbor: 3::3
@@ -382,6 +422,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
   - name: test_case_03
@@ -403,6 +444,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
           - neighbor: 3::3
@@ -413,6 +455,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
       - bgp_as: "{{bgp_as_1}}"
@@ -437,6 +480,7 @@ merged_tests:
             timers:
               keepalive: 30
               holdtime: 20
+              connect_retry: 10
             capability:
               dynamic: true
   - name: test_case_04
@@ -541,8 +585,9 @@ merged_tests:
             passive: true
             port: 3
             solo: true
-          - neighbor: 1.1.1.1
+          - neighbor: 192.168.1.5
             disable_connected_check: true
+            shutdown_msg : "msg 1"
             ttl_security: 5
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -577,8 +622,9 @@ merged_tests:
             passive: false
             port: 4
             solo: false
-          - neighbor: 1.1.1.1
+          - neighbor: 192.168.1.5
             disable_connected_check: false
+            shutdown_msg: "msg 2"
             ttl_security: 8
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -587,3 +633,4 @@ merged_tests:
             nbr_description: 'description 3'
             strict_capability_match: false
             v6only: false
+

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -562,8 +562,6 @@ merged_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
-               encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
                enabled: false
@@ -572,9 +570,6 @@ merged_tests:
             enforce_multihop: false
             local_address: 'Ethernet6'
             local_as:
-               as: 3
-               no_prepend: false
-               replace_as: false
             nbr_description: "description 2"
             override_capability: false
             passive: false

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -64,7 +64,7 @@ deleted_tests:
             solo: false
           - neighbor: 192.168.1.5
             disable_connected_check: false
-            shutdown_msg: "msg 2"
+            shutdown_msg: "msg2"
             ttl_security: 8
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -587,7 +587,7 @@ merged_tests:
             solo: true
           - neighbor: 192.168.1.5
             disable_connected_check: true
-            shutdown_msg : "msg 1"
+            shutdown_msg: "msg1"
             ttl_security: 5
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -624,7 +624,7 @@ merged_tests:
             solo: false
           - neighbor: 192.168.1.5
             disable_connected_check: false
-            shutdown_msg: "msg 2"
+            shutdown_msg: "msg2"
             ttl_security: 8
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
@@ -633,4 +633,3 @@ merged_tests:
             nbr_description: 'description 3'
             strict_capability_match: false
             v6only: false
-

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -86,7 +86,6 @@ deleted_tests:
           - name: SPINE
             remote_as:
               peer_type: internal
-            bfd: true
             address_family:
               afis:
                 - afi: ipv4
@@ -144,6 +143,16 @@ deleted_tests:
     state: deleted
     input:
       - bgp_as: "{{bgp_as_1}}"
+        peer_group:
+          - name: SPINE
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 2"
+            timers:
+              keepalive: 40
+              holdtime: 50
+              connect_retry: 60
         neighbors:
           - neighbor: "{{ interface2 }}"
             peer_group: SPINE
@@ -161,6 +170,16 @@ deleted_tests:
             peer_group: SPINE1
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
+        peer_group:
+          - name: SPINE
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 2"
+            timers:
+              keepalive: 40
+              holdtime: 50
+              connect_retry: 60
         neighbors:
           - neighbor: "{{ interface4 }}"
             peer_group: SPINE
@@ -178,6 +197,34 @@ deleted_tests:
             peer_group: SPINE
 
   - name: test_case_del_05
+    description: Delete peer group additional attributes
+    state: deleted
+    input:
+      - bgp_as: "{{bgp_as_1}}"
+        peer_group:
+          - name: SPINE
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+               as: 3
+               no_prepend: false
+               replace_as: false
+            pg_description: "description 2"
+            override_capability: false
+            passive: false
+            solo: false
+          - name: SPINE1
+            disable_connected_check: false
+            shutdown_msg: "msg2"
+            strict_capability_match: false
+            ttl_security: 8
+
+  - name: test_case_del_06
     description: Delete peer group BGP NEIGHBORS properties
     state: deleted
     input:
@@ -190,7 +237,7 @@ deleted_tests:
           - name: SPINE
           - name: SPINE1
 
-  - name: test_case_del_06
+  - name: test_case_del_07
     description: BGP NEIGHBORS remote-as properties
     state: deleted
     input: []
@@ -205,11 +252,15 @@ merged_tests:
           - name: SPINE
             remote_as:
               peer_as: 12
-            bfd: true
+            bfd:
+              enabled: true
+              check_failure: true
+              profile: "profile 1"
             advertisement_interval: 10
             timers:
               keepalive: 40
               holdtime: 50
+              connect_retry: 60
             capability:
               dynamic: true
               extended_nexthop: true
@@ -267,11 +318,15 @@ merged_tests:
           - name: SPINE
             remote_as:
               peer_type: internal
-            bfd: true
+            bfd:
+              enabled: true
+              check_failure: true
+              profile: "profile 1"
             advertisement_interval: 15
             timers:
               keepalive: 50
               holdtime: 40
+              connect_retry: 60
             capability:
               dynamic: true
               extended_nexthop: true
@@ -317,14 +372,22 @@ merged_tests:
       - bgp_as: "{{bgp_as_1}}"
         peer_group:
           - name: SPINE
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 2"
           - name: SPINE1
             remote_as:
               peer_type: external
-            bfd: true
+            bfd:
+              enabled: true
+              check_failure: true
+              profile: "profile 2"
             advertisement_interval: 15
             timers:
               keepalive: 30
               holdtime: 60
+              connect_retry: 90
             capability:
               dynamic: true
               extended_nexthop: true
@@ -368,14 +431,22 @@ merged_tests:
         vrf_name: "{{vrf_1}}"
         peer_group:
           - name: SPINE
+            bfd:
+              enabled: false
+              check_failure: false
+              profile: "profile 2"
           - name: SPINE1
             remote_as:
               peer_type: internal
-            bfd: true
+            bfd:
+              enabled: true
+              check_failure: true
+              profile: "profile 2"
             advertisement_interval: 30
             timers:
               keepalive: 10
               holdtime: 20
+              connect_retry: 30
             capability:
               dynamic: true
               extended_nexthop: true
@@ -531,7 +602,6 @@ merged_tests:
       - bgp_as: "{{bgp_as_1}}"
         peer_group:
           - name: SPINE
-            bfd: true
         neighbors:
           - neighbor: "{{ interface1 }}"
             remote_as:
@@ -564,6 +634,31 @@ merged_tests:
     state: merged
     input:
       - bgp_as: "{{bgp_as_1}}"
+        peer_group:
+          - name: SPINE
+            auth_pwd:
+               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
+               encrypted: true
+            dont_negotiate_capability: true
+            ebgp_multihop:
+               enabled: true
+               multihop_ttl: 1
+            enforce_first_as: true
+            enforce_multihop: true
+            local_address: 'Ethernet4'
+            local_as:
+               as: 2
+               no_prepend: true
+               replace_as: true
+            pg_description: "description 1"
+            override_capability: true
+            passive: true
+            solo: true
+          - name: SPINE1
+            disable_connected_check: true
+            shutdown_msg: "msg1"
+            strict_capability_match: true
+            ttl_security: 5
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
@@ -604,6 +699,28 @@ merged_tests:
     state: merged
     input:
       - bgp_as: "{{bgp_as_1}}"
+        peer_group:
+          - name: SPINE
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+               as: 3
+               no_prepend: false
+               replace_as: false
+            pg_description: "description 2"
+            override_capability: false
+            passive: false
+            solo: false
+          - name: SPINE1
+            disable_connected_check: false
+            shutdown_msg: "msg2"
+            strict_capability_match: false
+            ttl_security: 8
         neighbors:
           - neighbor: "{{ interface1 }}"
             dont_negotiate_capability: false

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -49,13 +49,15 @@ deleted_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
+               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
+               encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
                enabled: false
                multihop_ttl: 2
             enforce_first_as: false
             enforce_multihop: false
-            local_address: 'Ethernet6'
+            local_address: '1::1'
             local_as:
             nbr_description: "description 2"
             override_capability: false
@@ -203,13 +205,16 @@ deleted_tests:
       - bgp_as: "{{bgp_as_1}}"
         peer_group:
           - name: SPINE
+            auth_pwd:
+               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
+               encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
                enabled: false
                multihop_ttl: 2
             enforce_first_as: false
             enforce_multihop: false
-            local_address: 'Ethernet6'
+            local_address: '1.1.1.1'
             local_as:
                as: 3
                no_prepend: false
@@ -707,7 +712,7 @@ merged_tests:
                multihop_ttl: 2
             enforce_first_as: false
             enforce_multihop: false
-            local_address: 'Ethernet6'
+            local_address: '1.1.1.1'
             local_as:
                as: 3
                no_prepend: false
@@ -729,7 +734,7 @@ merged_tests:
                multihop_ttl: 2
             enforce_first_as: false
             enforce_multihop: false
-            local_address: 'Ethernet6'
+            local_address: '1::1'
             local_as:
                as: 3
                no_prepend: false

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -93,13 +93,11 @@ deleted_tests:
     input:
       - bgp_as: "{{bgp_as_1}}"
         neighbors:
-          - neighbor: "{{ interface1 }}"
           - neighbor: 11::11
           - neighbor: 67.1.1.1
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
         neighbors:
-          - neighbor: "{{ interface1 }}"
           - neighbor: 11::11
           - neighbor: 67.1.1.1
 
@@ -139,6 +137,41 @@ deleted_tests:
           - name: SPINE1
 
   - name: test_case_del_05
+    description: Delete BGP NEIGHBORS additional attributes
+    state: deleted
+    input:
+      - bgp_as: "{{bgp_as_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            auth_pwd:
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+            nbr_description: "description 2"
+            override_capability: false
+            passive: false
+            port: 4
+            solo: false
+          - neighbor: 1.1.1.1
+            disable_connected_check: false
+            ttl_security: 8
+      - bgp_as: "{{bgp_as_1}}"
+        vrf_name: "{{vrf_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            auth_pwd:
+               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
+               encrypted: true
+            nbr_description: 'description 3'
+            strict_capability_match: false
+            v6only: false
+
+  - name: test_case_del_06
     description: BGP NEIGHBORS remote-as properties
     state: deleted
     input: []
@@ -551,40 +584,6 @@ merged_tests:
         vrf_name: "{{vrf_1}}"
         neighbors:
           - neighbor: "{{ interface1 }}"
-            nbr_description: 'description 3'
-            strict_capability_match: false
-            v6only: false
-  - name: test_case_08
-    description: Delete BGP NEIGHBORS additional attributes
-    state: deleted
-    input:
-      - bgp_as: "{{bgp_as_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-            dont_negotiate_capability: false
-            ebgp_multihop:
-               enabled: false
-               multihop_ttl: 2
-            enforce_first_as: false
-            enforce_multihop: false
-            local_address: 'Ethernet6'
-            local_as:
-            nbr_description: "description 2"
-            override_capability: false
-            passive: false
-            port: 4
-            solo: false
-          - neighbor: 1.1.1.1
-            disable_connected_check: false
-            ttl_security: 8
-      - bgp_as: "{{bgp_as_1}}"
-        vrf_name: "{{vrf_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
-               encrypted: true
             nbr_description: 'description 3'
             strict_capability_match: false
             v6only: false

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -561,6 +561,9 @@ merged_tests:
       - bgp_as: "{{bgp_as_1}}"
         neighbors:
           - neighbor: "{{ interface1 }}"
+            auth_pwd:
+               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
+               encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
                enabled: false
@@ -584,6 +587,9 @@ merged_tests:
         vrf_name: "{{vrf_1}}"
         neighbors:
           - neighbor: "{{ interface1 }}"
+            auth_pwd:
+               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
+               encrypted: true
             nbr_description: 'description 3'
             strict_capability_match: false
             v6only: false

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -483,7 +483,7 @@ merged_tests:
             remote_as:
                peer_as: 1123
   - name: test_case_06
-    description: BGP NEIGHBORS auth-password and description properties
+    description: BGP NEIGHBORS configure additional attributes
     state: merged
     input:
       - bgp_as: "{{bgp_as_1}}"
@@ -492,26 +492,25 @@ merged_tests:
             auth_pwd:
                pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
                encrypted: true
+            dont_negotiate_capability: true
+            ebgp_multihop:
+               enabled: true
+               multihop_ttl: 1
+            enforce_first_as: true
+            enforce_multihop: true
+            local_address: 'Ethernet4'
+            local_as:
+               as: 2
+               no_prepend: true
+               replace_as: true
             nbr_description: "description 1"
-      - bgp_as: "{{bgp_as_1}}"
-        vrf_name: "{{vrf_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
-               encrypted: true
-            nbr_description: "description 2"
-  - name: test_case_07
-    description: Delete BGP NEIGHBORS auth-password and description properties
-    state: deleted
-    input:
-      - bgp_as: "{{bgp_as_1}}"
-        neighbors:
-          - neighbor: "{{ interface1 }}"
-            auth_pwd:
-               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
-               encrypted: true
-            nbr_description: "description 1"
+            override_capability: true
+            passive: true
+            port: 3
+            solo: true
+          - neighbor: 1.1.1.1
+            disable_connected_check: true
+            ttl_security: 5
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
         neighbors:
@@ -520,3 +519,71 @@ merged_tests:
                pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
                encrypted: true
             nbr_description: 'description 2'
+            strict_capability_match: true
+            v6only: true
+  - name: test_case_07
+    description: BGP NEIGHBORS modify additional attributes
+    state: merged
+    input:
+      - bgp_as: "{{bgp_as_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+               as: 3
+               no_prepend: false
+               replace_as: false
+            nbr_description: "description 2"
+            override_capability: false
+            passive: false
+            port: 4
+            solo: false
+          - neighbor: 1.1.1.1
+            disable_connected_check: false
+            ttl_security: 8
+      - bgp_as: "{{bgp_as_1}}"
+        vrf_name: "{{vrf_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            nbr_description: 'description 3'
+            strict_capability_match: false
+            v6only: false
+  - name: test_case_08
+    description: Delete BGP NEIGHBORS additional attributes
+    state: deleted
+    input:
+      - bgp_as: "{{bgp_as_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            dont_negotiate_capability: false
+            ebgp_multihop:
+               enabled: false
+               multihop_ttl: 2
+            enforce_first_as: false
+            enforce_multihop: false
+            local_address: 'Ethernet6'
+            local_as:
+               as: 3
+               no_prepend: false
+               replace_as: false
+            nbr_description: "description 2"
+            override_capability: false
+            passive: false
+            port: 4
+            solo: false
+          - neighbor: 1.1.1.1
+            disable_connected_check: false
+            ttl_security: 8
+      - bgp_as: "{{bgp_as_1}}"
+        vrf_name: "{{vrf_1}}"
+        neighbors:
+          - neighbor: "{{ interface1 }}"
+            nbr_description: 'description 3'
+            strict_capability_match: false
+            v6only: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added the following OC attributes to the bgp_neighbors module for peer groups:

bfd: check-control-plane-failure, enabled, bfd-profile
disable-ebgp-connected-route-check
dont-negotiate-capability
ebgp-multihop : enabled, multihop-ttl
enforce-first-as
enforce-multihop
local address
local-as
local-as-no-prepend
local-as-replace-as
override-capability
passive-mode
pg-description
shutdown-message
solo-peer
strict-capability-match
timers: connect-retry
ttl-security-hops

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

sonic_bgp_neighbors

##### ADDITIONAL INFORMATION

[show_running_configuration_bgp_pg_output.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8673691/show_running_configuration_bgp_pg_output.txt)

