### PR TITLE
Change NTP key values in regression test cases

### DIFF
--- a/tests/regression/roles/sonic_ntp/defaults/main.yml
+++ b/tests/regression/roles/sonic_ntp/defaults/main.yml
@@ -149,11 +149,11 @@ tests:
       ntp_keys:
         - key_id: 2
           key_type: NTP_AUTH_SHA1
-          key_value: U2FsdGVkX1+027l93IiTlk7pAmr+qZkZi5suYulk04A=
+          key_value: U2FsdGVkX197E9oiCGzwZlZxZpF5f/ZI8v+SGJdQvmA=
           encrypted: true
         - key_id: 6
           key_type: NTP_AUTH_MD5
-          key_value: U2FsdGVkX1+NqkNohGEhkHqpzJbunjsrmcCwIHT0r2M=
+          key_value: U2FsdGVkX1/wWVxmcp59mJQO6uzhFEHIxScdCbIqJh4=
           encrypted: true
 
   - name: test_case_15


### PR DESCRIPTION
SUMMARY
NTP encrypted key value is switch dependent. So change it to use those generated with regression switch.

ISSUE TYPE

- Regression test case modification Pull Request

ADDITIONAL INFORMATION

- regression test log:
[ntp_regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9474189/ntp_regression_test.log)

- regression test result: 
[regression-2022-09-01-18-03-17.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9474192/regression-2022-09-01-18-03-17.html.pdf)
