### PR TITLE
Addressed multiple bugs and updated test cases

### DIFF
--- a/plugins/action/sonic.py
+++ b/plugins/action/sonic.py
@@ -36,8 +36,7 @@ version_added: 1.0.0
 
 class ActionModule(ActionNetworkModule):
 
-    def run(self, tmp=None, task_vars=None):
-        del tmp  # tmp no longer has any effect
+    def run(self, task_vars=None):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'sonic_config' else False

--- a/plugins/module_utils/network/sonic/config/bgp/bgp.py
+++ b/plugins/module_utils/network/sonic/config/bgp/bgp.py
@@ -195,7 +195,7 @@ class Bgp(ConfigBase):
 
     def get_delete_single_bgp_request(self, vrf_name):
         delete_path = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
-        return({'path': delete_path, 'method': DELETE})
+        return ({'path': delete_path, 'method': DELETE})
 
     def get_delete_max_med_requests(self, vrf_name, max_med, match):
         requests = []

--- a/plugins/module_utils/network/sonic/config/bgp_af/bgp_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_af/bgp_af.py
@@ -206,7 +206,7 @@ class Bgp_af(ConfigBase):
         afi_safis_load = {'afi-safis': {'afi-safi': [afi_safi_load]}}
         pay_load = {'openconfig-network-instance:global': afi_safis_load}
 
-        return({"path": url, "method": PATCH, "data": pay_load})
+        return ({"path": url, "method": PATCH, "data": pay_load})
 
     def get_modify_advertise_request(self, vrf_name, conf_afi, conf_safi, conf_addr_fam):
         request = None
@@ -505,14 +505,14 @@ class Bgp_af(ConfigBase):
         url = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
         url += '/%s=%s/%s/%s' % (self.afi_safi_path, afi_safi, self.l2vpn_evpn_config_path, attr)
 
-        return({"path": url, "method": DELETE})
+        return ({"path": url, "method": DELETE})
 
     def get_delete_route_advertise_request(self, vrf_name, conf_afi, conf_safi):
         afi_safi = ('%s_%s' % (conf_afi, conf_safi)).upper()
         url = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
         url += '/%s=%s/%s' % (self.afi_safi_path, afi_safi, self.l2vpn_evpn_route_advertise_path)
 
-        return({'path': url, 'method': DELETE})
+        return ({'path': url, 'method': DELETE})
 
     def get_delete_route_advertise_list_request(self, vrf_name, conf_afi, conf_safi, advertise_afi):
         afi_safi = ('%s_%s' % (conf_afi, conf_safi)).upper()
@@ -520,7 +520,7 @@ class Bgp_af(ConfigBase):
         url = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
         url += '/%s=%s/%s/route-advertise-list=%s' % (self.afi_safi_path, afi_safi, self.l2vpn_evpn_route_advertise_path, advertise_afi_safi)
 
-        return({'path': url, 'method': DELETE})
+        return ({'path': url, 'method': DELETE})
 
     def get_delete_route_advertise_route_map_request(self, vrf_name, conf_afi, conf_safi, advertise_afi, route_map):
         afi_safi = ('%s_%s' % (conf_afi, conf_safi)).upper()
@@ -529,7 +529,7 @@ class Bgp_af(ConfigBase):
         url += '/%s=%s/%s/route-advertise-list=%s' % (self.afi_safi_path, afi_safi, self.l2vpn_evpn_route_advertise_path, advertise_afi_safi)
         url += '/config/route-map=%s' % route_map
 
-        return({'path': url, 'method': DELETE})
+        return ({'path': url, 'method': DELETE})
 
     def get_delete_route_advertise_requests(self, commands, have, is_delete_all):
         requests = []
@@ -583,7 +583,7 @@ class Bgp_af(ConfigBase):
         url = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
         url += '/%s=%s/route-flap-damping/config/enabled' % (self.afi_safi_path, afi_safi)
 
-        return({"path": url, "method": DELETE})
+        return ({"path": url, "method": DELETE})
 
     def get_delete_address_family_request(self, vrf_name, conf_afi, conf_safi):
         request = None
@@ -777,7 +777,7 @@ class Bgp_af(ConfigBase):
         dst_protocol = "openconfig-policy-types:BGP"
         url = '%s=%s/%s=' % (self.network_instance_path, vrf_name, self.table_connection_path)
         url += '%s,%s,%s/config/import-policy=%s' % (src_protocol, dst_protocol, addr_family, conf_route_map)
-        return({'path': url, 'method': DELETE})
+        return ({'path': url, 'method': DELETE})
 
     def get_delete_redistribute_requests(self, vrf_name, conf_afi, conf_safi, conf_redis_arr, is_delete_all, mat_redis_arr):
         requests = []

--- a/plugins/module_utils/network/sonic/config/bgp_communities/bgp_communities.py
+++ b/plugins/module_utils/network/sonic/config/bgp_communities/bgp_communities.py
@@ -337,7 +337,7 @@ class Bgp_communities(ConfigBase):
                                     ]
                                 }
                             }"""
-        env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+        env = jinja2.Environment(autoescape=False)
         t = env.from_string(payload_template)
         intended_payload = t.render(input_data)
         ret_payload = json.loads(intended_payload)

--- a/plugins/module_utils/network/sonic/config/bgp_ext_communities/bgp_ext_communities.py
+++ b/plugins/module_utils/network/sonic/config/bgp_ext_communities/bgp_ext_communities.py
@@ -328,7 +328,7 @@ class Bgp_ext_communities(ConfigBase):
                                     ]
                                 }
                             }"""
-        env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+        env = jinja2.Environment(autoescape=False)
         t = env.from_string(payload_template)
         intended_payload = t.render(input_data)
         ret_payload = json.loads(intended_payload)

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -924,7 +924,7 @@ class Bgp_neighbors(ConfigBase):
     def delete_neighbor_whole_request(self, vrf_name, neighbor):
         requests = []
         url = '%s=%s/%s/%s=%s/' % (self.network_instance_path, vrf_name, self.protocol_bgp_path, self.neighbor_path, neighbor)
-        return({'path': url, 'method': DELETE})
+        return ({'path': url, 'method': DELETE})
 
     def delete_specific_param_request(self, vrf_name, cmd):
         requests = []

--- a/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
@@ -224,7 +224,6 @@ class L2_interfaces(ConfigBase):
         requests = self.get_create_l2_interface_request(commands)
         if commands and len(requests):
             commands = update_states(commands, "merged")
-
         return commands, requests
 
     def _state_deleted(self, want, have, diff):
@@ -252,7 +251,7 @@ class L2_interfaces(ConfigBase):
 
     def get_trunk_delete_switchport_request(self, config, match_config):
         method = "DELETE"
-        name = config['name'].replace('/', '%2F')
+        name = config['name']
         requests = []
         match_trunk = match_config.get('trunk')
         if match_trunk:
@@ -273,7 +272,7 @@ class L2_interfaces(ConfigBase):
     def get_access_delete_switchport_request(self, config, match_config):
         method = "DELETE"
         request = None
-        name = config['name'].replace('/', '%2F')
+        name = config['name']
         match_access = match_config.get('access')
         if match_access and match_access.get('vlan') == config['access'].get('vlan'):
             key = intf_key
@@ -291,7 +290,7 @@ class L2_interfaces(ConfigBase):
         url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config"
         method = "DELETE"
         for intf in configs:
-            name = intf.get("name").replace('/', '%2F')
+            name = intf.get("name")
             key = intf_key
             if name.startswith('PortChannel'):
                 key = port_chnl_key
@@ -371,7 +370,7 @@ class L2_interfaces(ConfigBase):
         url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config"
         method = "PATCH"
         for conf in configs:
-            name = conf.get('name').replace('/', '%2F')
+            name = conf.get('name')
             if name == "eth0":
                 continue
             key = intf_key
@@ -383,7 +382,6 @@ class L2_interfaces(ConfigBase):
                        "data": payload
                        }
             requests.append(request)
-
         return requests
 
     def build_create_payload(self, conf):

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -338,7 +338,7 @@ class Lag_interfaces(ConfigBase):
         payload_template = """{\n"openconfig-if-aggregate:aggregate-id": "{{name}}"\n}"""
         temp = name.split("PortChannel", 1)[1]
         input_data = {"name": temp}
-        env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+        env = jinja2.Environment(autoescape=False)
         t = env.from_string(payload_template)
         intended_payload = t.render(input_data)
         ret_payload = json.loads(intended_payload)
@@ -351,7 +351,7 @@ class Lag_interfaces(ConfigBase):
             payload_template += """,\n "openconfig-if-aggregation:aggregation": {\n"config": {\n"lag-type": "{{mode}}"\n}\n}\n"""
             input_data["mode"] = mode.upper()
         payload_template += """}\n]\n}\n}"""
-        env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+        env = jinja2.Environment(autoescape=False)
         t = env.from_string(payload_template)
         intended_payload = t.render(input_data)
         ret_payload = json.loads(intended_payload)

--- a/plugins/module_utils/network/sonic/config/system/system.py
+++ b/plugins/module_utils/network/sonic/config/system/system.py
@@ -153,14 +153,14 @@ class System(ConfigBase):
         """
         commands = []
         requests = []
+        new_have = self.remove_default_entries(have)
         if not want:
             if have:
-                requests = self.get_delete_all_system_request(have)
+                requests = self.get_delete_all_system_request(new_have)
                 if len(requests) > 0:
                     commands = update_states(have, "deleted")
         else:
             want = utils.remove_empties(want)
-            new_have = self.remove_default_entries(have)
             d_diff = get_diff(want, new_have, is_skeleton=True)
             diff_want = get_diff(want, d_diff, is_skeleton=True)
             if diff_want:
@@ -230,16 +230,16 @@ class System(ConfigBase):
             if not hostname == "sonic":
                 new_data["hostname"] = hostname
             intf_name = data.get('interface_naming', None)
-            if intf_name is not None:
+            if not intf_name == "native":
                 new_data["interface_naming"] = intf_name
             new_anycast = {}
             anycast = data.get('anycast_address', None)
             if anycast:
                 ipv4 = anycast.get("ipv4", None)
-                if ipv4 is not None:
+                if not ipv4 == True:
                     new_anycast["ipv4"] = ipv4
                 ipv6 = anycast.get("ipv6", None)
-                if ipv6 is not None:
+                if not ipv6 == True:
                     new_anycast["ipv6"] = ipv6
                 mac = anycast.get("mac_address", None)
                 if mac is not None:
@@ -252,7 +252,7 @@ class System(ConfigBase):
         if "hostname" in have and have["hostname"] != "sonic":
             request = self.get_hostname_delete_request()
             requests.append(request)
-        if "interface_naming" in have and have["interface_naming"]:
+        if "interface_naming" in have and have["interface_naming"] != "native":
             request = self.get_intfname_delete_request()
             requests.append(request)
         if "anycast_address" in have and have["anycast_address"]:
@@ -276,12 +276,12 @@ class System(ConfigBase):
 
     def get_anycast_delete_request(self, anycast):
         requests = []
-        if "ipv4" in anycast:
+        if "ipv4" in anycast and anycast["ipv4"] != True:
             path = 'data/sonic-sag:sonic-sag/SAG_GLOBAL/SAG_GLOBAL_LIST=IP/IPv4'
             method = DELETE
             request = {'path': path, 'method': method}
             requests.append(request)
-        if "ipv6" in anycast:
+        if "ipv6" in anycast and anycast["ipv6"] != True:
             path = 'data/sonic-sag:sonic-sag/SAG_GLOBAL/SAG_GLOBAL_LIST=IP/IPv6'
             method = DELETE
             request = {'path': path, 'method': method}

--- a/plugins/module_utils/network/sonic/config/system/system.py
+++ b/plugins/module_utils/network/sonic/config/system/system.py
@@ -236,10 +236,10 @@ class System(ConfigBase):
             anycast = data.get('anycast_address', None)
             if anycast:
                 ipv4 = anycast.get("ipv4", None)
-                if not ipv4 == True:
+                if not ipv4 is True:
                     new_anycast["ipv4"] = ipv4
                 ipv6 = anycast.get("ipv6", None)
-                if not ipv6 == True:
+                if not ipv6 is True:
                     new_anycast["ipv6"] = ipv6
                 mac = anycast.get("mac_address", None)
                 if mac is not None:

--- a/plugins/module_utils/network/sonic/config/system/system.py
+++ b/plugins/module_utils/network/sonic/config/system/system.py
@@ -227,19 +227,19 @@ class System(ConfigBase):
             return new_data
         else:
             hostname = data.get('hostname', None)
-            if not hostname == "sonic":
+            if hostname is not "sonic":
                 new_data["hostname"] = hostname
             intf_name = data.get('interface_naming', None)
-            if not intf_name == "native":
+            if intf_name is not "native":
                 new_data["interface_naming"] = intf_name
             new_anycast = {}
             anycast = data.get('anycast_address', None)
             if anycast:
                 ipv4 = anycast.get("ipv4", None)
-                if not ipv4 is True:
+                if ipv4 is not True:
                     new_anycast["ipv4"] = ipv4
                 ipv6 = anycast.get("ipv6", None)
-                if not ipv6 is True:
+                if ipv6 is not True:
                     new_anycast["ipv6"] = ipv6
                 mac = anycast.get("mac_address", None)
                 if mac is not None:
@@ -249,10 +249,10 @@ class System(ConfigBase):
 
     def get_delete_all_system_request(self, have):
         requests = []
-        if "hostname" in have and have["hostname"] != "sonic":
+        if "hostname" in have and have["hostname"] is not "sonic":
             request = self.get_hostname_delete_request()
             requests.append(request)
-        if "interface_naming" in have and have["interface_naming"] != "native":
+        if "interface_naming" in have and have["interface_naming"] is not "native":
             request = self.get_intfname_delete_request()
             requests.append(request)
         if "anycast_address" in have and have["anycast_address"]:
@@ -276,12 +276,12 @@ class System(ConfigBase):
 
     def get_anycast_delete_request(self, anycast):
         requests = []
-        if "ipv4" in anycast and anycast["ipv4"] != True:
+        if "ipv4" in anycast and anycast["ipv4"] is not True:
             path = 'data/sonic-sag:sonic-sag/SAG_GLOBAL/SAG_GLOBAL_LIST=IP/IPv4'
             method = DELETE
             request = {'path': path, 'method': method}
             requests.append(request)
-        if "ipv6" in anycast and anycast["ipv6"] != True:
+        if "ipv6" in anycast and anycast["ipv6"] is not True:
             path = 'data/sonic-sag:sonic-sag/SAG_GLOBAL/SAG_GLOBAL_LIST=IP/IPv6'
             method = DELETE
             request = {'path': path, 'method': method}

--- a/plugins/module_utils/network/sonic/config/system/system.py
+++ b/plugins/module_utils/network/sonic/config/system/system.py
@@ -227,10 +227,10 @@ class System(ConfigBase):
             return new_data
         else:
             hostname = data.get('hostname', None)
-            if hostname is not "sonic":
+            if hostname != "sonic":
                 new_data["hostname"] = hostname
             intf_name = data.get('interface_naming', None)
-            if intf_name is not "native":
+            if intf_name != "native":
                 new_data["interface_naming"] = intf_name
             new_anycast = {}
             anycast = data.get('anycast_address', None)
@@ -249,10 +249,10 @@ class System(ConfigBase):
 
     def get_delete_all_system_request(self, have):
         requests = []
-        if "hostname" in have and have["hostname"] is not "sonic":
+        if "hostname" in have and have["hostname"] != "sonic":
             request = self.get_hostname_delete_request()
             requests.append(request)
-        if "interface_naming" in have and have["interface_naming"] is not "native":
+        if "interface_naming" in have and have["interface_naming"] != "native":
             request = self.get_intfname_delete_request()
             requests.append(request)
         if "anycast_address" in have and have["anycast_address"]:

--- a/plugins/module_utils/network/sonic/config/system/system.py
+++ b/plugins/module_utils/network/sonic/config/system/system.py
@@ -249,13 +249,13 @@ class System(ConfigBase):
 
     def get_delete_all_system_request(self, have):
         requests = []
-        if "hostname" in have and have["hostname"] != "sonic":
+        if "hostname" in have:
             request = self.get_hostname_delete_request()
             requests.append(request)
-        if "interface_naming" in have and have["interface_naming"] != "native":
+        if "interface_naming" in have:
             request = self.get_intfname_delete_request()
             requests.append(request)
-        if "anycast_address" in have and have["anycast_address"]:
+        if "anycast_address" in have:
             request = self.get_anycast_delete_request(have["anycast_address"])
             requests.extend(request)
         return requests
@@ -276,12 +276,12 @@ class System(ConfigBase):
 
     def get_anycast_delete_request(self, anycast):
         requests = []
-        if "ipv4" in anycast and anycast["ipv4"] is not True:
+        if "ipv4" in anycast:
             path = 'data/sonic-sag:sonic-sag/SAG_GLOBAL/SAG_GLOBAL_LIST=IP/IPv4'
             method = DELETE
             request = {'path': path, 'method': method}
             requests.append(request)
-        if "ipv6" in anycast and anycast["ipv6"] is not True:
+        if "ipv6" in anycast:
             path = 'data/sonic-sag:sonic-sag/SAG_GLOBAL/SAG_GLOBAL_LIST=IP/IPv6'
             method = DELETE
             request = {'path': path, 'method': method}

--- a/plugins/module_utils/network/sonic/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/interfaces/interfaces.py
@@ -144,4 +144,4 @@ class InterfacesFacts(object):
         self.loop_backs += "{0},".format(loop_back)
 
     def is_loop_back_already_esist(self, loop_back):
-        return(",{0},".format(loop_back) in self.loop_backs)
+        return (",{0},".format(loop_back) in self.loop_backs)

--- a/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
@@ -73,9 +73,9 @@ class L2_interfacesFacts(object):
                     new_det['name'] = name
                     if name == "eth0":
                         continue
-                    if(open_cfg_vlan['config'].get('access-vlan')):
+                    if (open_cfg_vlan['config'].get('access-vlan')):
                         new_det['access'] = dict({'vlan': open_cfg_vlan['config'].get('access-vlan')})
-                    if(open_cfg_vlan['config'].get('trunk-vlans')):
+                    if (open_cfg_vlan['config'].get('trunk-vlans')):
                         new_det['trunk'] = {}
                         new_det['trunk']['allowed_vlans'] = []
 

--- a/plugins/module_utils/network/sonic/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l3_interfaces/l3_interfaces.py
@@ -182,4 +182,4 @@ class L3_interfacesFacts(object):
         self.loop_backs += "{Loopback},".format(Loopback=loop_back)
 
     def is_loop_back_already_esist(self, loop_back):
-        return(",{0},".format(loop_back) in self.loop_backs)
+        return (",{0},".format(loop_back) in self.loop_backs)

--- a/plugins/module_utils/network/sonic/sonic.py
+++ b/plugins/module_utils/network/sonic/sonic.py
@@ -42,7 +42,7 @@ from ansible.module_utils.connection import Connection, ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import NetworkConfig, ConfigLine
 
 _DEVICE_CONFIGS = {}
-STANDARD_ETH_REGEXP = r"Eth\d+/\d+"
+STANDARD_ETH_REGEXP = r"Eth\d+(/\d+)+"
 PATTERN = re.compile(STANDARD_ETH_REGEXP)
 
 

--- a/plugins/module_utils/network/sonic/utils/interfaces_util.py
+++ b/plugins/module_utils/network/sonic/utils/interfaces_util.py
@@ -45,7 +45,7 @@ def build_interfaces_create_request(interface_name):
     method = "PATCH"
     payload_template = """{"openconfig-interfaces:interfaces": {"interface": [{"name": "{{interface_name}}", "config": {"name": "{{interface_name}}"}}]}}"""
     input_data = {"interface_name": interface_name}
-    env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+    env = jinja2.Environment(autoescape=False)
     t = env.from_string(payload_template)
     intended_payload = t.render(input_data)
     ret_payload = json.loads(intended_payload)

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -52,7 +52,7 @@ deleted_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
+               pwd: "U2FsdGVkX19eY7P3qRyyjaFsQgjoSQE71IX6IeBRios="
                encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
@@ -76,7 +76,7 @@ deleted_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
+               pwd: "U2FsdGVkX19eY7P3qRyyjaFsQgjoSQE71IX6IeBRios="
                encrypted: true
             nbr_description: 'description 3'
             strict_capability_match: false
@@ -250,7 +250,7 @@ deleted_tests:
         peer_group:
           - name: SPINE
             auth_pwd:
-               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
+               pwd: "U2FsdGVkX19eY7P3qRyyjaFsQgjoSQE71IX6IeBRios="
                encrypted: true
             dont_negotiate_capability: false
             ebgp_multihop:
@@ -686,7 +686,7 @@ merged_tests:
         peer_group:
           - name: SPINE
             auth_pwd:
-               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
+               pwd: "U2FsdGVkX19eY7P3qRyyjaFsQgjoSQE71IX6IeBRios="
                encrypted: true
             dont_negotiate_capability: true
             ebgp_multihop:
@@ -694,7 +694,7 @@ merged_tests:
                multihop_ttl: 1
             enforce_first_as: true
             enforce_multihop: true
-            local_address: 'Ethernet4'
+            local_address: "{{ interface5 }}"
             local_as:
                as: 2
                no_prepend: true
@@ -711,7 +711,7 @@ merged_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
+               pwd: "U2FsdGVkX19eY7P3qRyyjaFsQgjoSQE71IX6IeBRios="
                encrypted: true
             dont_negotiate_capability: true
             ebgp_multihop:
@@ -719,7 +719,7 @@ merged_tests:
                multihop_ttl: 1
             enforce_first_as: true
             enforce_multihop: true
-            local_address: 'Ethernet4'
+            local_address: "{{ interface5 }}"
             local_as:
                as: 2
                no_prepend: true
@@ -738,7 +738,7 @@ merged_tests:
         neighbors:
           - neighbor: "{{ interface1 }}"
             auth_pwd:
-               pwd: "U2FsdGVkX1/pFrFm4ChlWbaxmoqzIOSgCjQHgvi5MEI="
+               pwd: "U2FsdGVkX19eY7P3qRyyjaFsQgjoSQE71IX6IeBRios="
                encrypted: true
             nbr_description: 'description 2'
             strict_capability_match: true

--- a/tests/regression/roles/sonic_static_routes/defaults/main.yml
+++ b/tests/regression/roles/sonic_static_routes/defaults/main.yml
@@ -19,7 +19,7 @@ tests:
          - prefix: '2.0.0.0/8'
            next_hops:
              - index:
-                 interface: 'Ethernet4'
+                 interface: '{{ interface1 }}'
                metric: 1
                tag: 2
                track: 3
@@ -29,14 +29,14 @@ tests:
             next_hops:
               - index:
                   blackhole: True
-                  interface: 'Ethernet4'
+                  interface: '{{ interface1 }}'
                   nexthop_vrf: '{{vrf_2}}'
                   next_hop: '5.0.0.0'
                 metric: 1
                 tag: 2
                 track: 3
               - index:
-                  interface: 'eth0'
+                  interface: '{{ interface1 }}'
                   nexthop_vrf: '{{vrf_2}}'
                   next_hop: '4.0.0.0'
                 metric: 4
@@ -47,10 +47,10 @@ tests:
           - prefix: '1.0.0.0/8'
             next_hops:
               - index:
-                  interface: 'Ethernet6'
+                  interface: '{{ interface2 }}'
                   nexthop_vrf: '{{vrf_1}}'
               - index:
-                  interface: 'Ethernet8'
+                  interface: '{{ interface3 }}'
                   next_hop: '2.0.0.0'
           - prefix: '7.0.0.0/8'
             next_hops:
@@ -66,7 +66,7 @@ tests:
          - prefix: '2.0.0.0/8'
            next_hops:
              - index:
-                 interface: 'Ethernet4'
+                 interface: '{{ interface1 }}'
                metric: 10
                tag: 20
                track: 30
@@ -81,7 +81,7 @@ tests:
             next_hops:
               - index:
                   blackhole: True
-                  interface: 'Ethernet4'
+                  interface: '{{ interface1 }}'
                   nexthop_vrf: '{{vrf_2}}'
                   next_hop: '5.0.0.0'
                 metric: 11
@@ -92,7 +92,7 @@ tests:
           - prefix: '1.0.0.0/8'
             next_hops:
               - index:
-                  interface: 'Ethernet6'
+                  interface: '{{ interface2 }}'
                   nexthop_vrf: '{{vrf_1}}'
                 metric: 6
                 tag: 7
@@ -114,7 +114,7 @@ tests:
          - prefix: '2.0.0.0/8'
            next_hops:
              - index:
-                 interface: 'Ethernet4'
+                 interface: '{{ interface1 }}'
                metric: 10
                tag: 20
                track: 30
@@ -129,14 +129,14 @@ tests:
             next_hops:
               - index:
                   blackhole: True
-                  interface: 'Ethernet4'
+                  interface: '{{ interface1 }}'
                   nexthop_vrf: '{{vrf_2}}'
                   next_hop: '5.0.0.0'
                 metric: 11
                 tag: 22
                 track: 33
               - index:
-                  interface: 'eth0'
+                  interface: '{{ interface1 }}'
                   nexthop_vrf: '{{vrf_2}}'
                   next_hop: '4.0.0.0'
   - name: test_case_04
@@ -148,7 +148,7 @@ tests:
          - prefix: '2.0.0.0/8'
            next_hops:
              - index:
-                 interface: 'Ethernet4'
+                 interface: '{{ interface1 }}'
              - index:
                 next_hop: '3.0.0.0'
       - vrf_name: '{{vrf_2}}'
@@ -156,7 +156,7 @@ tests:
           - prefix: '1.0.0.0/8'
             next_hops:
               - index:
-                  interface: 'Ethernet8'
+                  interface: '{{ interface3 }}'
                   next_hop: '2.0.0.0'
   - name: test_case_05
     description: Delete static route prefix configuration

--- a/tests/regression/roles/sonic_static_routes/tasks/main.yml
+++ b/tests/regression/roles/sonic_static_routes/tasks/main.yml
@@ -9,8 +9,3 @@
 - name: "Test {{ module_name }} started ..."
   include_tasks: tasks_template.yaml
   loop: "{{ tests }}"
-
-- name: "test_delete_all {{ module_name }} stated ..."
-  include_tasks: tasks_template_del.yaml
-  loop: "{{ test_delete_all }}"
-  when: test_delete_all is defined

--- a/tests/regression/roles/sonic_system/defaults/main.yml
+++ b/tests/regression/roles/sonic_system/defaults/main.yml
@@ -9,8 +9,8 @@ tests:
       hostname: SONIC-test
       interface_naming: standard
       anycast_address:
-        ipv4: true
-        ipv6: true
+        ipv4: false
+        ipv6: false
 
   - name: test_case_02
     description: Update created System properties
@@ -31,6 +31,8 @@ tests:
     input:
       hostname: SONIC-new
       interface_naming: standard
+      anycast_address:
+        ipv4: false
 
   - name: del_test_case_02
     description: Delete System associated anycast mac address


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Removed AutoEscapeExtension since it is now built-in with Jinja 3.10
- Reverted the l2_interfaces standard naming bug fix changes
- Fixed system defaults bug and updated  system test cases
- Updated the regex expression in sonic.py to accommodate standard naming in port breakout mode 
- Updated bgp_neighbors test cases to accomodate encryption/decryption method changes and made use of interface variables
- Updated static_routes test cases to make use of interface variables and got rid of repetitive delete all task
- Resolved minor sanity check errors for bgp, bgp_af, bgp_neighbors, interfaces, l2_interfaces, l3_interfaces

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bgp_communities
bgp_ext_communities
bgp_neighbors
interfaces_util
l2_interfaces
lag_interfaces
sonic
static_routes
system


##### ADDITIONAL INFORMATION
[regression-2022-08-17-15-48-25.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9366601/regression-2022-08-17-15-48-25.html.pdf)

Latest regression test log for system
[regression-2022-08-31-09-59-06.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9463493/regression-2022-08-31-09-59-06.html.pdf)

*vxlan cases currently fail due to unresolved sonic-mgmt-common bug
