### PR TITLE
Deleted port name split for lag_interfaces

### DIFF
--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -336,8 +336,7 @@ class Lag_interfaces(ConfigBase):
 
     def build_create_payload_member(self, name):
         payload_template = """{\n"openconfig-if-aggregate:aggregate-id": "{{name}}"\n}"""
-        temp = name.split("PortChannel", 1)[1]
-        input_data = {"name": temp}
+        input_data = {"name": name}
         env = jinja2.Environment(autoescape=False)
         t = env.from_string(payload_template)
         intended_payload = t.render(input_data)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I deleted the portchannel name split in config to accommodate changed behavior.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lag_interfaces

##### ADDITIONAL INFORMATION
[regression-2022-09-27-16-19-55.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9660232/regression-2022-09-27-16-19-55.html.pdf)
[lag_interfaces_output.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9660234/lag_interfaces_output.log)

