### PR TITLE
Adding template for Pull Request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,15 +36,15 @@ List the GitHub issues impacted by this PR. If no Github issues are affected, pl
 
 ##### Checklist:
 
-- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
+- [ ] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
 - [ ] I have verified that new and existing unit tests pass locally with my changes
 - [ ] I have not allowed coverage numbers to degenerate
 - [ ] I have maintained at least 90% code coverage
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
-- [ ] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)
+- [ ] I have maintained backward compatibility or I have provided any relevant "breaking changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
+- [ ] I have provided a summary for this PR in fragment file format in the “changelogs/fragments” directory
 
 ##### How Has This Been Tested?
 Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,7 +44,7 @@ List the GitHub issues impacted by this PR. If no Github issues are affected, pl
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have maintained backward compatibility or I have provided any relevant "breaking changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
-- [ ] I have provided a summary for this PR in fragment file format in the “changelogs/fragments” directory
+- [ ] I have provided a summary for this PR in fragment file format in the "changelogs/fragments" directory
 
 ##### How Has This Been Tested?
 Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+##### SUMMARY
+<!--- Describe the change below, including rationale and design decisions -->
+
+##### GitHub Issues
+List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".
+
+| GitHub Issue # |
+| -------------- |
+| |
+
+
+##### ISSUE TYPE
+<!--- Pick one below and delete the rest -->
+- Bugfix Pull Request
+- Docs Pull Request
+- Feature Pull Request
+- Test Pull Request
+
+##### COMPONENT NAME
+<!--- Write the short name of the module, plugin, task or feature below -->
+
+##### OUTPUT
+<!--- Paste the functionality test result below -->
+```paste below
+
+```
+##### ADDITIONAL INFORMATION
+<!--- Include additional information to help people understand the change here -->
+<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
+
+<!--- Paste verbatim command output below, e.g. before and after your change -->
+```paste below
+
+```
+<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->
+
+##### Checklist:
+
+- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
+- [ ] I have verified that new and existing unit tests pass locally with my changes
+- [ ] I have not allowed coverage numbers to degenerate
+- [ ] I have maintained at least 90% code coverage
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
+- [ ] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)
+
+##### How Has This Been Tested?
+Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

This is PR is an extension of [PR#121](https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/121). We have added all the comments from PR121 to this PR and have commented it below.

@kerry-meyer Thanks for creating these guideline. I have posted some minor comments/questions inline.

**kerry-meyer**   In the PR description, please provide any relevant details on recommended procedures and/or tools for measuring code coverage (if any).

**KVSK** We have commented the below statement under additional information section to handle this code coverage measurement.
 "Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool."

**kerry-meyer**  Please change this to:
I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.

**KVSK** Addressed as suggested. 

**kerry-meyer**   What does "vetting" mean in this requirement? Is there a recommended procedure to check for "security issues" (or is this a judgement call for the PR submitter)?

**KVSK** Have requested the technical team to comment on this.

**kerry-meyer**  Please add an item for documentation requirements:
I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. (REF: "https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to")

**KVSK** Addressed as suggested. 

**kerry-meyer**  Please add a sentence here:
If no Github issues are affected, please indicate this with "N/A".

**KVSK** Addressed as suggested. 
