### PR TITLE
Fixed collection sanity check errors

### DIFF
--- a/plugins/cliconf/sonic.py
+++ b/plugins/cliconf/sonic.py
@@ -32,8 +32,6 @@ description:
 
 import json
 
-from itertools import chain
-
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.common._collections_compat import Mapping

--- a/plugins/module_utils/network/sonic/config/aaa/aaa.py
+++ b/plugins/module_utils/network/sonic/config/aaa/aaa.py
@@ -19,7 +19,10 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.c
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
 )
-from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.facts import Facts
+try:
+    from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.facts import Facts
+except ImportError as err:
+    raise ImportError(err)
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     update_states,
     get_diff,

--- a/plugins/module_utils/network/sonic/config/aaa/aaa.py
+++ b/plugins/module_utils/network/sonic/config/aaa/aaa.py
@@ -19,10 +19,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.c
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
 )
-try:
-    from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.facts import Facts
-except ImportError as err:
-    raise ImportError(err)
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.facts import Facts
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     update_states,
     get_diff,

--- a/plugins/module_utils/network/sonic/config/bgp/bgp.py
+++ b/plugins/module_utils/network/sonic/config/bgp/bgp.py
@@ -13,18 +13,11 @@ created
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-try:
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
-    search_obj_in_list,
-    remove_empties
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.facts import Facts
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import (
@@ -32,10 +25,8 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     edit_config
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
-    dict_to_set,
     update_states,
     get_diff,
-    remove_empties_from_list
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import to_request
 from ansible.module_utils.connection import ConnectionError

--- a/plugins/module_utils/network/sonic/config/bgp_af/bgp_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_af/bgp_af.py
@@ -23,7 +23,6 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.c
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
-    search_obj_in_list
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.facts import Facts
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import (

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -13,11 +13,6 @@ created
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-try:
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/ip_neighbor/ip_neighbor.py
+++ b/plugins/module_utils/network/sonic/config/ip_neighbor/ip_neighbor.py
@@ -30,7 +30,6 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     get_diff,
     update_states,
-    remove_empties_from_list
 )
 from ansible.module_utils.connection import ConnectionError
 

--- a/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
@@ -30,7 +30,6 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     to_request,
     edit_config
 )
-from ansible.module_utils._text import to_native
 from ansible.module_utils.connection import ConnectionError
 
 TEST_KEYS = [

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -14,8 +14,6 @@ created
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )
@@ -32,8 +30,6 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     update_states,
     send_requests,
     get_normalize_interface_name,
-    normalize_interface_name,
-    normalize_interface_name_list
 )
 from ansible.module_utils.connection import ConnectionError
 

--- a/plugins/module_utils/network/sonic/config/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/config/ntp/ntp.py
@@ -14,8 +14,6 @@ created
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )
@@ -32,7 +30,6 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     get_replaced_config,
     send_requests,
     update_states,
-    normalize_interface_name,
     normalize_interface_name_list
 )
 from ansible.module_utils.connection import ConnectionError

--- a/plugins/module_utils/network/sonic/config/users/users.py
+++ b/plugins/module_utils/network/sonic/config/users/users.py
@@ -26,7 +26,6 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     edit_config
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
-    dict_to_set,
     update_states,
     get_diff,
 )

--- a/plugins/module_utils/network/sonic/config/vlans/vlans.py
+++ b/plugins/module_utils/network/sonic/config/vlans/vlans.py
@@ -14,8 +14,6 @@ created
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import json
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )
@@ -39,15 +37,6 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.connection import ConnectionError
 import traceback
 
-LIB_IMP_ERR = None
-ERR_MSG = None
-try:
-    import jinja2
-    HAS_LIB = True
-except Exception as e:
-    HAS_LIB = False
-    ERR_MSG = to_native(e)
-    LIB_IMP_ERR = traceback.format_exc()
 
 TEST_KEYS = [
     {'config': {'vlan_id': ''}},

--- a/plugins/module_utils/network/sonic/config/vlans/vlans.py
+++ b/plugins/module_utils/network/sonic/config/vlans/vlans.py
@@ -33,9 +33,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     to_request,
     edit_config
 )
-from ansible.module_utils._text import to_native
 from ansible.module_utils.connection import ConnectionError
-import traceback
 
 
 TEST_KEYS = [

--- a/plugins/module_utils/network/sonic/facts/aaa/aaa.py
+++ b/plugins/module_utils/network/sonic/facts/aaa/aaa.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/bgp/bgp.py
+++ b/plugins/module_utils/network/sonic/facts/bgp/bgp.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/bgp_af/bgp_af.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_af/bgp_af.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_as_paths/bgp_as_paths.py
@@ -11,7 +11,6 @@ based on the configuration.
 """
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/bgp_communities/bgp_communities.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_communities/bgp_communities.py
@@ -11,7 +11,6 @@ based on the configuration.
 """
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/bgp_ext_communities/bgp_ext_communities.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_ext_communities/bgp_ext_communities.py
@@ -11,7 +11,6 @@ based on the configuration.
 """
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors/bgp_neighbors.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors_af/bgp_neighbors_af.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/interfaces/interfaces.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l2_interfaces/l2_interfaces.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/l3_interfaces/l3_interfaces.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/lag_interfaces/lag_interfaces.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/logging/logging.py
+++ b/plugins/module_utils/network/sonic/facts/logging/logging.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/mclag/mclag.py
+++ b/plugins/module_utils/network/sonic/facts/mclag/mclag.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/facts/ntp/ntp.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/port_breakout/port_breakout.py
+++ b/plugins/module_utils/network/sonic/facts/port_breakout/port_breakout.py
@@ -11,8 +11,6 @@ based on the configuration.
 """
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import re
-import json
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/port_group/port_group.py
+++ b/plugins/module_utils/network/sonic/facts/port_group/port_group.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/facts/radius_server/radius_server.py
@@ -11,8 +11,6 @@ based on the configuration.
 """
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import re
-import json
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/sonic/facts/static_routes/static_routes.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/system/system.py
+++ b/plugins/module_utils/network/sonic/facts/system/system.py
@@ -11,7 +11,6 @@ based on the configuration.
 """
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/facts/tacacs_server/tacacs_server.py
@@ -11,8 +11,6 @@ based on the configuration.
 """
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import re
-import json
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/users/users.py
+++ b/plugins/module_utils/network/sonic/facts/users/users.py
@@ -11,7 +11,6 @@ based on the configuration.
 """
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/sonic/facts/vlans/vlans.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/vrfs/vrfs.py
+++ b/plugins/module_utils/network/sonic/facts/vrfs/vrfs.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/facts/vxlans/vxlans.py
+++ b/plugins/module_utils/network/sonic/facts/vxlans/vxlans.py
@@ -13,7 +13,6 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/sonic/sonic.py
+++ b/plugins/module_utils/network/sonic/sonic.py
@@ -33,7 +33,6 @@ import json
 import re
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import env_fallback
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
     ComplexList

--- a/plugins/module_utils/network/sonic/utils/bgp_utils.py
+++ b/plugins/module_utils/network/sonic/utils/bgp_utils.py
@@ -13,16 +13,10 @@ based on the configuration.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
-from copy import deepcopy
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
-    utils,
-)
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     normalize_interface_name,
 )
-from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.argspec.bgp.bgp import BgpArgs
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import (
     to_request,
     edit_config


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
entire collection
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
[regression-2023-02-23-14-15-14.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/10819232/regression-2023-02-23-14-15-14.html.pdf)
[regression-2023-02-22-13-43-01.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/10819234/regression-2023-02-22-13-43-01.html.pdf)
[sanity_err_fixes_logging_only.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/10819248/sanity_err_fixes_logging_only.pdf)
[ansible_sanity_fixes_no_interface_mclag_aaa_regression-2023-02-22-00-22-38..pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/10819259/ansible_sanity_fixes_no_interface_mclag_aaa_regression-2023-02-22-00-22-38.pdf)

It has been verified that the failures in the above regression logs aren't due to the change set in this PR. The failures are caused by SONiC code changes and will be debugged and resolved in another commit.

