### PR TITLE
Change NTP get fact on NTP servers

### DIFF
--- a/plugins/module_utils/network/sonic/facts/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/facts/ntp/ntp.py
@@ -128,10 +128,12 @@ class NtpFacts(object):
         servers = []
         for ntp_server in ntp_servers:
             if 'config' in ntp_server:
-                server = ntp_server['config']
-                if 'key-id' in server:
-                    server['key_id'] = server['key-id']
-                    server.pop('key-id')
+                server = {}
+                server['address'] = ntp_server['config'].get('address', None)
+                if 'key-id' in ntp_server['config']:
+                    server['key_id'] = ntp_server['config']['key-id']
+                server['minpoll'] = ntp_server['config'].get('minpoll', None)
+                server['maxpoll'] = ntp_server['config'].get('maxpoll', None)
                 servers.append(server)
         ntp_config['servers'] = servers
 


### PR DESCRIPTION
SUMMARY

get-fact on NTP server brings in unsupported paramer. This is to fix the issue.

ISSUE TYPE

- Bugfix Pull Request


COMPONENT NAME

sonic_ntp

ADDITIONAL INFORMATION

regression test log: 
[ntp_regression_log.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9472369/ntp_regression_log.log)

regression test result:
[regression-2022-09-01-10-10-23.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9472376/regression-2022-09-01-10-10-23.html.pdf)
