### PR TITLE
Add "stable-2.14" to our test matrix

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -18,6 +18,7 @@ jobs:
         - stable-2.11
         - stable-2.12
         - stable-2.13
+        - stable-2.14
         - devel
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The Ansible core team has announced that the Ansible core "2.14" version is stable and should be added to collection workflow test matrices.

This PR is to add it to the Dell enterprise_sonic test matrix.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Add "stable-2.14" to the test matrix for the sonic_enterprise collection in the .github workflows "ansible-test.yml" file .
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
workflows
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
