### PR TITLE
Add replaced and overridden states support to VRFS module

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/vrfs/vrfs.py
+++ b/plugins/module_utils/network/sonic/argspec/vrfs/vrfs.py
@@ -59,7 +59,7 @@ class VrfsArgs(object):  # pylint: disable=R0903
             "type": "list"
         },
         "state": {
-            "choices": ["merged", "deleted"],
+            "choices": ["merged", "replaced", "overridden", "deleted"],
             "default": "merged",
             "type": "str"
         }

--- a/plugins/module_utils/network/sonic/utils/utils.py
+++ b/plugins/module_utils/network/sonic/utils/utils.py
@@ -509,3 +509,18 @@ def command_list_str_to_dict(module, warnings, cmd_list_in, exec_cmd=False):
             cmd_list_out.append(cmd_out)
 
     return cmd_list_out
+
+
+def send_requests(module, requests):
+
+    reply = dict()
+    response = []
+    if not module.check_mode and requests:
+        try:
+            response = edit_config(module, to_request(module, requests))
+        except ConnectionError as exc:
+            module.fail_json(msg=str(exc), code=exc.code)
+
+        reply = response[0][1]
+
+    return reply

--- a/plugins/modules/sonic_vrfs.py
+++ b/plugins/modules/sonic_vrfs.py
@@ -66,6 +66,8 @@ options:
     type: str
     choices:
     - merged
+    - replaced
+    - overridden
     - deleted
     default: merged
 """
@@ -156,6 +158,88 @@ EXAMPLES = """
 #                    Eth1/16
 #                    Eth1/17
 #Vrfcheck4           Eth1/5
+#                    Eth1/6
+#
+# Using overridden
+#
+# Before state:
+# -------------
+#
+#show ip vrf
+#VRF-NAME            INTERFACES
+#----------------------------------------------------------------
+#Vrfcheck1
+#Vrfcheck2
+#Vrfcheck3           Eth1/7
+#                    Eth1/8
+#
+- name: Overridden VRF configuration
+  dellemc.enterprise_sonic.sonic_vrfs:
+  sonic_vrfs:
+    config:
+      - name: Vrfcheck1
+        members:
+          interfaces:
+            - name: Eth1/3
+            - name: Eth1/14
+      - name: Vrfcheck3
+        members:
+          interfaces:
+            - name: Eth1/5
+            - name: Eth1/6
+    state: overridden
+#
+# After state:
+# ------------
+#
+#show ip vrf
+#VRF-NAME            INTERFACES
+#----------------------------------------------------------------
+#Vrfcheck1           Eth1/3
+#                    Eth1/14
+#Vrfcheck2
+#Vrfcheck3           Eth1/5
+#                    Eth1/6
+#
+# Using replaced
+#
+# Before state:
+# -------------
+#
+#show ip vrf
+#VRF-NAME            INTERFACES
+#----------------------------------------------------------------
+#Vrfcheck1           Eth1/3
+#Vrfcheck2
+#Vrfcheck3           Eth1/5
+#                    Eth1/6
+#
+- name: Replace VRF configuration
+  dellemc.enterprise_sonic.sonic_vrfs:
+  sonic_vrfs:
+    config:
+      - name: Vrfcheck1
+        members:
+          interfaces:
+            - name: Eth1/3
+            - name: Eth1/14
+      - name: Vrfcheck3
+        members:
+          interfaces:
+            - name: Eth1/5
+            - name: Eth1/6
+    state: replaced
+#
+# After state:
+# ------------
+#
+#show ip vrf
+#VRF-NAME            INTERFACES
+#----------------------------------------------------------------
+#Vrfcheck1           Eth1/3
+#                    Eth1/14
+#Vrfcheck2
+#Vrfcheck3           Eth1/5
 #                    Eth1/6
 #
 """

--- a/tests/regression/roles/sonic_vrfs/defaults/main.yml
+++ b/tests/regression/roles/sonic_vrfs/defaults/main.yml
@@ -4,6 +4,7 @@ module_name: vrf
 
 vrf_1: VrfReg1
 vrf_2: VrfReg2
+vrf_3: VrfReg3
 
 po1: Portchannel 100
 vlan1: Vlan 100
@@ -13,6 +14,10 @@ po2: Portchannel 101
 vlan2: Vlan 101
 looopback2: Loopback 101
 
+po3: Portchannel 103
+vlan3: Vlan 103
+looopback3: Loopback 103
+
 preparations_tests:
   delete_interfaces:
     - "no interface {{ po1 }}"
@@ -21,6 +26,9 @@ preparations_tests:
     - "no interface {{ po2 }}"
     - "no interface {{ vlan2 }}"
     - "no interface {{ looopback2 }}"
+    - "no interface {{ po3 }}"
+    - "no interface {{ vlan3 }}"
+    - "no interface {{ looopback3 }}"
   init_interfaces:
     - "interface {{ po1 }}"
     - "interface {{ vlan1 }}"
@@ -28,6 +36,9 @@ preparations_tests:
     - "interface {{ po2 }}"
     - "interface {{ vlan2 }}"
     - "interface {{ looopback2 }}"
+    - "interface {{ po3 }}"
+    - "interface {{ vlan3 }}"
+    - "interface {{ looopback3 }}"
 
 tests_cli:
   - name: cli_test_case_01
@@ -87,7 +98,7 @@ tests:
            - name: "{{ vlan2 }}"
            - name: "{{ looopback2 }}"
 
-  - name: del_test_case_04
+  - name: test_case_04
     description: Delete VRF properties
     state: deleted
     input:
@@ -101,7 +112,7 @@ tests:
            - name: "{{ interface2 }}"
            - name: "{{ po2 }}"
 
-  - name: del_test_case_05
+  - name: test_case_05
     description: Delete VRF properties
     state: deleted
     input:
@@ -109,7 +120,7 @@ tests:
        members:
          interfaces:
 
-  - name: del_test_case_06
+  - name: test_case_06
     description: Delete VRF properties
     state: deleted
     input:
@@ -133,7 +144,58 @@ tests:
            - name: "{{ vlan2 }}"
            - name: "{{ looopback2 }}"
 
-  - name: del_test_case_08
+  - name: test_case_08
+    description: Overridden VRF properties
+    state: overridden
+    input:
+     - name: "{{ vrf_3 }}"
+       members:
+         interfaces:
+           - name: "{{ interface3 }}"
+           - name: "{{ vlan3 }}"
+           - name: "{{ looopback3 }}"
+     - name: "{{ vrf_1 }}"
+       members:
+         interfaces:
+           - name: "{{ interface1 }}"
+           - name: "{{ po3 }}"
+
+  - name: test_case_09
+    description: Replace VRF properties
+    state: replaced
+    input:
+     - name: "{{ vrf_3 }}"
+       members:
+         interfaces:
+           - name: "{{ interface3 }}"
+           - name: "{{ looopback3 }}"
+     - name: "{{ vrf_1 }}"
+       members:
+         interfaces:
+           - name: "{{ interface2 }}"
+           - name: "{{ po2 }}"
+
+  - name: test_case_10
+    description: Replace VRF properties with new VRF
+    state: replaced
+    input:
+     - name: "{{ vrf_3 }}"
+       members:
+         interfaces:
+           - name: "{{ interface3 }}"
+           - name: "{{ vlan3 }}"
+     - name: "{{ vrf_2 }}"
+       members:
+         interfaces:
+           - name: "{{ interface1 }}"
+           - name: "{{ vlan2 }}"
+     - name: "{{ vrf_1 }}"
+       members:
+         interfaces:
+           - name: "{{ interface2 }}"
+           - name: "{{ po2 }}"
+
+  - name: test_case_11
     description: Delete VRF properties
     state: deleted
     input: []


### PR DESCRIPTION
SUMMARY
This is to add support for replaced and overridden states to VRFS module.

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
soniuc_vrfs

ADDITIONAL INFORMATION
- regression test log: 
[regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/10668193/regression_test.log)

- regression test result: 
[regression-2023-02-03-11-41-35.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/10668199/regression-2023-02-03-11-41-35.html.pdf)
