### PR TITLE
Allow use of the OC Yang compliant vlan range delimiter ".." in new SONiC images

### DIFF
--- a/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
@@ -47,8 +47,8 @@ class L2_interfacesFacts(object):
 
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
-    def vlan_range_to_list(self, in_range):
-        range_bounds = in_range.split('-')
+    def vlan_range_to_list(self, in_range, range_str):
+        range_bounds = in_range.split(range_str)
         range_bottom = int(range_bounds[0])
         range_top = int(range_bounds[1]) + 1
         vlan_list = list(range(range_bottom, range_top))
@@ -84,8 +84,13 @@ class L2_interfacesFacts(object):
                         # each resulting "range list" onto the main list for the
                         # interface.
                         for vlan in open_cfg_vlan['config'].get('trunk-vlans'):
-                            if isinstance(vlan, str) and '-' in vlan:
-                                new_det['trunk']['allowed_vlans'].extend(self.vlan_range_to_list(vlan))
+                            if isinstance(vlan, str):
+                                if '..' in vlan:
+                                    new_det['trunk']['allowed_vlans'].extend(
+                                            self.vlan_range_to_list(vlan, '..'))
+                                elif '-' in vlan:    
+                                    new_det['trunk']['allowed_vlans'].extend(
+                                            self.vlan_range_to_list(vlan, '-'))
                             else:
                                 new_det['trunk']['allowed_vlans'].append({'vlan': vlan})
                     l2_interfaces.append(new_det)

--- a/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
@@ -87,10 +87,10 @@ class L2_interfacesFacts(object):
                             if isinstance(vlan, str):
                                 if '..' in vlan:
                                     new_det['trunk']['allowed_vlans'].extend(
-                                            self.vlan_range_to_list(vlan, '..'))
-                                elif '-' in vlan:    
+                                        self.vlan_range_to_list(vlan, '..'))
+                                elif '-' in vlan:
                                     new_det['trunk']['allowed_vlans'].extend(
-                                            self.vlan_range_to_list(vlan, '-'))
+                                        self.vlan_range_to_list(vlan, '-'))
                             else:
                                 new_det['trunk']['allowed_vlans'].append({'vlan': vlan})
                     l2_interfaces.append(new_det)


### PR DESCRIPTION

The l2_interface "facts" facility previously accepted only the "-" character/string as a vlan "range" delimiter for specifying allowed trunking vlans to be configured on an interface. Recent SONiC images have modified the implementation to use the OC Yang compliant ".." string instead. (e.g. The range previously specified as "5-7" is now specified as "5..7".)

This change set provides a modified, backward compatible implementation for l2_interface "facts" gathering by allowing and handling either of these options for the vlan trunking allowed range string delimiter.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
l2_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Regression Test Results:


[l2_interfaces_facts_vlan_range_string_change_html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9762084/l2_interfaces_facts_vlan_range_string_change_html.pdf)
[l2_interfaces_facts_vlan_range_string_change.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9762085/l2_interfaces_facts_vlan_range_string_change.log)

Regression Test Results for a SONiC 4.0 image (backward compatibility verification):

[l2_interfaces_facts_range_string_change_4.0_html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9769092/l2_interfaces_facts_range_string_change_4.0_html.pdf)
[l2_interfaces_facts_range_string_change_4.0.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9769097/l2_interfaces_facts_range_string_change_4.0.log)
