### PR TITLE
Updated test cases to reflect cvl neighbor validation code changes.

### DIFF
--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -213,7 +213,7 @@ deleted_tests:
           - neighbor: 3::3
             peer_group: SPINE
           - neighbor: 192.168.1.5
-            peer_group: SPINE1
+            peer_group: SPINE
       - bgp_as: "{{bgp_as_1}}"
         vrf_name: "{{vrf_1}}"
         peer_group:
@@ -230,7 +230,7 @@ deleted_tests:
           - neighbor: "{{ interface4 }}"
             peer_group: SPINE
           - neighbor: "{{ interface3 }}"
-            peer_group: SPINE1
+            peer_group: SPINE
             bfd:
               enabled: false
               check_failure: false
@@ -468,7 +468,6 @@ merged_tests:
           - neighbor: 192.168.1.5
             remote_as:
               peer_as: 112
-            peer_group: SPINE1
             advertisement_interval: 21
             timers:
               keepalive: 22
@@ -509,7 +508,6 @@ merged_tests:
           - neighbor: "{{ interface3 }}"
             remote_as:
               peer_as: 212
-            peer_group: SPINE1
             advertisement_interval: 44
             timers:
               keepalive: 55


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I updated the test cases to reflect cvl neighbor validation code changes.

sonic(config-router-bgp-neighbor)# peer-group PG1
sonic(config-router-bgp-neighbor)# peer-group PG2
%Error: Cannot change the peer-group. Deconfigure first

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_bgp_neighbors

##### ADDITIONAL INFORMATION
[regression-2022-10-24-10-28-10.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9853982/regression-2022-10-24-10-28-10.html.pdf)

