### PR TITLE
README.md file: Add release mapping information

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Version compatibility
 * Recommended Ansible version 2.10 or higher
 * Enterprise SONiC Distribution by Dell Technologies version 3.1 or higher
 * Recommended Python 3.5 or higher, or Python 2.7
+* Dell Enterprise SONiC images for releases 3.1 - 3.5: Use Ansible Enterprise SONiC collection version 1.1.0 or later 1.m.n versions (from the 1.x branch of this repo).
+* Dell Enterprise SONiC images for release 4.0 and later 4.x.y releases: Use Ansible Enterprise SONiC collection version 2.0.0 or later 2.m.n releases (from the 2.x branch of this repo).
+* In general:  Dell Enterprise SONiC release versions "R.x.y" are supported by Ansible Enterprise SONiC collection versions "R-2.m.n" on branch "R-2.x".
 
 
 > **NOTE**: Community SONiC versions that include the Management Framework container should work as well, however, this collection has not been tested nor validated 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add information on mapping Dell Enterprise SONiC release image versions to the corresponding supporting Ansible Enterprise SONiC collection release versions.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I have received feedback from users that it was difficult to determine from our README file the mapping between Dell Enterprise SONiC release image versions and the corresponding supporting Ansible Enterprise SONiC collection release versions.

This change places the information closer to the top of the README file and provides explicit mapping of versions to make it easier for users to find this information.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
