### PR TITLE
Create release 1.1.1 changelog and other Ansible release artifacts

### DIFF
--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -1,0 +1,155 @@
+objects:
+  role: {}
+plugins:
+  become: {}
+  cache: {}
+  callback: {}
+  cliconf:
+    sonic:
+      description: Use sonic cliconf to run command on Dell OS10 platform
+      name: sonic
+      version_added: null
+  connection: {}
+  httpapi:
+    sonic:
+      description: HttpApi Plugin for devices supporting Restconf SONIC API
+      name: sonic
+      version_added: 1.0.0
+  inventory: {}
+  lookup: {}
+  module:
+    sonic_aaa:
+      description: Manage AAA and its parameters
+      name: sonic_aaa
+      namespace: ''
+      version_added: 1.1.0
+    sonic_api:
+      description: Manages REST operations on devices running Enterprise SONiC
+      name: sonic_api
+      namespace: ''
+      version_added: 1.0.0
+    sonic_bgp:
+      description: Manage global BGP and its parameters
+      name: sonic_bgp
+      namespace: ''
+      version_added: 1.0.0
+    sonic_bgp_af:
+      description: Manage global BGP address-family and its parameters
+      name: sonic_bgp_af
+      namespace: ''
+      version_added: 1.0.0
+    sonic_bgp_as_paths:
+      description: Manage BGP autonomous system path (or as-path-list) and its parameters
+      name: sonic_bgp_as_paths
+      namespace: ''
+      version_added: 1.0.0
+    sonic_bgp_communities:
+      description: Manage BGP community and its parameters
+      name: sonic_bgp_communities
+      namespace: ''
+      version_added: 1.0.0
+    sonic_bgp_ext_communities:
+      description: Manage BGP extended community-list and its parameters
+      name: sonic_bgp_ext_communities
+      namespace: ''
+      version_added: 1.0.0
+    sonic_bgp_neighbors:
+      description: Manage a BGP neighbor and its parameters
+      name: sonic_bgp_neighbors
+      namespace: ''
+      version_added: 1.0.0
+    sonic_bgp_neighbors_af:
+      description: Manage the BGP neighbor address-family and its parameters
+      name: sonic_bgp_neighbors_af
+      namespace: ''
+      version_added: 1.0.0
+    sonic_command:
+      description: Runs commands on devices running Enterprise SONiC
+      name: sonic_command
+      namespace: ''
+      version_added: 1.0.0
+    sonic_config:
+      description: Manages configuration sections on devices running Enterprise SONiC
+      name: sonic_config
+      namespace: ''
+      version_added: 1.0.0
+    sonic_facts:
+      description: Collects facts on devices running Enterprise SONiC
+      name: sonic_facts
+      namespace: ''
+      version_added: 1.0.0
+    sonic_interfaces:
+      description: Configure Interface attributes on interfaces such as, Eth, LAG,
+        VLAN, and loopback. (create a loopback interface if it does not exist.)
+      name: sonic_interfaces
+      namespace: ''
+      version_added: 1.0.0
+    sonic_l2_interfaces:
+      description: Configure interface-to-VLAN association that is based on access
+        or trunk mode
+      name: sonic_l2_interfaces
+      namespace: ''
+      version_added: 1.0.0
+    sonic_l3_interfaces:
+      description: Configure the IPv4 and IPv6 parameters on Interfaces such as, Eth,
+        LAG, VLAN, and loopback
+      name: sonic_l3_interfaces
+      namespace: ''
+      version_added: 1.0.0
+    sonic_lag_interfaces:
+      description: Manage link aggregation group (LAG) interface parameters
+      name: sonic_lag_interfaces
+      namespace: ''
+      version_added: 1.0.0
+    sonic_mclag:
+      description: Manage multi chassis link aggregation groups domain (MCLAG) and
+        its parameters
+      name: sonic_mclag
+      namespace: ''
+      version_added: 1.0.0
+    sonic_port_breakout:
+      description: Configure port breakout settings on physical interfaces
+      name: sonic_port_breakout
+      namespace: ''
+      version_added: 1.0.0
+    sonic_radius_server:
+      description: Manage RADIUS server and its parameters
+      name: sonic_radius_server
+      namespace: ''
+      version_added: 1.0.0
+    sonic_system:
+      description: Configure system parameters
+      name: sonic_system
+      namespace: ''
+      version_added: 1.0.0
+    sonic_tacacs_server:
+      description: Manage TACACS server and its parameters
+      name: sonic_tacacs_server
+      namespace: ''
+      version_added: 1.1.0
+    sonic_users:
+      description: Manage users and its parameters
+      name: sonic_users
+      namespace: ''
+      version_added: 1.1.0
+    sonic_vlans:
+      description: Manage VLAN and its parameters
+      name: sonic_vlans
+      namespace: ''
+      version_added: 1.0.0
+    sonic_vrfs:
+      description: Manage VRFs and associate VRFs to interfaces such as, Eth, LAG,
+        VLAN, and loopback
+      name: sonic_vrfs
+      namespace: ''
+      version_added: 1.0.0
+    sonic_vxlans:
+      description: Manage VxLAN EVPN and its parameters
+      name: sonic_vxlans
+      namespace: ''
+      version_added: 1.0.0
+  netconf: {}
+  shell: {}
+  strategy: {}
+  vars: {}
+version: 1.1.1

--- a/changelogs/CHANGELOG.rst
+++ b/changelogs/CHANGELOG.rst
@@ -1,8 +1,56 @@
-=================================================================================
-Ansible Network Collection for Enterprise SONiC Distribution by Dell Technologies
-=================================================================================
+===============================================================================================
+Ansible Network Collection for Enterprise SONiC Distribution by Dell Technologies Release Notes
+===============================================================================================
 
 .. contents:: Topics
+
+
+v1.1.1
+======
+
+Release Summary
+---------------
+
+This is a minor enhancement and bugfix release for the ``dellemc.enterprise_sonic``
+collection on 2020-06-02. The changelog describes changes made to the modules
+and plugins included in this collection since release 1.1.0.
+
+
+Minor Changes
+-------------
+
+- README - describe branch naming conventions for the "main" and "1.x" branches (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/54).
+- README - describe the mapping of SONiC release versions to the corresponding branch and release names in the Dell SONiC Enterprise Ansible collection. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/84).
+- bgp_as_paths - Add a 'permit/deny' attribute (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+- bgp_neighbors - add 'password' and 'description' attributes (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/69).
+- meta - add the newly required execution_environment.yml file to the 'meta' directory (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/89).
+- port_breakout - modify port numbers to match commonly available breakout ports (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/89).
+- workflows - add stable-2.12 to the CI test matrix (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/51).
+- workflows - add stable-2.13 to the CI test matrix (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/91).
+
+Bugfixes
+--------
+
+- Fixes incorrect grouping of parameters to be used for invocation of the "send_command" API for sending commands to a device. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/71).
+- aaa - fix a logic mistake in validating authentication data (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+- aaa - modify a 'delete' test case to eliminate a subsequent idempotency failure for a 'merge' test case restoring the deleted attribute. The attribute that was being used for the test case had a non-idempotent effect in the SONiC switch functional code. This did not allow verification of the correct idempotency logic in the Ansible handling of the attribute 'delete' and 'restore' functionality. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/80).
+- bgp - removed unnecessary brackets in a configuration handling instruction (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+- bgp_neighbors - add a 'maxsplit' value in facts handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+- bgp_neighbors - removed unnecessary brackets in configuration handling instructions (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+- radius_server - add a missing 'get' in configuration handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+- system - delete an initial test case requiring 'changed' state for deletion of final configuration attributes assuming 'leftover' configuration from previous execution. Replace this initial test case with cleanup of any residual state with no assumption of leftover residual state. Do the final deletion of configuration at the end of the test instead of at the beginning to retain verification that the deletion works correctly (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/87).
+- tacacs_server - correct an argument spelling error in facts handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+
+v1.1.0
+======
+
+New Modules
+-----------
+
+- sonic_aaa - AAA resource module.
+- sonic_radius_server - RADIUS resource module.
+- sonic_system - SYSTEM resource module.
+- sonic_tacacs_server - TACACS Server resource module.
 
 v1.0.0
 ======
@@ -10,41 +58,36 @@ v1.0.0
 New Plugins
 -----------
 
-CLICONF
+Cliconf
 ~~~~~~~
 
 - sonic - Use Ansible CLICONF to run commands on Enterprise SONiC.
 
-HTTPAPI
+Httpapi
 ~~~~~~~
 
 - sonic - Use Ansible HTTPAPI to run commands on Enterprise SONiC.
 
-
 New Modules
 -----------
 
+- sonic_api - Perform REST operations through the Management Framework REST API.
+- sonic_bgp - BGP resource module.
+- sonic_bgp_af - BGP AF resource module.
+- sonic_bgp_as_paths - BGP AS path resource module.
+- sonic_bgp_communities - BGP communities resource module.
+- sonic_bgp_ext_communities - BGP Ext communities resource module.
+- sonic_bgp_neighbors - BGP neighbors resource module.
+- sonic_bgp_neighbors_af - BGP neighbors AF resource module.
 - sonic_command - Run commands through Management Framework CLI.
 - sonic_config - Manage configuration through the Management Framework CLI.
-- sonic_api - Perform REST operations through the Management Framework REST API.
-
-New Resource modules
---------------------
-
-- sonic_interfaces - Interface resource module
-- sonic_l2_interfaces - Layer 2 interface resource module
-- sonic_l3_interfaces - Layer 3 interface resource module
-- sonic_lag_interfaces - Link aggregation (LAG) resource module
-- sonic_vlans - VLAN resource module
-- sonic_bgp - BGP configuration
-- sonic_bgp_af - BGP AF configuration
-- sonic_bgp_neighbors - BGP neighbors configuration
-- sonic_bgp_neighbors_af - BGP neighbors AF configuration
-- sonic_bgp_as_paths - BGP AS path configuration
-- sonic_bgp_communities - BGP communities configuration
-- sonic_bgp_ext_communities - BGP Ext communities configuration
-- sonic_mclag - MLAG configuration
-- sonic_vrfs - VRF configuration
-- sonic_vxlan - VxLAN EVPN configuration
-
-(c) 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+- sonic_interfaces - Interface resource module.
+- sonic_l2_interfaces - Layer 2 interface resource module.
+- sonic_l3_interfaces - Layer 3 interface resource module.
+- sonic_lag_interfaces - Link aggregation (LAG) resource module.
+- sonic_mclag - MCLAG resource module.
+- sonic_port_breakout - port breakout resource module.
+- sonic_users - USERS resource module.
+- sonic_vlans - VLAN resource module.
+- sonic_vrfs - VRF resource module.
+- sonic_vxlans - VxLAN EVPN resource module.

--- a/changelogs/archive_fragments/1.1.1/1.1.1.yaml
+++ b/changelogs/archive_fragments/1.1.1/1.1.1.yaml
@@ -1,0 +1,4 @@
+release_summary: |
+  This is a minor enhancement and bugfix release for the ``dellemc.enterprise_sonic``
+  collection on 2020-06-02. The changelog describes changes made to the modules
+  and plugins included in this collection since release 1.1.0.

--- a/changelogs/archive_fragments/1.1.1/51-add-stable-2.12-to-CI-test-matrix.yaml
+++ b/changelogs/archive_fragments/1.1.1/51-add-stable-2.12-to-CI-test-matrix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - workflows - add stable-2.12 to the CI test matrix (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/51).

--- a/changelogs/archive_fragments/1.1.1/52-bgp-as_path-attributes-and-radius-tacacs-auth-fixes.yaml
+++ b/changelogs/archive_fragments/1.1.1/52-bgp-as_path-attributes-and-radius-tacacs-auth-fixes.yaml
@@ -1,0 +1,9 @@
+minor_changes:
+  - bgp_as_paths - Add a 'permit/deny' attribute (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+bugfixes:
+  - aaa - fix a logic mistake in validating authentication data (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+  - bgp - removed unnecessary brackets in a configuration handling instruction (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+  - bgp_neighbors - removed unnecessary brackets in configuration handling instructions (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+  - radius_server - add a missing 'get' in configuration handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+  - bgp_neighbors - add a 'maxsplit' value in facts handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+  - tacacs_server - correct an argument spelling error in facts handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).

--- a/changelogs/archive_fragments/1.1.1/54-README-branch-naming.yaml
+++ b/changelogs/archive_fragments/1.1.1/54-README-branch-naming.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - README - describe branch naming conventions for the "main" and "1.x" branches (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/54).

--- a/changelogs/archive_fragments/1.1.1/69-bgp-neighbors-password-and-description.yaml
+++ b/changelogs/archive_fragments/1.1.1/69-bgp-neighbors-password-and-description.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - bgp_neighbors - add 'password' and 'description' attributes (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/69).

--- a/changelogs/archive_fragments/1.1.1/71-cli-prompt-answer-handling.yaml
+++ b/changelogs/archive_fragments/1.1.1/71-cli-prompt-answer-handling.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fixes incorrect grouping of parameters to be used for invocation of the "send_command" API for sending
+    commands to a device. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/71).

--- a/changelogs/archive_fragments/1.1.1/80-aaa-regression-test-fix.yaml
+++ b/changelogs/archive_fragments/1.1.1/80-aaa-regression-test-fix.yaml
@@ -1,0 +1,7 @@
+bugfixes:
+  - aaa - modify a 'delete' test case to eliminate a subsequent idempotency failure
+    for a 'merge' test case restoring the deleted attribute. The attribute that was
+    being used for the test case had a non-idempotent effect in the SONiC switch
+    functional code. This did not allow verification of the correct idempotency
+    logic in the Ansible handling of the attribute 'delete' and 'restore'
+    functionality. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/80).

--- a/changelogs/archive_fragments/1.1.1/84-README-mapping-SONiC-releases-to-ansible-branches.yaml
+++ b/changelogs/archive_fragments/1.1.1/84-README-mapping-SONiC-releases-to-ansible-branches.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - README - describe the mapping of SONiC release versions to the corresponding
+    branch and release names in the Dell SONiC Enterprise
+    Ansible collection. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/84).

--- a/changelogs/archive_fragments/1.1.1/87-system-regression-test-fix.yaml
+++ b/changelogs/archive_fragments/1.1.1/87-system-regression-test-fix.yaml
@@ -1,0 +1,7 @@
+bugfixes:
+  - system - delete an initial test case requiring 'changed' state for deletion
+    of final configuration attributes assuming 'leftover' configuration from
+    previous execution. Replace this initial test case with cleanup of any
+    residual state with no assumption of leftover residual state. Do the final
+    deletion of configuration at the end of the test instead of at the beginning
+    to retain verification that the deletion works correctly (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/87).

--- a/changelogs/archive_fragments/1.1.1/89-execution-environment.yaml
+++ b/changelogs/archive_fragments/1.1.1/89-execution-environment.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - meta - add the newly required execution_environment.yml file to the 'meta'
+    directory (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/89).
+  - port_breakout - modify port numbers to match commonly available breakout ports (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/89).

--- a/changelogs/archive_fragments/1.1.1/91-add-stable-2.13-to-CI-test-matrix.yaml
+++ b/changelogs/archive_fragments/1.1.1/91-add-stable-2.13-to-CI-test-matrix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - workflows - add stable-2.13 to the CI test matrix (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/91).

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,18 +1,36 @@
 ancestor: null
 releases:
   1.0.0:
-    release_summary: This collection includes Ansible core modules, network resource modules, 
-          and plugins needed to provision and manage Dell EMC PowerSwitch platforms running 
-          Enterprise SONiC Distribution by Dell Technologies 
     modules:
+    - description: Perform REST operations through the Management Framework REST API.
+      name: sonic_api
+      namespace: ''
+    - description: BGP resource module.
+      name: sonic_bgp
+      namespace: ''
+    - description: BGP AF resource module.
+      name: sonic_bgp_af
+      namespace: ''
+    - description: BGP AS path resource module.
+      name: sonic_bgp_as_paths
+      namespace: ''
+    - description: BGP communities resource module.
+      name: sonic_bgp_communities
+      namespace: ''
+    - description: BGP Ext communities resource module.
+      name: sonic_bgp_ext_communities
+      namespace: ''
+    - description: BGP neighbors resource module.
+      name: sonic_bgp_neighbors
+      namespace: ''
+    - description: BGP neighbors AF resource module.
+      name: sonic_bgp_neighbors_af
+      namespace: ''
     - description: Run commands through Management Framework CLI.
       name: sonic_command
       namespace: ''
-    - description:  Manage configuration through the Management Framework CLI.
+    - description: Manage configuration through the Management Framework CLI.
       name: sonic_config
-      namespace: ''
-    - description: Perform REST operations through the Management Framework REST API.
-      name: sonic_api
       namespace: ''
     - description: Interface resource module.
       name: sonic_interfaces
@@ -26,44 +44,23 @@ releases:
     - description: Link aggregation (LAG) resource module.
       name: sonic_lag_interfaces
       namespace: ''
-    - description: VLAN resource module.
-      name: sonic_vlans
-      namespace: ''
-    - description: BGP resource module.
-      name: sonic_bgp
-      namespace: ''
-    - description: BGP AF resource module.
-      name: sonic_bgp_af
-      namespace: ''
-    - description: BGP neighbors resource module.
-      name: sonic_bgp_neighbors
-      namespace: ''
-    - description: BGP neighbors AF resource module.
-      name: sonic_bgp_neighbors_af
-      namespace: ''
-    - description: BGP AS path resource module.
-      name: sonic_bgp_as_paths
-      namespace: ''
-    - description: BGP communities resource module.
-      name: sonic_bgp_communities
-      namespace: ''
-    - description: BGP Ext communities resource module.
-      name: sonic_bgp_ext_communities
-      namespace: ''
-    - description: VxLAN EVPN resource module.
-      name: sonic_vxlans
-      namespace: ''
     - description: MCLAG resource module.
       name: sonic_mclag
-      namespace: ''
-    - description: USERS resource module.
-      name: sonic_users
       namespace: ''
     - description: port breakout resource module.
       name: sonic_port_breakout
       namespace: ''
+    - description: USERS resource module.
+      name: sonic_users
+      namespace: ''
+    - description: VLAN resource module.
+      name: sonic_vlans
+      namespace: ''
     - description: VRF resource module.
       name: sonic_vrfs
+      namespace: ''
+    - description: VxLAN EVPN resource module.
+      name: sonic_vxlans
       namespace: ''
     plugins:
       cliconf:
@@ -74,22 +71,78 @@ releases:
       - description: Use Ansible HTTPAPI to run commands on Enterprise SONiC.
         name: sonic
         namespace: null
-    release_date: '2020-12-07'    
+    release_date: '2020-12-07'
   1.1.0:
-    release_summary: Supports AAA, Users, System and Port breakout 
-          resource modules    
     modules:
-    - description: TACACS Server resource module.
-      name: sonic_tacacs_server
+    - description: AAA resource module.
+      name: sonic_aaa
       namespace: ''
     - description: RADIUS resource module.
       name: sonic_radius_server
       namespace: ''
-    - description: AAA resource module.
-      name: sonic_aaa
-      namespace: ''
     - description: SYSTEM resource module.
       name: sonic_system
       namespace: ''
+    - description: TACACS Server resource module.
+      name: sonic_tacacs_server
+      namespace: ''
     release_date: '2021-05-28'
-        
+  1.1.1:
+    changes:
+      bugfixes:
+      - Fixes incorrect grouping of parameters to be used for invocation of the "send_command"
+        API for sending commands to a device. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/71).
+      - aaa - fix a logic mistake in validating authentication data (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+      - aaa - modify a 'delete' test case to eliminate a subsequent idempotency failure
+        for a 'merge' test case restoring the deleted attribute. The attribute that
+        was being used for the test case had a non-idempotent effect in the SONiC
+        switch functional code. This did not allow verification of the correct idempotency
+        logic in the Ansible handling of the attribute 'delete' and 'restore' functionality.
+        (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/80).
+      - bgp - removed unnecessary brackets in a configuration handling instruction
+        (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+      - bgp_neighbors - add a 'maxsplit' value in facts handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+      - bgp_neighbors - removed unnecessary brackets in configuration handling instructions
+        (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+      - radius_server - add a missing 'get' in configuration handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+      - system - delete an initial test case requiring 'changed' state for deletion
+        of final configuration attributes assuming 'leftover' configuration from previous
+        execution. Replace this initial test case with cleanup of any residual state
+        with no assumption of leftover residual state. Do the final deletion of configuration
+        at the end of the test instead of at the beginning to retain verification
+        that the deletion works correctly (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/87).
+      - tacacs_server - correct an argument spelling error in facts handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+      minor_changes:
+      - README - describe branch naming conventions for the "main" and "1.x" branches
+        (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/54).
+      - README - describe the mapping of SONiC release versions to the corresponding
+        branch and release names in the Dell SONiC Enterprise Ansible collection.
+        (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/84).
+      - bgp_as_paths - Add a 'permit/deny' attribute (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/52).
+      - bgp_neighbors - add 'password' and 'description' attributes (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/69).
+      - meta - add the newly required execution_environment.yml file to the 'meta'
+        directory (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/89).
+      - port_breakout - modify port numbers to match commonly available breakout ports
+        (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/89).
+      - workflows - add stable-2.12 to the CI test matrix (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/51).
+      - workflows - add stable-2.13 to the CI test matrix (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/91).
+      release_summary: 'This is a minor enhancement and bugfix release for the ``dellemc.enterprise_sonic``
+
+        collection on 2020-06-02. The changelog describes changes made to the modules
+
+        and plugins included in this collection since release 1.1.0.
+
+        '
+    fragments:
+    - 1.1.1.yaml
+    - 51-add-stable-2.12-to-CI-test-matrix.yaml
+    - 52-bgp-as_path-attributes-and-radius-tacacs-auth-fixes.yaml
+    - 54-README-branch-naming.yaml
+    - 69-bgp-neighbors-password-and-description.yaml
+    - 71-cli-prompt-answer-handling.yaml
+    - 80-aaa-regression-test-fix.yaml
+    - 84-README-mapping-SONiC-releases-to-ansible-branches.yaml
+    - 87-system-regression-test-fix.yaml
+    - 89-execution-environment.yaml
+    - 91-add-stable-2.13-to-CI-test-matrix.yaml
+    release_date: '2020-06-02'

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -3,6 +3,7 @@ changelog_filename_version_depth: 0
 changes_file: changelog.yaml
 changes_format: combined
 keep_fragments: false
+archive_path_template: changelogs/archive_fragments/{version}
 mention_ancestor: true
 new_plugins_after_name: removed_features
 notesdir: fragments

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: dellemc
 name: enterprise_sonic
-version: 1.1.0
+version: 1.1.1
 readme: README.md
 authors:
 - Senthil Kumar Ganesan <Senthil_Kumar_Ganesa@Dell.com>
@@ -8,6 +8,8 @@ authors:
 - Dhivya <Dhivya_P@Dell.com>
 - Mohamed Javeed <Mohamed_Javeed_Faroo@Dell.com>
 - Nirai Madai <Niraimadaiselvam_Mar@Dell.com>
+- Shade Talabi <Shade_Talabi@Dell.com>
+- Kerry Meyer <Kerry_Meyer@Dell.com>
  
 description: Ansible Network Collection for Enterprise SONiC Distribution by Dell Technologies
 license_file: LICENSE


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change set contains the archive source fragments used for generating
the Ansible release changelog, the generated changelog, and other
files generated by the antsibull-changelog tool for the release.

The galaxy.yml file and the changelogs/config.yaml file have also
been updated to specify the new galaxy version information, to add
new authors for the Dell SONiC Enterprise Ansible collection and to save
changelog fragments in an archive folder.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Test Results for the current 1.x branch (content to be released)

[1.1.1_release_all_modules_regression-2022-06-02-20-40-53.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8829565/1.1.1_release_all_modules_regression-2022-06-02-20-40-53.pdf)

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below


```
