### PR TITLE
Support template under docs folder

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -10,6 +10,4 @@ You may obtain a copy of the License at
 
 # Support
 
-  * To report any issue, create an issue [here](https://github.com/ansible-collections/dellemc.enterprise_sonic/issues).
-  * If any requirements have not been addressed, then create an issue [here](https://github.com/ansible-collections/dellemc.enterprise_sonic/issues).
-  * To provide feedback to the development team, provide the feedback [here](https://github.com/ansible-collections/dellemc.enterprise_sonic/issues).
+  * To report any defects, request functionality, or provide general feedback to the development team, please open an Issue using the [Github issue tracker](https://github.com/ansible-collections/dellemc.enterprise_sonic/issues).

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,15 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the GPL, Version 3.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/gpl-3.0.txt
+-->
+
+# Support
+
+  * To report any issue, create an issue [here](https://github.com/ansible-collections/dellemc.enterprise_sonic/issues).
+  * If any requirements have not been addressed, then create an issue [here](https://github.com/ansible-collections/dellemc.enterprise_sonic/issues).
+  * To provide feedback to the development team, provide the feedback [here](https://github.com/ansible-collections/dellemc.enterprise_sonic/issues).


### PR DESCRIPTION
This PR has been raised, as the original [PR#143](https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/143) was closed due to deletion of head repository.

Have mentioned the comments below given in previous PR and its response.

<strong>jeff-yin  : Line 15 : </strong>I don't think we should use e-mail to provide/receive feedback. If folks have feedback they should just open an issue. The development team is subscribed to the repositories so we will get notified via e-mail anyway.
<strong>KVSK </strong> addressed.

<strong>jeff-yin  : Line 14 : </strong>Why don't we link this repo directly? i.e., https://github.com/ansible-collections/dellemc.enterprise_sonic/issues
<strong>KVSK</strong> addressed.

<strong>jeff-yin : Line 13: </strong> Why don't we link to this repo directly? i.e., https://github.com/ansible-collections/dellemc.enterprise_sonic/issues
<strong>KVSK</strong> addressed.