### PR TITLE
Added support for interface standard naming and port breakout mode in sonic_l2_interfaces

### DIFF
--- a/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
@@ -252,7 +252,7 @@ class L2_interfaces(ConfigBase):
 
     def get_trunk_delete_switchport_request(self, config, match_config):
         method = "DELETE"
-        name = config['name']
+        name = config['name'].replace('/','%2F')
         requests = []
         match_trunk = match_config.get('trunk')
         if match_trunk:
@@ -273,7 +273,7 @@ class L2_interfaces(ConfigBase):
     def get_access_delete_switchport_request(self, config, match_config):
         method = "DELETE"
         request = None
-        name = config['name']
+        name = config['name'].replace('/','%2F')
         match_access = match_config.get('access')
         if match_access and match_access.get('vlan') == config['access'].get('vlan'):
             key = intf_key
@@ -291,7 +291,7 @@ class L2_interfaces(ConfigBase):
         url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config"
         method = "DELETE"
         for intf in configs:
-            name = intf.get("name")
+            name = intf.get("name").replace('/','%2F')
             key = intf_key
             if name.startswith('PortChannel'):
                 key = port_chnl_key
@@ -371,7 +371,7 @@ class L2_interfaces(ConfigBase):
         url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config"
         method = "PATCH"
         for conf in configs:
-            name = conf.get('name')
+            name = conf.get('name').replace('/','%2F')
             if name == "eth0":
                 continue
             key = intf_key

--- a/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
@@ -252,7 +252,7 @@ class L2_interfaces(ConfigBase):
 
     def get_trunk_delete_switchport_request(self, config, match_config):
         method = "DELETE"
-        name = config['name'].replace('/','%2F')
+        name = config['name'].replace('/', '%2F')
         requests = []
         match_trunk = match_config.get('trunk')
         if match_trunk:
@@ -273,7 +273,7 @@ class L2_interfaces(ConfigBase):
     def get_access_delete_switchport_request(self, config, match_config):
         method = "DELETE"
         request = None
-        name = config['name'].replace('/','%2F')
+        name = config['name'].replace('/', '%2F')
         match_access = match_config.get('access')
         if match_access and match_access.get('vlan') == config['access'].get('vlan'):
             key = intf_key
@@ -291,7 +291,7 @@ class L2_interfaces(ConfigBase):
         url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config"
         method = "DELETE"
         for intf in configs:
-            name = intf.get("name").replace('/','%2F')
+            name = intf.get("name").replace('/', '%2F')
             key = intf_key
             if name.startswith('PortChannel'):
                 key = port_chnl_key
@@ -371,7 +371,7 @@ class L2_interfaces(ConfigBase):
         url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config"
         method = "PATCH"
         for conf in configs:
-            name = conf.get('name').replace('/','%2F')
+            name = conf.get('name').replace('/', '%2F')
             if name == "eth0":
                 continue
             key = intf_key


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added support for configuration of interfaces in standard naming mode.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #94 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_l2_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
[l2_interfaces_output.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8971803/l2_interfaces_output.log)
[regression-2022-06-23-15-31-07.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/8971806/regression-2022-06-23-15-31-07.html.pdf)
