### PR TITLE
Add server "prefer" attribute to NTP module

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/argspec/ntp/ntp.py
@@ -64,7 +64,8 @@ class NtpArgs(object):  # pylint: disable=R0903
                                     'type': 'str'},
                         'key_id': {'type': 'int', 'no_log': True},
                         'maxpoll': {'type': 'int'},
-                        'minpoll': {'type': 'int'}
+                        'minpoll': {'type': 'int'},
+                        'prefer': {'type': 'bool'}
                     },
                     'type': 'list'
                 },

--- a/plugins/module_utils/network/sonic/config/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/config/ntp/ntp.py
@@ -215,7 +215,9 @@ class Ntp(ConfigBase):
                     key_id_config = server.get('key_id', None)
                     minpoll_config = server.get('minpoll', None)
                     maxpoll_config = server.get('maxpoll', None)
-                    if key_id_config or minpoll_config or maxpoll_config:
+                    prefer_config = server.get('prefer', None)
+                    if key_id_config or minpoll_config or maxpoll_config or \
+                       prefer_config is not None:
                         err_msg = "NTP server parameter(s) can not be deleted."
                         self._module.fail_json(msg=err_msg, code=405)
 
@@ -247,6 +249,8 @@ class Ntp(ConfigBase):
                         server.pop('minpoll')
                     if 'maxpoll' in server and not server['maxpoll']:
                         server.pop('maxpoll')
+                    if 'prefer' in server and server['prefer'] is None:
+                        server.pop('prefer')
 
     def get_merge_requests(self, configs, have):
 
@@ -448,15 +452,20 @@ class Ntp(ConfigBase):
         # Create URL and payload
         method = DELETE
 
-        servers_config = configs.get('servers', None)
         src_intf_config = configs.get('source_interfaces', None)
         vrf_config = configs.get('vrf', None)
         enable_auth_config = configs.get('enable_ntp_auth', None)
         trusted_key_config = configs.get('trusted_keys', None)
 
-        if servers_config or src_intf_config or vrf_config or \
+        if src_intf_config or vrf_config or \
            trusted_key_config or enable_auth_config is not None:
             url = 'data/openconfig-system:system/ntp'
+            request = {"path": url, "method": method}
+            requests.append(request)
+
+        servers_config = configs.get('servers', None)
+        if servers_config:
+            url = 'data/openconfig-system:system/ntp/servers'
             request = {"path": url, "method": method}
             requests.append(request)
 

--- a/plugins/module_utils/network/sonic/facts/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/facts/ntp/ntp.py
@@ -134,6 +134,7 @@ class NtpFacts(object):
                     server['key_id'] = ntp_server['config']['key-id']
                 server['minpoll'] = ntp_server['config'].get('minpoll', None)
                 server['maxpoll'] = ntp_server['config'].get('maxpoll', None)
+                server['prefer'] = ntp_server['config'].get('prefer', None)
                 servers.append(server)
         ntp_config['servers'] = servers
 

--- a/plugins/modules/sonic_ntp.py
+++ b/plugins/modules/sonic_ntp.py
@@ -88,6 +88,11 @@ options:
             description:
               - Maximum poll interval to poll NTP server.
               - maxpoll can not be deleted.
+          prefer:
+            type: bool
+            description:
+              - Indicates whether this server should be preferred.
+              - prefer can not be deleted.
       ntp_keys:
         type: list
         elements: dict
@@ -138,13 +143,13 @@ EXAMPLES = """
 # -------------
 #
 #sonic# show ntp server
-#----------------------------------------------------------------------
-#NTP Servers                     minpoll maxpoll Authentication key ID
-#----------------------------------------------------------------------
-#10.11.0.1                       6       10
-#10.11.0.2                       5       9
-#dell.com                        6       9
-#dell.org                        7       10
+#----------------------------------------------------------------------------
+#NTP Servers                     minpoll maxpoll Prefer Authentication key ID
+#----------------------------------------------------------------------------
+#10.11.0.1                       6       10      False
+#10.11.0.2                       5       9       False
+#dell.com                        6       9       False
+#dell.org                        7       10      True
 #
 - name: Delete NTP server configuration
   sonic_ntp:
@@ -158,11 +163,11 @@ EXAMPLES = """
 # ------------
 #
 #sonic# show ntp server
-#----------------------------------------------------------------------
-#NTP Servers                     minpoll maxpoll Authentication key ID
-#----------------------------------------------------------------------
-#10.11.0.1                       6       10
-#dell.com                        6       9
+#----------------------------------------------------------------------------
+#NTP Servers                     minpoll maxpoll Prefer Authentication key ID
+#----------------------------------------------------------------------------
+#10.11.0.1                       6       10      False
+#dell.com                        6       9       False
 #
 #
 # Using deleted
@@ -225,11 +230,11 @@ EXAMPLES = """
 # -------------
 #
 #sonic# show ntp server
-#----------------------------------------------------------------------
-#NTP Servers                     minpoll maxpoll Authentication key ID
-#----------------------------------------------------------------------
-#10.11.0.1                       6       10
-#dell.com                        6       9
+#----------------------------------------------------------------------------
+#NTP Servers                     minpoll maxpoll Prefer Authentication key ID
+#----------------------------------------------------------------------------
+#10.11.0.1                       6       10      False
+#dell.com                        6       9       False
 #
 - name: Merge NTP server configuration
   sonic_ntp:
@@ -240,19 +245,20 @@ EXAMPLES = """
         - address: dell.org
           minpoll: 7
           maxpoll: 10
+          prefer: true
     state: merged
 
 # After state:
 # ------------
 #
 #sonic# show ntp server
-#----------------------------------------------------------------------
-#NTP Servers                     minpoll maxpoll Authentication key ID
-#----------------------------------------------------------------------
-#10.11.0.1                       6       10
-#10.11.0.2                       5       9
-#dell.com                        6       9
-#dell.org                        7       10
+#----------------------------------------------------------------------------
+#NTP Servers                     minpoll maxpoll Prefer Authentication key ID
+#----------------------------------------------------------------------------
+#10.11.0.1                       6       10      Flase
+#10.11.0.2                       5       10      Flase
+#dell.com                        6       9       Flase
+#dell.org                        7       10      True
 #
 #
 # Using merged

--- a/tests/regression/roles/sonic_ntp/defaults/main.yml
+++ b/tests/regression/roles/sonic_ntp/defaults/main.yml
@@ -81,6 +81,7 @@ tests:
         - address: "{{ ntp_ip_server_3 }}"
           minpoll: 7
           maxpoll: 10
+          prefer: true
 
   - name: test_case_06
     description: Delete a NTP source interface

--- a/tests/regression/roles/sonic_ntp/defaults/main.yml
+++ b/tests/regression/roles/sonic_ntp/defaults/main.yml
@@ -84,20 +84,30 @@ tests:
           prefer: true
 
   - name: test_case_06
+    description: Configure NTP server prefer to false
+    state: merged
+    input:
+      servers:
+        - address: "{{ ntp_ip_server_3 }}"
+          minpoll: 6
+          maxpoll: 10
+          prefer: false
+
+  - name: test_case_07
     description: Delete a NTP source interface
     state: deleted
     input:
       source_interfaces:
         - "{{ interface1 }}"
 
-  - name: test_case_07
+  - name: test_case_08
     description: Delete a NTP server
     state: deleted
     input:
       servers:
         - address: "{{ ntp_ip_server_1 }}"
 
-  - name: test_case_08
+  - name: test_case_09
     description: Delete several NTP source interfaces
     state: deleted
     input:
@@ -105,7 +115,7 @@ tests:
         - "{{ interface2 }}"
         - "{{ po1 }}"
 
-  - name: test_case_09
+  - name: test_case_10
     description: Delete several NTP servers
     state: deleted
     input:
@@ -113,7 +123,7 @@ tests:
         - address: "{{ ntp_ip_server_1 }}"
         - address: "{{ ntp_ip_server_3 }}"
 
-  - name: test_case_10
+  - name: test_case_11
     description: Delete NTP source interfaces and servers
     state: deleted
     input:
@@ -125,25 +135,25 @@ tests:
         - address: "{{ ntp_ip_server_1 }}"
         - address: "{{ ntp_host_server }}"
 
-  - name: test_case_11
+  - name: test_case_12
     description: Configure NTP VRF
     state: merged
     input:
       vrf: "{{ mgmt_vrf }}"
 
-  - name: test_case_12
+  - name: test_case_13
     description: Delete NTP VRF
     state: deleted
     input:
       vrf: "{{ mgmt_vrf }}"
 
-  - name: test_case_13
+  - name: test_case_14
     description: Enable NTP authentication
     state: merged
     input:
       enable_ntp_auth: true
 
-  - name: test_case_14
+  - name: test_case_15
     description: Create NTP authentication keys
     state: merged
     input:
@@ -157,7 +167,7 @@ tests:
           key_value: U2FsdGVkX1/wWVxmcp59mJQO6uzhFEHIxScdCbIqJh4=
           encrypted: true
 
-  - name: test_case_15
+  - name: test_case_16
     description: Configure NTP trusted keys
     state: merged
     input:
@@ -165,7 +175,7 @@ tests:
         - 2
         - 6
 
-  - name: test_case_16
+  - name: test_case_17
     description: Create NTP servers with key
     state: merged
     input:
@@ -175,7 +185,7 @@ tests:
           minpoll: 6
           maxpoll: 9
 
-  - name: test_case_17
+  - name: test_case_18
     description: Delete NTP trusted keys
     state: deleted
     input:
@@ -183,14 +193,14 @@ tests:
         - 2
         - 6
 
-  - name: test_case_18
+  - name: test_case_19
     description: Delete NTP server
     state: deleted
     input:
       servers:
         - address: "{{ ntp_ip_server_1 }}"
 
-  - name: test_case_19
+  - name: test_case_20
     description: Delete NTP authentication keys
     state: deleted
     input:
@@ -198,13 +208,13 @@ tests:
         - key_id: 2
         - key_id: 6
 
-  - name: test_case_20
+  - name: test_case_21
     description: Delete NTP authentication
     state: deleted
     input:
       enable_ntp_auth: true
 
-  - name: test_case_21
+  - name: test_case_22
     description: Delete all NTP configurations
     state: deleted
     input: {}


### PR DESCRIPTION
SUMMARY
This is to add NTP server "prefer" attribute to NTP module.

ISSUE TYPE
- Module Enhancement Pull Request

COMPONENT NAME
sonic_ntp

ADDITIONAL INFORMATION
- regression test log: 
[regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9767805/regression_test.log)

- regression test result: 
[regression-2022-10-12-10-50-29.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9767807/regression-2022-10-12-10-50-29.html.pdf)


