### PR TITLE
Unit testing code for modules/sonic_facts.py added

### DIFF
--- a/tests/unit/modules/network/sonic/fixtures/sonic_facts.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_facts.yaml
@@ -1,0 +1,5 @@
+---
+merged_01:
+  module_args:
+    gather_network_resources:
+      - "vlans"

--- a/tests/unit/modules/network/sonic/test_sonic_facts.py
+++ b/tests/unit/modules/network/sonic/test_sonic_facts.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.dellemc.enterprise_sonic.tests.unit.compat.mock import (
+    patch,
+)
+from ansible_collections.dellemc.enterprise_sonic.plugins.modules import (
+    sonic_facts,
+)
+from ansible_collections.dellemc.enterprise_sonic.tests.unit.modules.utils import (
+    set_module_args,
+)
+from .sonic_module import TestSonicModule
+
+
+class TestSonicInterfacesModule(TestSonicModule):
+    module = sonic_facts
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_get_network_resources_facts = patch(
+            "ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.facts.FactsBase.get_network_resources_facts"
+        )
+        cls.fixture_data = cls.load_fixtures('sonic_facts.yaml')
+
+    def setUp(self):
+        super(TestSonicInterfacesModule, self).setUp()
+        self.get_network_resources_facts = self.mock_get_network_resources_facts.start()
+        self.get_network_resources_facts.return_value = ({
+            'ansible_network_resources': {'bgp': [{'bgp_as': '24', 'router_id': '10.1.1.1', 'log_neighbor_changes': True, 'vrf_name': 'default',
+                                          'timers': {'holdtime': 180, 'keepalive_interval': 60},
+                                                  'bestpath': {'as_path': {'confed': False, 'ignore': False, 'multipath_relax': True,
+                                                                           'multipath_relax_as_set': False},
+                                                               'med': {'confed': False, 'missing_as_worst': False, 'always_compare_med': False},
+                                                               'compare_routerid': False}, 'max_med': None}]},
+            'ansible_net_gather_network_resources': ['bgp'], 'ansible_net_gather_subset': []}, [])
+
+    def tearDown(self):
+        super(TestSonicInterfacesModule, self).tearDown()
+        self.mock_get_network_resources_facts.stop()
+
+    def test_sonic_facts_merged_01(self):
+        set_module_args(self.fixture_data['merged_01']['module_args'])
+        result = self.execute_module(changed=False)


### PR DESCRIPTION
##### SUMMARY
Unit testing code for modules/sonic_facts.py added

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sonic_facts Unit Testing

##### DESCRIPTION
The main objective of UT is to ensure that all files present in plugins/modules folder are covered. This particular file sonic_facts.py is a common module to pull out the facts for all other modules.
This file is not specific to any particular protocol and hence the unit test cases for this file does not follow the same strategy as the protocol unit testing code. This unit testing is only to ensure that the code coverage for this file is met.
The actual functionality for each protocol is being validated in the unit testing that corresponds to the protocol unit testing code. 
The strategy used in this proposed change is to call any one protocol facts code and test the same using stub return values. 
The return values from stub does not matter since this particular file does not validate the return values.
i.e. The main agenda for this unit testing is only to test whether the code flow for sonic_facts works as expected which is being testing using the UT code.