### PR TITLE
Install dependencies from ansible galaxy in code coverage workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -8,9 +8,6 @@ jobs:
     env:
       PY_COLORS: "1"
       source_directory: "./source"
-      collection_pre_install: >-
-        git+https://github.com/ansible-collections/ansible.utils.git
-        git+https://github.com/ansible-collections/ansible.netcommon.git
     strategy:
       fail-fast: false
       matrix:
@@ -44,10 +41,6 @@ jobs:
         uses: ansible-network/github_actions/.github/actions/identify_collection@main
         with:
           source_path: ${{ env.source_directory }}
-
-      - name: Pre install collections dependencies first so the collection install does not
-        run: ansible-galaxy collection install ${{ env.collection_pre_install }} -p /home/runner/collections
-        if: env.collection_pre_install != ''
 
       - name: Build and install the collection
         uses: ansible-network/github_actions/.github/actions/build_install_collection@main


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Install released version of dependencies from ansible galaxy in code coverage workflow, instead of installing directly from git.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- workflow

##### OUTPUT
<!--- Paste the functionality test result below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
