### PR TITLE
Provided workaround for SONiC mgmt vrf bug

### DIFF
--- a/playbooks/common_examples/mgmt_vrf_config.yaml
+++ b/playbooks/common_examples/mgmt_vrf_config.yaml
@@ -1,0 +1,16 @@
+---
+- name: Example playbook of configuring with mgmt_vrf_on and mgmt_vrf_off tasks.
+  hosts: datacenter
+  gather_facts: False
+  connection: httpapi
+  collections:
+    - dellemc.enterprise_sonic
+  tasks:
+    - include_tasks: mgmt_vrf_on.yaml
+    - name: Add VLANs
+      sonic_vlans:
+        config:
+          - vlan_id: 11
+          - vlan_id: 12
+        state: merged
+    - include_tasks: mgmt_vrf_off.yaml    

--- a/playbooks/common_examples/mgmt_vrf_config.yaml
+++ b/playbooks/common_examples/mgmt_vrf_config.yaml
@@ -1,4 +1,15 @@
 ---
+# Execution of a task that adds or deletes the configuration of the
+# management VRF ("mgmt") causes a disruption of the
+# management interface connection on which playbook configuration
+# commands are executing. As a result, playbook execution is aborted
+# unless the management VRF configuration task is constructed to
+# ignore errors. 
+#
+# This example demonstrates how to combine tasks that configure other
+# resource modules ("sonic_vrfs", in this case) with tasks that add or remove
+# "management VRF" configuration.
+
 - name: Example playbook of configuring with mgmt_vrf_on and mgmt_vrf_off tasks.
   hosts: datacenter
   gather_facts: False

--- a/playbooks/common_examples/mgmt_vrf_off.yaml
+++ b/playbooks/common_examples/mgmt_vrf_off.yaml
@@ -1,0 +1,6 @@
+- name: Delete mgmt VRF configuration
+  sonic_vrfs:
+    config:
+      - name: mgmt
+    state: deleted
+  ignore_errors: yes

--- a/playbooks/common_examples/mgmt_vrf_on.yaml
+++ b/playbooks/common_examples/mgmt_vrf_on.yaml
@@ -1,0 +1,6 @@
+- name: Create mgmt VRF configuration
+  sonic_vrfs:
+    config:
+      - name: mgmt
+    state: merged
+  ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added tasks for configuring and unconfiguring the mgmt vrf as a workaround for the mgmt vrf vug.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_vrfs
##### ADDITIONAL INFORMATION
[mgmt_vrf_config_output.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/10239729/mgmt_vrf_config_output.txt)
