### PR TITLE
Resolved regression failures against 4.x

### DIFF
--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -49,7 +49,7 @@ deleted_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
+               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
                encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
@@ -73,7 +73,7 @@ deleted_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
+               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
                encrypted: true
             nbr_description: 'description 3'
             strict_capability_match: false
@@ -206,7 +206,7 @@ deleted_tests:
         peer_group:
           - name: SPINE
             auth_pwd:
-               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
+               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
                encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
@@ -642,7 +642,7 @@ merged_tests:
         peer_group:
           - name: SPINE
             auth_pwd:
-               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
+               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
                encrypted: true
             dont_negotiate_capability: true
             ebgp_multihop:
@@ -667,7 +667,7 @@ merged_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M="
+               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
                encrypted: true
             dont_negotiate_capability: true
             ebgp_multihop:
@@ -694,7 +694,7 @@ merged_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg="
+               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
                encrypted: true
             nbr_description: 'description 2'
             strict_capability_match: true

--- a/tests/regression/roles/sonic_system/defaults/main.yml
+++ b/tests/regression/roles/sonic_system/defaults/main.yml
@@ -1,10 +1,6 @@
 ---
 ansible_connection: httpapi
 module_name: system
-delete_all:
-  - name: del_all_test_case_01
-    description: Delete System properties
-    state: deleted
 tests:
   - name: test_case_01
     description: System properties
@@ -42,3 +38,8 @@ tests:
     input:
       anycast_address:
         mac_address: 00:09:5B:EC:EE:F2
+
+test_delete_all:
+  - name: del_all_test_case_01
+    description: Delete System properties
+    state: deleted

--- a/tests/regression/roles/sonic_system/tasks/main.yml
+++ b/tests/regression/roles/sonic_system/tasks/main.yml
@@ -1,13 +1,16 @@
 - debug: msg="sonic_system Test started ..."
 
-- name: "delete_all {{ module_name }} stated ..."
-  include_tasks: tasks_template_del.yaml
-  loop: "{{ delete_all }}"
-  when: delete_all is defined
+- name: Preparation Tests
+  include_tasks: preparation_tests.yaml
 
 - name: "Test {{ module_name }} started ..."
   include_tasks: tasks_template.yaml
   loop: "{{ tests }}"
+
+- name: "test_delete_all {{ module_name }} stated ..."
+  include_tasks: tasks_template_del.yaml
+  loop: "{{ test_delete_all }}"
+  when: test_delete_all is defined
 
 - name: "Cleanup test  {{ module_name }} started"
   include_tasks: cleanup_tests.yaml

--- a/tests/regression/roles/sonic_system/tasks/preparation_tests.yaml
+++ b/tests/regression/roles/sonic_system/tasks/preparation_tests.yaml
@@ -1,0 +1,5 @@
+- name: Deletes system configurations
+  sonic_system:
+    config: {}
+    state: deleted
+  ignore_errors: yes

--- a/tests/regression/roles/sonic_vxlan/defaults/main.yml
+++ b/tests/regression/roles/sonic_vxlan/defaults/main.yml
@@ -92,7 +92,7 @@ tests:
           - vni: 102
             vrf: "{{vrf2}}"
   - name: del_test_case_06
-    description: Update VRF properties
+    description: Delete VRF properties
     state: deleted
     input:
       - name: vtep1
@@ -106,20 +106,13 @@ tests:
           - vni: 102
             vrf: "{{vrf2}}"
   - name: del_test_case_07
-    description: Update VRF properties
+    description: Delete VRF properties
     state: deleted
     input:
       - name: vtep1
         vlan_map: []
         vrf_map: []
   - name: del_test_case_08
-    description: Update VRF properties
-    state: deleted
-    input:
-      - name: vtep1
-        source_ip: 1.1.1.1
-        evpn_nvo: nvo5
-  - name: del_test_case_09
-    description: Update VRF properties
+    description: Delete VRF properties
     state: deleted
     input: []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolved regression failures for:
- sonic_bgp_neighbors: I updated the pwd value due to encryption/decryption method changes.
- sonic_system: The initial delete all test case failed because there was nothing to delete so I added preparation tests and moved the delete all test case to the end of the playbook.
- sonic_vxlan: The test case failed because specified attributes were already deleted in the previous test case so I removed repetitive delete test case.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_bgp_neighbors, sonic_system, sonic_vxlan
##### ADDITIONAL INFORMATION
[regression-2022-05-20-16-39-11.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8745801/regression-2022-05-20-16-39-11.html.pdf)
[vxlan_output.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8745806/vxlan_output.log)
[system_output.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8745808/system_output.log)


```
