### PR TITLE
Make NTP minpoll and maxpoll config together

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/argspec/ntp/ntp.py
@@ -67,6 +67,7 @@ class NtpArgs(object):  # pylint: disable=R0903
                         'minpoll': {'type': 'int'},
                         'prefer': {'type': 'bool'}
                     },
+                    'required_together': [['minpoll', 'maxpoll']],
                     'type': 'list'
                 },
                 'source_interfaces': {

--- a/plugins/modules/sonic_ntp.py
+++ b/plugins/modules/sonic_ntp.py
@@ -67,7 +67,7 @@ options:
         elements: dict
         description:
           - List of NTP servers.
-          - minpoll and maxpoll are required to configure together.
+          - minpoll and maxpoll are required to be configured together.
         suboptions:
           address:
             type: str

--- a/plugins/modules/sonic_ntp.py
+++ b/plugins/modules/sonic_ntp.py
@@ -67,6 +67,7 @@ options:
         elements: dict
         description:
           - List of NTP servers.
+          - minpoll and maxpoll are required to configure together.
         suboptions:
           address:
             type: str


### PR DESCRIPTION
SUMMARY
Make NTP server minpoll and maxpoll attributes be configured together. This is required by SONIC.

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
sonic_ntp

ADDITIONAL INFORMATION
- regression test result: 
[regression-2022-10-28-09-58-25.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9890701/regression-2022-10-28-09-58-25.html.pdf)

- regression test log: 
[regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9890703/regression_test.log)


```
