### PR TITLE
playbook support for vlan trunk ranges

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/argspec/l2_interfaces/l2_interfaces.py
@@ -53,7 +53,7 @@ class L2_interfacesArgs(object):  # pylint: disable=R0903
                         'allowed_vlans': {
                             'elements': 'dict',
                             'options': {
-                                'vlan': {'type': 'int'}
+                                'vlan': {'type': 'str'}
                             },
                             'type': 'list'
                         }

--- a/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import json
+from urllib.parse import quote
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase
@@ -35,6 +36,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 )
 from ansible.module_utils._text import to_native
 from ansible.module_utils.connection import ConnectionError
+import copy
 import traceback
 
 LIB_IMP_ERR = None
@@ -123,7 +125,7 @@ class L2_interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        want = self._module.params['config']
+        want = copy.deepcopy(self._module.params['config'])
         normalize_interface_name(want, self._module)
         have = existing_l2_interfaces_facts
 
@@ -176,7 +178,7 @@ class L2_interfaces(ConfigBase):
             if requests_del:
                 requests.extend(requests_del)
 
-            requests_rep = self.get_create_l2_interface_request(commands)
+            requests_rep = self.get_create_l2_interface_request(commands, have)
             if len(requests_del) or len(requests_rep):
                 requests.extend(requests_rep)
                 commands = update_states(commands, "replaced")
@@ -203,7 +205,7 @@ class L2_interfaces(ConfigBase):
             commands.extend(commands_del)
 
         commands_over = diff
-        requests_over = self.get_create_l2_interface_request(commands_over)
+        requests_over = self.get_create_l2_interface_request(commands_over, have)
         if requests_over:
             requests.extend(requests_over)
             commands_over = update_states(commands_over, "overridden")
@@ -221,7 +223,7 @@ class L2_interfaces(ConfigBase):
                   at position-1
         """
         commands = diff
-        requests = self.get_create_l2_interface_request(commands)
+        requests = self.get_create_l2_interface_request(commands, have)
         if commands and len(requests):
             commands = update_states(commands, "merged")
         return commands, requests
@@ -239,8 +241,14 @@ class L2_interfaces(ConfigBase):
             commands = have
             requests = self.get_delete_all_switchport_requests(commands)
         else:
+            requests = self.get_delete_specific_switchport_requests(want, have)
+            # If "want" has been modified during execution of
+            # get_delete_specific_switchport_requests due to absence of some
+            # of the specified commands from the current device configuration,
+            # the returned value for "commands" needs to reflect the revised
+            # set of commands so that the playbook output can correctly display
+            # the commands actually sent to the device.
             commands = want
-            requests = self.get_delete_specifig_switchport_requests(want, have)
             if len(requests) == 0:
                 commands = []
 
@@ -253,20 +261,55 @@ class L2_interfaces(ConfigBase):
         method = "DELETE"
         name = config['name']
         requests = []
+        conf_allowed_vlans = config['trunk'].get('allowed_vlans', [])
         match_trunk = match_config.get('trunk')
         if match_trunk:
-            conf_allowed_vlans = config['trunk'].get('allowed_vlans', [])
-            if conf_allowed_vlans:
+            match_trunk_vlans = match_trunk.get('allowed_vlans', [])
+            if conf_allowed_vlans and match_trunk_vlans:
+                vlan_id_list = ""
+                conf_vlan_index = 0
+                pop_list = []
                 for each_allowed_vlan in conf_allowed_vlans:
-                    if each_allowed_vlan in match_trunk.get('allowed_vlans'):
-                        vlan_id = each_allowed_vlan['vlan']
-                        key = intf_key
-                        if name.startswith('PortChannel'):
-                            key = port_chnl_key
-                        url = "data/openconfig-interfaces:interfaces/interface={0}/{1}/".format(name, key)
-                        url += "openconfig-vlan:switched-vlan/config/trunk-vlans={0}".format(vlan_id)
-                        request = {"path": url, "method": method}
-                        requests.append(request)
+                    vlan_id = each_allowed_vlan.get('vlan')
+                    if not vlan_id:
+                        pop_list.insert(0, conf_vlan_index)
+                        conf_vlan_index += 1
+                        continue
+                    if self.input_vlan_id_in_device_config(vlan_id, match_trunk_vlans):
+                        if '-' in vlan_id:
+                            vlan_id_fmt = vlan_id.replace('-', '..')
+                        else:
+                            vlan_id_fmt = vlan_id
+
+                        if vlan_id_list:
+                            vlan_id_list += ",{}".format(vlan_id_fmt)
+                        else:
+                            vlan_id_list = vlan_id_fmt
+                    else:
+                        # defer popping of unconfigured vlans until completion of the outer loop.
+                        pop_list.insert(0, conf_vlan_index)
+
+
+                    conf_vlan_index += 1
+
+                if vlan_id_list:
+                    key = intf_key
+                    if name.startswith('PortChannel'):
+                        key = port_chnl_key
+
+                    url = "data/openconfig-interfaces:interfaces/interface={0}/{1}/".format(name, key)
+                    url += "openconfig-vlan:switched-vlan/config/"
+                    url +=  "trunk-vlans=" + quote(vlan_id_list)
+
+                    request = {"path": url, "method": method}
+                    requests.append(request)
+
+                    for pop_list_index in pop_list:
+                        config['trunk']['allowed_vlans'].pop(pop_list_index)
+
+        if conf_allowed_vlans and not requests:
+            config['trunk'].pop('allowed_vlans')
+
         return requests
 
     def get_access_delete_switchport_request(self, config, match_config):
@@ -280,6 +323,9 @@ class L2_interfaces(ConfigBase):
                 key = port_chnl_key
             url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config/access-vlan"
             request = {"path": url.format(name, key), "method": method}
+        elif config['access'].get('vlan'):
+            config['access'].pop('vlan')
+
         return request
 
     def get_delete_all_switchport_requests(self, configs):
@@ -301,7 +347,7 @@ class L2_interfaces(ConfigBase):
 
         return requests
 
-    def get_delete_specifig_switchport_requests(self, configs, have):
+    def get_delete_specific_switchport_requests(self, configs, have):
         requests = []
         if not configs:
             return requests
@@ -317,7 +363,7 @@ class L2_interfaces(ConfigBase):
                 if not ('access' in keys) and not ('trunk' in keys):
                     requests.extend(self.get_delete_all_switchport_requests([conf]))
                 else:
-                    # if access or trnuk is  mentioned with value
+                    # if access or trunk is mentioned with value
                     if conf.get('access') or conf.get('trunk'):
                         # if access is mentioned with value
                         if conf.get('access'):
@@ -338,14 +384,17 @@ class L2_interfaces(ConfigBase):
                             allowed_vlans = conf['trunk'].get('allowed_vlans')
                             if allowed_vlans:
                                 requests.extend(self.get_trunk_delete_switchport_request(conf, matched))
-                            # allowed vlans mentinoed without value
+                            # allowed vlans mentioned without value
                             else:
-                                if matched.get('trunk') and matched.get('trunk').get('allowed_vlans'):
-                                    conf['trunk']['allowed_vlans'] = matched.get('trunk') and matched.get('trunk').get('allowed_vlans').copy()
-                                    requests.extend(self.get_trunk_delete_switchport_request(conf, matched))
+                                trunk_match = matched.get('trunk')
+                                if trunk_match and trunk_match.get('allowed_vlans'):
+                                    conf['trunk']['allowed_vlans'] = trunk_match.get('allowed_vlans').copy()
+                                    requests.extend(
+                                           self.get_trunk_delete_switchport_request(conf, matched))
+
                     # check for access or trunk is mentioned without value
                     else:
-                        # access mentioned wothout value
+                        # access mentioned without value
                         if ('access' in keys) and conf.get('access', None) is None:
                             # get the existing values and delete it
                             if matched.get('access'):
@@ -353,7 +402,7 @@ class L2_interfaces(ConfigBase):
                                 request = self.get_access_delete_switchport_request(conf, matched)
                                 if request:
                                     requests.append(request)
-                        # trunk mentioned wothout value
+                        # trunk mentioned without value
                         if ('trunk' in keys) and conf.get('trunk', None) is None:
                             # get the existing values and delete it
                             if matched.get('trunk'):
@@ -362,44 +411,105 @@ class L2_interfaces(ConfigBase):
 
         return requests
 
-    def get_create_l2_interface_request(self, configs):
+    def get_create_l2_interface_request(self, configs, have):
         requests = []
         if not configs:
             return requests
         # Create URL and payload
         url = "data/openconfig-interfaces:interfaces/interface={}/{}/openconfig-vlan:switched-vlan/config"
         method = "PATCH"
+        pop_list = []
+        conf_index = 0
         for conf in configs:
             name = conf.get('name')
             if name == "eth0":
+                pop_list.insert(0, conf_index)
+                conf_index += 1
                 continue
             key = intf_key
             if name.startswith('PortChannel'):
                 key = port_chnl_key
-            payload = self.build_create_payload(conf)
-            request = {"path": url.format(name, key),
-                       "method": method,
-                       "data": payload
-                       }
-            requests.append(request)
+            matched = next((cnf for cnf in have if cnf['name'] == name), None)
+            payload = self.build_create_payload(conf, matched)
+            if payload:
+                request = {"path": url.format(name, key),
+                           "method": method,
+                           "data": payload
+                           }
+                requests.append(request)
+            else:
+                pop_list.insert(0, conf_index)
+            conf_index += 1
+
+        for index in pop_list:
+            configs.pop(index)
         return requests
 
-    def build_create_payload(self, conf):
+    def build_create_payload(self, conf, matched):
         payload_url = '{"openconfig-vlan:config":{ '
         access_payload = ''
         trunk_payload = ''
         if conf.get('access'):
             access_vlan_id = conf['access']['vlan']
             access_payload = '"access-vlan": {0}'.format(access_vlan_id)
-        if conf.get('trunk'):
+        if conf.get('trunk') and conf['trunk'].get('allowed_vlans'):
             trunk_payload = '"trunk-vlans": ['
             cnt = 0
+            pop_list = []
+            conf_vlan_index = 0
+            match_trunk_vlans = []
+            match_trunk = {}
+            if matched:
+                match_trunk = matched.get('trunk')
+            if match_trunk:
+                match_trunk_vlans = match_trunk.get('allowed_vlans', [])
+
             for each_allowed_vlan in conf['trunk']['allowed_vlans']:
+                vlan_val = each_allowed_vlan['vlan']
+                # The following idempotency handling is required because of
+                # vlan trunk ranges. A configured range can contain a vlan or
+                # range that has been requested for configuration in the
+                # executing playbook. In this case, the requested vlan or range will
+                # not be removed during "get_diff" processing because the subset
+                # vlan or range value will not match the value of a larger
+                # configured range in which it is contained.
+                #
+                # Don't request configuration of any vlans or ranges that are already
+                # configured on the target device.
+                if match_trunk_vlans:
+                    if self.vlan_or_range_is_already_configured(vlan_val, match_trunk_vlans):
+                        # Defer popping of already configured vlan values until
+                        # completion of the loop.
+                        pop_list.insert(0, conf_vlan_index)
+                        conf_vlan_index += 1
+                        continue
+
+                if '-' in vlan_val:
+                    request_vlan_val = '"{}"'.format(vlan_val.replace("-", ".."))
+                else:
+                    request_vlan_val = vlan_val
+                conf_vlan_index += 1
+
+                # The specified vlan or range is not already fully configured
+                # on the target device, so include it in the request.
                 if cnt > 0:
                     trunk_payload += ','
-                trunk_payload += str(each_allowed_vlan['vlan'])
+                trunk_payload += request_vlan_val
                 cnt = cnt + 1
-            trunk_payload += ']'
+
+            if cnt:
+                # Remove from the list of "invocation" configured vlans any
+                # vlans or ranges that are already configured on the target
+                # device. This enables correct reporting of the vlans that
+                # are actually being configured on the device.
+                for pop_list_index in pop_list:
+                    conf['trunk']['allowed_vlans'].pop(pop_list_index)
+                trunk_payload += ']'
+            else:
+                trunk_payload = ''
+
+        if access_payload == '' and trunk_payload == '':
+            return ''
 
         if access_payload != '':
             payload_url += access_payload
@@ -412,3 +522,115 @@ class L2_interfaces(ConfigBase):
 
         ret_payload = json.loads(payload_url)
         return ret_payload
+
+    def get_range_bounds(self, range_val):
+        """Assume an input range value that is a string containing either
+        a single integer value or a range string with bounds separated by
+        a "-' character or "..".
+        Return integer values for the lower and upper bounds of the
+        input range string.
+        """
+
+        range_bounds = []
+        if '-' in range_val:
+            range_bounds = range_val.split("-")
+        elif '..' in range_val:
+            range_bounds = range_val.split("..")
+        if range_bounds:
+            range_lower = int(range_bounds[0])
+            range_upper = int(range_bounds[1])
+        else:
+            range_lower = range_upper = int(range_val)
+
+        return range_lower, range_upper
+
+    def vlan_range_subset(self, subset, superset):
+        """Vlan range string subset check:
+
+        Determine what portion of the range or vlan specified by the input
+        "subset" string is a subset of the range specified by the input
+        "superset" string. If any portion of the input subset is contained
+        in the input superset, return a string specifying the contained
+        portion as either a single vlan or a range string in the form
+        "<lower bound>..<upper bound>". If no portion of the input subset
+        string is contained in the input superset string, return an empty
+        string.
+        """
+
+        subset_lower, subset_upper = self.get_range_bounds(subset)
+        superset_lower, superset_upper = self.get_range_bounds(superset)
+
+        # Check for a subset fully contained in the superset.
+        if (subset_lower >= superset_lower and
+                subset_upper <= superset_upper):
+            return subset
+
+        # Check for a subset lower bound contained in the superset.
+        if (subset_lower >= superset_lower and
+                subset_lower <= superset_upper):
+            if subset_lower == superset_upper:
+                # The subset portion is a single vlan.
+                return str(subset_lower)
+            return "{}..{}".format(str(subset_lower), str(superset_upper))
+
+        # Check for a subset upper bound contained in the superset.
+        if (subset_upper <= superset_upper and
+                subset_upper >= superset_lower):
+            if superset_lower == subset_upper:
+                return str(subset_upper)
+            return "{}..{}".format(str(superset_lower), str(subset_upper))
+
+        # None of the subset is contained in the superset.
+        return ""
+
+    def vlan_or_range_is_already_configured(self, input_vlan_val, match_trunk_vlans):
+        """ Determine if the trunk vlan or range specified by input_vlan_val
+            is already fully configured on the target device.
+
+        :param input_val: a string containing either a single vlan (integer)
+                          value or a range in the form "x-y" or "x..y".
+        :param match_trunk_vlans: the current trunk vlan configuration for the interface on
+                        which adding of the input_vlan_val trunk vlan(s) has been requested:
+                        specified as a list of individual vlan dictionaries.
+        :rtype: bool
+        :returns: True if the vlan or range is aleady configured on the device; False if
+                  the vlan or range is not already configured.
+        """
+        if not input_vlan_val or not match_trunk_vlans:
+            return False
+        input_range_lower, input_range_upper = self.get_range_bounds(input_vlan_val)
+
+        for match_trunk_vlan in match_trunk_vlans:
+            cfg_trunk_vlan_val = match_trunk_vlan.get('vlan')
+            if not cfg_trunk_vlan_val:
+                continue
+            overlap_vlans = self.vlan_range_subset(input_vlan_val, cfg_trunk_vlan_val)
+            if overlap_vlans:
+                overlap_range_lower, overlap_range_upper = self.get_range_bounds(overlap_vlans)
+                if (overlap_range_lower == input_range_lower and
+                    overlap_range_upper == input_range_upper):
+                    return True
+        return False
+
+    def input_vlan_id_in_device_config(self, input_vlan_id, match_trunk_vlans):
+        """ Determine if any portion of the trunk vlan or range specified by input_vlan_id
+            is configured on the target device.
+
+        :param input_vlan_id: a string containing either a single vlan (integer)
+                              value or a range in the form "x-y" or "x..y".
+        :param match_trunk_vlans: the current trunk vlan configuration for the interface on
+                        which adding of the input_vlan_val trunk vlan(s) has been requested:
+                        specified as a list of individual vlan dictionaries.
+        :rtype: bool
+        :returns: True if any portion of the vlan or range is aleady configured on the
+                  device; False if the vlan or range is not already configured.
+        """
+        for match_trunk_vlan in match_trunk_vlans:
+            cfg_vlan_id = match_trunk_vlan.get('vlan')
+            if not cfg_vlan_id:
+                continue
+            vlan_id = self.vlan_range_subset(input_vlan_id,
+                                             cfg_vlan_id)
+            if vlan_id:
+                return True
+        return False

--- a/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
@@ -282,7 +282,7 @@ class L2_interfaces(ConfigBase):
                             vlan_id_fmt = vlan_id
 
                         if vlan_id_list:
-                            vlan_id_list += ",{}".format(vlan_id_fmt)
+                            vlan_id_list += ",{1}".format(vlan_id_fmt)
                         else:
                             vlan_id_list = vlan_id_fmt
                     else:
@@ -485,7 +485,7 @@ class L2_interfaces(ConfigBase):
                         continue
 
                 if '-' in vlan_val:
-                    request_vlan_val = '"{}"'.format(vlan_val.replace("-", ".."))
+                    request_vlan_val = '"{1}"'.format(vlan_val.replace("-", ".."))
                 else:
                     request_vlan_val = vlan_val
                 conf_vlan_index += 1
@@ -571,14 +571,14 @@ class L2_interfaces(ConfigBase):
             if subset_lower == superset_upper:
                 # The subset portion is a single vlan.
                 return str(subset_lower)
-            return "{}..{}".format(str(subset_lower), str(superset_upper))
+            return "{1}..{2}".format(str(subset_lower), str(superset_upper))
 
         # Check for a subset upper bound contained in the superset.
         if (subset_upper <= superset_upper and
                 subset_upper >= superset_lower):
             if superset_lower == subset_upper:
                 return str(subset_upper)
-            return "{}..{}".format(str(superset_lower), str(subset_upper))
+            return "{1}..{2}".format(str(superset_lower), str(subset_upper))
 
         # None of the subset is contained in the superset.
         return ""

--- a/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
@@ -89,7 +89,7 @@ class L2_interfacesFacts(object):
                         for vlan in open_cfg_vlan['config'].get('trunk-vlans'):
                             vlan_argspec = ''
                             if isinstance(vlan, str):
-                                vlan_argspec = vlan.replace('"','')
+                                vlan_argspec = vlan.replace('"', '')
                                 if '..' in vlan_argspec:
                                     vlan_argspec = vlan_argspec.replace('..', '-')
                             else:

--- a/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
@@ -79,20 +79,22 @@ class L2_interfacesFacts(object):
                         new_det['trunk'] = {}
                         new_det['trunk']['allowed_vlans'] = []
 
-                        # Save trunk vlans as a list of single vlan dicts: Convert
-                        # any ranges to lists of individual vlan dicts and merge
-                        # each resulting "range list" onto the main list for the
-                        # interface.
+                        # Save trunk vlans and vlan ranges as a list of single vlan dicts:
+                        # Convert single vlan values to strings and convert any ranges
+                        # to the argspec range format. (This block assumes that any string
+                        # value received is a range, using either ".." or "-" as a
+                        # separator between the boundaries of the range. It also assumes
+                        # that any non-string value received is an integer specifying a
+                        # single vlan.)
                         for vlan in open_cfg_vlan['config'].get('trunk-vlans'):
+                            vlan_argspec = ''
                             if isinstance(vlan, str):
-                                if '..' in vlan:
-                                    new_det['trunk']['allowed_vlans'].extend(
-                                        self.vlan_range_to_list(vlan, '..'))
-                                elif '-' in vlan:
-                                    new_det['trunk']['allowed_vlans'].extend(
-                                        self.vlan_range_to_list(vlan, '-'))
+                                vlan_argspec = vlan.replace('"','')
+                                if '..' in vlan_argspec:
+                                    vlan_argspec = vlan_argspec.replace('..', '-')
                             else:
-                                new_det['trunk']['allowed_vlans'].append({'vlan': vlan})
+                                vlan_argspec = str(vlan)
+                            new_det['trunk']['allowed_vlans'].append({'vlan': vlan_argspec})
                     l2_interfaces.append(new_det)
 
         return l2_interfaces

--- a/plugins/modules/sonic_l2_interfaces.py
+++ b/plugins/modules/sonic_l2_interfaces.py
@@ -164,9 +164,9 @@ EXAMPLES = """
   sonic_l2_interfaces:
     config:
       - name: Ethernet12
-        access: 
+        access:
           vlan: 12
-        trunk: 
+        trunk:
           allowed_vlans:
              - vlan: 13-16
     state: deleted

--- a/plugins/modules/sonic_l2_interfaces.py
+++ b/plugins/modules/sonic_l2_interfaces.py
@@ -59,7 +59,7 @@ options:
             elements: dict
             suboptions:
               vlan:
-                type: int
+                type: str
                 description: Configures the specified VLAN in trunk mode.
       access:
         type: dict

--- a/plugins/modules/sonic_l2_interfaces.py
+++ b/plugins/modules/sonic_l2_interfaces.py
@@ -60,7 +60,7 @@ options:
             suboptions:
               vlan:
                 type: str
-                description: Configures the specified VLAN in trunk mode.
+                description: Configures the specified VLAN or VLAN range in trunk mode.
       access:
         type: dict
         description: Configures access mode characteristics of the interface.

--- a/plugins/modules/sonic_l2_interfaces.py
+++ b/plugins/modules/sonic_l2_interfaces.py
@@ -54,13 +54,13 @@ options:
         description: Configures trunking parameters on an interface.
         suboptions:
           allowed_vlans:
-            description: Specifies list of allowed VLANs of trunk mode on the interface.
+            description: Specifies a list of allowed trunk mode VLANs and VLAN ranges for the interface.
             type: list
             elements: dict
             suboptions:
               vlan:
                 type: str
-                description: Configures the specified VLAN or VLAN range in trunk mode.
+                description: Configures the specified trunk mode VLAN or VLAN range.
       access:
         type: dict
         description: Configures access mode characteristics of the interface.
@@ -145,6 +145,47 @@ EXAMPLES = """
 #15         Inactive
 #
 #
+# Using deleted
+#
+# Before state:
+# -------------
+#
+#do show Vlan
+#Q: A - Access (Untagged), T - Tagged
+#NUM        Status      Q Ports
+#11         Inactive    T  Ethernet12
+#12         Inactive    A  Ethernet12
+#13         Inactive    T  Ethernet12
+#14         Inactive    T  Ethernet12
+#15         Inactive    T  Ethernet12
+#16         Inactive    T  Ethernet12
+
+- name: Delete the access vlan and a range of trunk vlans for an interface
+  sonic_l2_interfaces:
+    config:
+      - name: Ethernet12
+        access: 
+          vlan: 12
+        trunk: 
+          allowed_vlans:
+             - vlan: 13-16
+    state: deleted
+
+# After state:
+# ------------
+#
+#do show Vlan
+#Q: A - Access (Untagged), T - Tagged
+#NUM        Status      Q Ports
+#11         Inactive    T  Ethernet12
+#12         Inactive
+#13         Inactive
+#14         Inactive
+#15         Inactive
+#16         Inactive
+#
+#
+#
 # Using merged
 #
 # Before state:
@@ -153,10 +194,11 @@ EXAMPLES = """
 #do show Vlan
 #Q: A - Access (Untagged), T - Tagged
 #NUM        Status      Q Ports
+#10         Inactive
 #11         Inactive    T  Eth1/7
 #12         Inactive    T  Eth1/7
 #
-- name: Configures switch port of interfaces
+- name: Configures an access vlan for an interface
   dellemc.enterprise_sonic.sonic_l2_interfaces:
     config:
      - name: Eth1/3
@@ -184,15 +226,23 @@ EXAMPLES = """
 #Q: A - Access (Untagged), T - Tagged
 #NUM        Status      Q Ports
 #10         Inactive    A  Eth1/3
+#12         Inactive
+#13         Inactive
+#14         Inactive
+#15         Inactive
+#16         Inactive
+#18         Inactive
 #
-- name: Configures switch port of interfaces
+- name: Modify the access vlan, add a range of trunk vlans and a single trunk vlan for an interface
   dellemc.enterprise_sonic.sonic_l2_interfaces:
     config:
      - name: Eth1/3
+       access:
+         vlan: 12
        trunk:
          allowed_vlans:
-            - vlan: 11
-            - vlan: 12
+            - vlan: 13-16
+            - vlan: 18
     state: merged
 #
 # After state:
@@ -201,9 +251,13 @@ EXAMPLES = """
 #do show Vlan
 #Q: A - Access (Untagged), T - Tagged
 #NUM        Status      Q Ports
-#10         Inactive    A  Eth1/3
-#11         Inactive    T  Eth1/7
-#12         Inactive    T  Eth1/7
+#10         Inactive
+#12         Inactive    A  Eth1/3
+#13         Inactive    T  Eth1/3
+#14         Inactive    T  Eth1/3
+#15         Inactive    T  Eth1/3
+#16         Inactive    T  Eth1/3
+#18         Inactive    T  Eth1/3
 #
 #
 # Using merged

--- a/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
@@ -13,6 +13,49 @@ preparations_tests:
         - vlan_id: 400
         - vlan_id: 401
         - vlan_id: 402
+        - vlan_id: 605
+        - vlan_id: 606
+        - vlan_id: 607
+        - vlan_id: 609
+        - vlan_id: 610
+        - vlan_id: 611
+        - vlan_id: 612
+        - vlan_id: 613
+        - vlan_id: 615
+        - vlan_id: 616
+        - vlan_id: 617
+        - vlan_id: 619
+        - vlan_id: 620
+        - vlan_id: 621
+        - vlan_id: 622
+        - vlan_id: 624
+        - vlan_id: 625
+        - vlan_id: 625
+        - vlan_id: 626
+        - vlan_id: 627
+        - vlan_id: 628
+        - vlan_id: 629
+        - vlan_id: 634
+        - vlan_id: 635
+        - vlan_id: 636
+        - vlan_id: 637
+        - vlan_id: 639
+        - vlan_id: 640
+        - vlan_id: 642
+        - vlan_id: 643
+        - vlan_id: 644
+        - vlan_id: 646
+        - vlan_id: 647
+        - vlan_id: 649
+        - vlan_id: 650
+        - vlan_id: 651
+        - vlan_id: 653
+        - vlan_id: 654
+        - vlan_id: 655
+        - vlan_id: 656
+        - vlan_id: 658
+        - vlan_id: 659
+        - vlan_id: 660
     delete_port_configurations:
           - name: "{{ interface1 }}"
           - name: "{{ interface2 }}"
@@ -61,14 +104,72 @@ tests:
             - vlan: 503
         access:
           vlan: 402
-  # delete test cases started
   - name: test_case_03
+    description: Add trunk vlan range base config
+    state: merged
+    input:
+      - name: "{{ interface5 }}"
+        trunk:
+          allowed_vlans:
+            - vlan: 605
+            - vlan: 611
+            - vlan: 617
+            - vlan: 619-620
+            - vlan: 626-627
+            - vlan: 636-637
+            - vlan: 639
+            - vlan: 643
+            - vlan: 647
+            - vlan: 649-650
+            - vlan: 654-655
+            - vlan: 659-660
+        access:
+          vlan: 611
+  - name: test_case_04
+    description: Add trunk vlan range overlay lower half
+    state: merged
+    input:
+      - name: "{{ interface5 }}"
+        trunk:
+          allowed_vlans:
+            - vlan: 605-607
+            - vlan: 609-613
+            - vlan: 615-617
+            - vlan: 619-622
+            - vlan: 624-629
+            - vlan: 634-637
+            - vlan: 639-640
+        access:
+          vlan: 611
+  - name: test_case_05
+    description: Add trunk vlan range overlay all
+    state: merged
+    input:
+      - name: "{{ interface5 }}"
+        trunk:
+          allowed_vlans:
+            - vlan: 605-607
+            - vlan: 609-613
+            - vlan: 615-617
+            - vlan: 619-622
+            - vlan: 624-629
+            - vlan: 634-637
+            - vlan: 639-640
+            - vlan: 642-644
+            - vlan: 646-647
+            - vlan: 649-651
+            - vlan: 653-656
+            - vlan: 658-660
+        access:
+          vlan: 611
+  # delete test cases started
+  - name: test_case_06
     description: Delete Access VLAN
     state: deleted
     input:
       - name: "{{ interface1 }}"
         access:
-  - name: test_case_04
+  - name: test_case_07
     description: Delete specific trunk VLANs
     state: deleted
     input:
@@ -76,26 +177,84 @@ tests:
         trunk:
           allowed_vlans:
             - vlan: 502
-  - name: test_case_05
+  - name: test_case_08
     description: Delete access VLANs from both associations
     state: deleted
     input:
       - name: "{{ interface3 }}"
         access:
           vlan:
-  - name: test_case_06
+  - name: test_case_09
     description: Delete all trunk VLANs
     state: deleted
     input:
       - name: "{{ interface3 }}"
         trunk:
           allowed_vlans:
-  - name: test_case_07
+  - name: test_case_10
     description: Delete all associations in specific interface
     state: deleted
     input:
       - name: "{{ interface2 }}"
-  - name: test_case_08
+  - name: test_case_11
+    description: Delete trunk vlan range overlay base
+    state: deleted
+    input:
+      - name: "{{ interface5 }}"
+        trunk:
+          allowed_vlans:
+            - vlan: 605
+            - vlan: 611
+            - vlan: 617
+            - vlan: 619-620
+            - vlan: 626-627
+            - vlan: 636-637
+            - vlan: 639
+            - vlan: 643
+            - vlan: 647
+            - vlan: 649-650
+            - vlan: 654-655
+            - vlan: 659-660
+        access:
+          vlan: 611
+  - name: test_case_12
+    description: Delete trunk vlan range overlay lower half
+    state: deleted
+    input:
+      - name: "{{ interface5 }}"
+        trunk:
+          allowed_vlans:
+            - vlan: 605-607
+            - vlan: 609-613
+            - vlan: 615-617
+            - vlan: 619-622
+            - vlan: 624-629
+            - vlan: 634-637
+            - vlan: 639-640
+        access:
+          vlan: 611
+  - name: test_case_13
+    description: Delete trunk vlan range overlay all
+    state: deleted
+    input:
+      - name: "{{ interface5 }}"
+        trunk:
+          allowed_vlans:
+            - vlan: 605-607
+            - vlan: 609-613
+            - vlan: 615-617
+            - vlan: 619-622
+            - vlan: 624-629
+            - vlan: 634-637
+            - vlan: 639-640
+            - vlan: 642-644
+            - vlan: 646-647
+            - vlan: 649-651
+            - vlan: 653-656
+            - vlan: 658-660
+        access:
+          vlan: 611
+  - name: test_case_14
     description: Delete All associations in all interfaces
     state: deleted
     input: []


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Change the argspec to use a string instead of an integer when specifying a vlan or a vlan range.
- Add handling to support a "vlan" argument that specifies a vlan range in the form "X-Y".
- provide correct tracking of commands sent to the device after eliminating requested configuration that is already present on the device.
- Fix bugs causing incorrect reporting of the original playbook command "invocation" and the final set of commands sent to the device.
- Add regression test cases to cover the possible overlap conditions between trunk vlans and ranges configured on the device and requested additions or deletions of trunk vlans and ranges.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_l2_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Regression test results:
[vlan_range_feature_regression_report_with_sanity_fixes_2023-01-06-13-54-12_html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/10363677/vlan_range_feature_regression_report_with_sanity_fixes_2023-01-06-13-54-12_html.pdf)

[vlan_range_regression_after_sanity_fixes_2023_0106_reduced.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/10363678/vlan_range_regression_after_sanity_fixes_2023_0106_reduced.log)


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
