### PR TITLE
Adding Maintainers Guide

### DIFF
--- a/docs/MAINTAINER_GUIDE.md
+++ b/docs/MAINTAINER_GUIDE.md
@@ -1,0 +1,1 @@
+At this point, only the Dell team is contributing. A guide shall be provided when it is opened for external maintainers.


### PR DESCRIPTION
<strong>kerry-meyer</strong>This PR has been raised as the original [PR#136](https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/136) has been closed due deletion of head repository.

Please respond to each of the questions below unless the answer to the first one is "Yes".

Should this PR be "Closed"? (It can be re-opened later with actual content, but since it clearly isn't being posted for review, it would help with our tracking to either close it for now or provide real content.)

Is there a distinction being made here between a "Maintainers Guide" and a "Contributors Guide"? (Note: There is no expectation of having external "maintainers". If a "maintainers'" guide is viewed as something we should have, then any guidelines defined now would be relevant regardless of whether or not there are external contributors.)

Does the comment posted in this file mean that PR 134 (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/134 : Added Contributors Guide to docs folder) should be deferred or closed for now?


<strong>stalabi1 </strong> At this point, only the Dell team is contributing. A guide shall be provided when it is opened for external maintainers.
<strong>KVSK </strong> Addressed