### PR TITLE
Fixed regex to support standard naming with port breakout mode and resolved other minor bugs

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           path: ansible_collections/dellemc/enterprise_sonic
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check

--- a/plugins/action/sonic.py
+++ b/plugins/action/sonic.py
@@ -36,8 +36,7 @@ version_added: 1.0.0
 
 class ActionModule(ActionNetworkModule):
 
-    def run(self, tmp=None, task_vars=None):
-        del tmp  # tmp no longer has any effect
+    def run(self, task_vars=None):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'sonic_config' else False

--- a/plugins/module_utils/network/sonic/config/bgp/bgp.py
+++ b/plugins/module_utils/network/sonic/config/bgp/bgp.py
@@ -195,7 +195,7 @@ class Bgp(ConfigBase):
 
     def get_delete_single_bgp_request(self, vrf_name):
         delete_path = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
-        return({'path': delete_path, 'method': DELETE})
+        return ({'path': delete_path, 'method': DELETE})
 
     def get_delete_max_med_requests(self, vrf_name, max_med, match):
         requests = []

--- a/plugins/module_utils/network/sonic/config/bgp_af/bgp_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_af/bgp_af.py
@@ -205,7 +205,7 @@ class Bgp_af(ConfigBase):
         afi_safis_load = {'afi-safis': {'afi-safi': [afi_safi_load]}}
         pay_load = {'openconfig-network-instance:global': afi_safis_load}
 
-        return({"path": url, "method": PATCH, "data": pay_load})
+        return ({"path": url, "method": PATCH, "data": pay_load})
 
     def get_modify_advertise_request(self, vrf_name, conf_afi, conf_safi, conf_addr_fam):
         request = None
@@ -494,21 +494,21 @@ class Bgp_af(ConfigBase):
         url = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
         url += '/%s=%s/%s/advertise-default-gw' % (self.afi_safi_path, afi_safi, self.l2vpn_evpn_config_path)
 
-        return({"path": url, "method": DELETE})
+        return ({"path": url, "method": DELETE})
 
     def get_delete_dampening_request(self, vrf_name, conf_afi, conf_safi):
         afi_safi = ("%s_%s" % (conf_afi, conf_safi)).upper()
         url = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
         url += '/%s=%s/openconfig-bgp-ext:route-flap-damping/config/enabled' % (self.afi_safi_path, afi_safi)
 
-        return({"path": url, "method": DELETE})
+        return ({"path": url, "method": DELETE})
 
     def get_delete_advertise_all_vni_request(self, vrf_name, conf_afi, conf_safi):
         afi_safi = ("%s_%s" % (conf_afi, conf_safi)).upper()
         url = '%s=%s/%s' % (self.network_instance_path, vrf_name, self.protocol_bgp_path)
         url += '/%s=%s/%s/advertise-all-vni' % (self.afi_safi_path, afi_safi, self.l2vpn_evpn_config_path)
 
-        return({"path": url, "method": DELETE})
+        return ({"path": url, "method": DELETE})
 
     def get_delete_address_family_request(self, vrf_name, conf_afi, conf_safi):
         request = None
@@ -676,7 +676,7 @@ class Bgp_af(ConfigBase):
         dst_protocol = "openconfig-policy-types:BGP"
         url = '%s=%s/%s=' % (self.network_instance_path, vrf_name, self.table_connection_path)
         url += '%s,%s,%s/config/import-policy=%s' % (src_protocol, dst_protocol, addr_family, conf_route_map)
-        return({'path': url, 'method': DELETE})
+        return ({'path': url, 'method': DELETE})
 
     def get_delete_redistribute_requests(self, vrf_name, conf_afi, conf_safi, conf_redis_arr, is_delete_all, mat_redis_arr):
         requests = []

--- a/plugins/module_utils/network/sonic/config/bgp_communities/bgp_communities.py
+++ b/plugins/module_utils/network/sonic/config/bgp_communities/bgp_communities.py
@@ -337,7 +337,7 @@ class Bgp_communities(ConfigBase):
                                     ]
                                 }
                             }"""
-        env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+        env = jinja2.Environment(autoescape=False)
         t = env.from_string(payload_template)
         intended_payload = t.render(input_data)
         ret_payload = json.loads(intended_payload)

--- a/plugins/module_utils/network/sonic/config/bgp_ext_communities/bgp_ext_communities.py
+++ b/plugins/module_utils/network/sonic/config/bgp_ext_communities/bgp_ext_communities.py
@@ -328,7 +328,7 @@ class Bgp_ext_communities(ConfigBase):
                                     ]
                                 }
                             }"""
-        env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+        env = jinja2.Environment(autoescape=False)
         t = env.from_string(payload_template)
         intended_payload = t.render(input_data)
         ret_payload = json.loads(intended_payload)

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -640,7 +640,7 @@ class Bgp_neighbors(ConfigBase):
     def delete_neighbor_whole_request(self, vrf_name, neighbor):
         requests = []
         url = '%s=%s/%s/%s=%s/' % (self.network_instance_path, vrf_name, self.protocol_bgp_path, self.neighbor_path, neighbor)
-        return({'path': url, 'method': DELETE})
+        return ({'path': url, 'method': DELETE})
 
     def delete_specific_param_request(self, vrf_name, cmd):
         requests = []

--- a/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
@@ -252,7 +252,7 @@ class L2_interfaces(ConfigBase):
 
     def get_trunk_delete_switchport_request(self, config, match_config):
         method = "DELETE"
-        name = config['name'].replace('/', '%2F')
+        name = config['name']
         requests = []
         match_trunk = match_config.get('trunk')
         if match_trunk:
@@ -273,7 +273,7 @@ class L2_interfaces(ConfigBase):
     def get_access_delete_switchport_request(self, config, match_config):
         method = "DELETE"
         request = None
-        name = config['name'].replace('/', '%2F')
+        name = config['name']
         match_access = match_config.get('access')
         if match_access and match_access.get('vlan') == config['access'].get('vlan'):
             key = intf_key
@@ -291,7 +291,7 @@ class L2_interfaces(ConfigBase):
         url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config"
         method = "DELETE"
         for intf in configs:
-            name = intf.get("name").replace('/', '%2F')
+            name = intf.get("name")
             key = intf_key
             if name.startswith('PortChannel'):
                 key = port_chnl_key
@@ -371,7 +371,7 @@ class L2_interfaces(ConfigBase):
         url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config"
         method = "PATCH"
         for conf in configs:
-            name = conf.get('name').replace('/', '%2F')
+            name = conf.get('name')
             if name == "eth0":
                 continue
             key = intf_key

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -338,7 +338,7 @@ class Lag_interfaces(ConfigBase):
         payload_template = """{\n"openconfig-if-aggregate:aggregate-id": "{{name}}"\n}"""
         temp = name.split("PortChannel", 1)[1]
         input_data = {"name": temp}
-        env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+        env = jinja2.Environment(autoescape=False)
         t = env.from_string(payload_template)
         intended_payload = t.render(input_data)
         ret_payload = json.loads(intended_payload)
@@ -351,7 +351,7 @@ class Lag_interfaces(ConfigBase):
             payload_template += """,\n "openconfig-if-aggregation:aggregation": {\n"config": {\n"lag-type": "{{mode}}"\n}\n}\n"""
             input_data["mode"] = mode.upper()
         payload_template += """}\n]\n}\n}"""
-        env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+        env = jinja2.Environment(autoescape=False)
         t = env.from_string(payload_template)
         intended_payload = t.render(input_data)
         ret_payload = json.loads(intended_payload)

--- a/plugins/module_utils/network/sonic/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/interfaces/interfaces.py
@@ -144,4 +144,4 @@ class InterfacesFacts(object):
         self.loop_backs += "{0},".format(loop_back)
 
     def is_loop_back_already_esist(self, loop_back):
-        return(",{0},".format(loop_back) in self.loop_backs)
+        return (",{0},".format(loop_back) in self.loop_backs)

--- a/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
@@ -63,9 +63,9 @@ class L2_interfacesFacts(object):
                     new_det['name'] = name
                     if name == "eth0":
                         continue
-                    if(open_cfg_vlan['config'].get('access-vlan')):
+                    if (open_cfg_vlan['config'].get('access-vlan')):
                         new_det['access'] = dict({'vlan': open_cfg_vlan['config'].get('access-vlan')})
-                    if(open_cfg_vlan['config'].get('trunk-vlans')):
+                    if (open_cfg_vlan['config'].get('trunk-vlans')):
                         new_det['trunk'] = {}
                         new_det['trunk']['allowed_vlans'] = []
                         new_det['trunk']['allowed_vlans'].extend([dict({'vlan': vlan}) for vlan in open_cfg_vlan['config'].get('trunk-vlans')])

--- a/plugins/module_utils/network/sonic/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l3_interfaces/l3_interfaces.py
@@ -182,4 +182,4 @@ class L3_interfacesFacts(object):
         self.loop_backs += "{Loopback},".format(Loopback=loop_back)
 
     def is_loop_back_already_esist(self, loop_back):
-        return(",{0},".format(loop_back) in self.loop_backs)
+        return (",{0},".format(loop_back) in self.loop_backs)

--- a/plugins/module_utils/network/sonic/sonic.py
+++ b/plugins/module_utils/network/sonic/sonic.py
@@ -42,7 +42,7 @@ from ansible.module_utils.connection import Connection, ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import NetworkConfig, ConfigLine
 
 _DEVICE_CONFIGS = {}
-STANDARD_ETH_REGEXP = r"Eth\d+/\d+"
+STANDARD_ETH_REGEXP = r"Eth\d+(/\d+)+"
 PATTERN = re.compile(STANDARD_ETH_REGEXP)
 
 

--- a/plugins/module_utils/network/sonic/utils/interfaces_util.py
+++ b/plugins/module_utils/network/sonic/utils/interfaces_util.py
@@ -45,7 +45,7 @@ def build_interfaces_create_request(interface_name):
     method = "PATCH"
     payload_template = """{"openconfig-interfaces:interfaces": {"interface": [{"name": "{{interface_name}}", "config": {"name": "{{interface_name}}"}}]}}"""
     input_data = {"interface_name": interface_name}
-    env = jinja2.Environment(autoescape=False, extensions=['jinja2.ext.autoescape'])
+    env = jinja2.Environment(autoescape=False)
     t = env.from_string(payload_template)
     intended_payload = t.render(input_data)
     ret_payload = json.loads(intended_payload)


### PR DESCRIPTION
- Fixed the regex expression in sonic.py to support standard naming with port breakout mode
- Removed AutoEscapeExtension in config since it is now built-in with Jinja 3.10

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
sonic.py
bgp_communities
bgp_ext_communities
lag_interfaces
interfaces_util

##### ADDITIONAL INFORMATION
Executed in standard naming mode :
[regression-2022-09-06-12-58-22.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9500415/regression-2022-09-06-12-58-22.html.pdf)

test regression results for l2_interfaces after reverting standard naming bug fix :
[regression-2022-09-07-11-39-13.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9508797/regression-2022-09-07-11-39-13.html.pdf)

