### PR TITLE
[unit test] pylint disable unused-import in compat/mock.py

### DIFF
--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 try:
-    from unittest.mock import (
+    from unittest.mock import (  # pylint: disable=unused-import
         call,
         patch,
         mock_open,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

For pylint, disable unused-import in compat/mock.py to avoid pylint failure for imports not used directly within that file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- unit test

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
