### PR TITLE
Removed the vxlan co-req restriction for the evpn_nvo and source_ip attributes

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/vxlans/vxlans.py
+++ b/plugins/module_utils/network/sonic/argspec/vxlans/vxlans.py
@@ -62,7 +62,6 @@ class VxlansArgs(object):  # pylint: disable=R0903
                     'type': 'list'
                 }
             },
-            'required_together': [['source_ip', 'evpn_nvo']],
             'type': 'list'
         },
         'state': {

--- a/plugins/module_utils/network/sonic/facts/vxlans/vxlans.py
+++ b/plugins/module_utils/network/sonic/facts/vxlans/vxlans.py
@@ -166,10 +166,9 @@ class VxlansFacts(object):
             vxlan['source_ip'] = each_tunnel.get('src_ip', None)
             vxlan['primary_ip'] = each_tunnel.get('primary_ip', None)
             vxlan['evpn_nvo'] = None
-            if vxlan['source_ip']:
-                evpn_nvo = next((nvo_map['name'] for nvo_map in vxlans_evpn_nvo_list if nvo_map['source_vtep'] == vxlan['name']), None)
-                if evpn_nvo:
-                    vxlan['evpn_nvo'] = evpn_nvo
+            evpn_nvo = next((nvo_map['name'] for nvo_map in vxlans_evpn_nvo_list if nvo_map['source_vtep'] == vxlan['name']), None)
+            if evpn_nvo:
+                vxlan['evpn_nvo'] = evpn_nvo
             vxlans.append(vxlan)
 
     def fill_vlan_map(self, vxlans, vxlan_vlan_map):

--- a/plugins/modules/sonic_vxlans.py
+++ b/plugins/modules/sonic_vxlans.py
@@ -43,7 +43,6 @@ options:
   config:
     description:
       - A list of VxLAN configurations.
-      - source_ip and evpn_nvo are required together.
     type: list
     elements: dict
     suboptions:

--- a/tests/regression/roles/sonic_vxlan/defaults/main.yml
+++ b/tests/regression/roles/sonic_vxlan/defaults/main.yml
@@ -56,12 +56,12 @@ tests:
       - name: vtep1
         source_ip: 1.1.1.1
         primary_ip: 2.2.2.2
-        evpn_nvo: nvo5
   - name: test_case_03
     description: Update VRF properties
     state: merged
     input:
       - name: vtep1
+        evpn_nvo: nvo5
         vlan_map:
           - vni: 101
             vlan: "{{vlan1}}"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I removed the vxlan co-req restriction for the evpn_nvo and source_ip attributes to match CLI behavior.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_vxlan

##### ADDITIONAL INFORMATION
[regression-2022-10-31-11-46-19.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9904019/regression-2022-10-31-11-46-19.html.pdf)
[vxlan_regression_output.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/9904021/vxlan_regression_output.log)

