### PR TITLE
Enterprise SONIC Updated Port_breakout with "replaced" and "overridden" options

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/port_breakout/port_breakout.py
+++ b/plugins/module_utils/network/sonic/argspec/port_breakout/port_breakout.py
@@ -51,7 +51,7 @@ class Port_breakoutArgs(object):  # pylint: disable=R0903
             'type': 'list'
         },
         'state': {
-            'choices': ['merged', 'deleted'],
+            'choices': ['merged', 'replaced', 'overridden', 'deleted'],
             'default': 'merged'
         }
     }  # pylint: disable=C0301

--- a/plugins/module_utils/network/sonic/config/port_breakout/port_breakout.py
+++ b/plugins/module_utils/network/sonic/config/port_breakout/port_breakout.py
@@ -207,13 +207,9 @@ class Port_breakout(ConfigBase):
         commands = []
         requests = []
         if not diff:
-              return commands,requests
+            return commands, requests
         commands = have
         requests = self.get_delete_port_breakout_requests(commands, have)
-
-        import sys
-        #with open('requests', 'w') as sys.stdout:
-        #    print(requests)
 
         if commands and len(requests) > 0:
             send_requests(self._module, requests)
@@ -221,8 +217,6 @@ class Port_breakout(ConfigBase):
             commands = []
 
         commands = diff
-        #with open('diff', 'w') as sys.stdout:
-        #    print(diff)
 
         requests = self.get_modify_port_breakout_requests(commands, want)
         if commands and len(requests) > 0:

--- a/plugins/modules/sonic_port_breakout.py
+++ b/plugins/modules/sonic_port_breakout.py
@@ -196,12 +196,13 @@ EXAMPLES = """
 #                                   Eth1/49/3
 #                                   Eth1/49/4
 #
-    - name: Replace users configurations
-      sonic_port_breakout:
-        config:
-          - name: 1/49
-            mode: 4x10G
-        state: replaced
+- name: Replace users configurations
+  sonic_port_breakout:
+    config:
+      - name: 1/49
+        mode: 4x10G
+    state: replaced
+
 # After state:
 # ------------
 #
@@ -233,12 +234,12 @@ EXAMPLES = """
 #1/51  1x100G         Completed     Eth1/51/1
 #
 #
-    - name: Override users configurations
-      sonic_port_breakout:
-        config:
-          - name: 1/56
-            mode: 4x10G
-        state: overridden
+- name: Override users configurations
+    sonic_port_breakout:
+      config:
+        - name: 1/56
+          mode: 4x10G
+      state: overridden
 # After state:
 # ------------
 #

--- a/plugins/modules/sonic_port_breakout.py
+++ b/plugins/modules/sonic_port_breakout.py
@@ -235,11 +235,11 @@ EXAMPLES = """
 #
 #
 - name: Override users configurations
-    sonic_port_breakout:
-      config:
-        - name: 1/56
-          mode: 4x10G
-      state: overridden
+  sonic_port_breakout:
+    config:
+      - name: 1/56
+        mode: 4x10G
+    state: overridden
 # After state:
 # ------------
 #

--- a/plugins/modules/sonic_port_breakout.py
+++ b/plugins/modules/sonic_port_breakout.py
@@ -29,17 +29,23 @@ The module file for sonic_port_breakout
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community',
+  'license': 'Apache 2.0'
+}
+
 DOCUMENTATION = """
 ---
 module: sonic_port_breakout
-version_added: 1.0.0
-notes:
-- Tested against Enterprise SONiC Distribution by Dell Technologies.
-- Supports C(check_mode).
-author: Niraimadaiselvam M (@niraimadaiselvamm)
-short_description: Configure port breakout settings on physical interfaces
+version_added: "1.0.0"
+author: "Niraimadaiselvam M (@niraimadaiselvamm)"
+short_description: Configures port breakout settings on Enterprise SONiC.
 description:
   - This module provides configuration management of port breakout parameters on devices running Enterprise SONiC.
+notes:
+  - Tested against Enterprise SONiC, release 3.0.2.
 options:
   config:
     description:
@@ -63,7 +69,7 @@ options:
           - 2x100G
           - 2x200G
           - 2x50G
-          - 4x100G
+          - 4x100G 
           - 4x10G
           - 4x25G
           - 4x50G
@@ -73,8 +79,7 @@ options:
       - In case of merged, the input mode configuration will be merged with the existing port breakout configuration on the device.
       - In case of deleted the existing port breakout mode configuration will be removed from the device.
     default: merged
-    choices: ['merged', 'deleted']
-    type: str
+    choices: ['merged', 'replaced', 'overridden', 'deleted']
 """
 EXAMPLES = """
 # Using deleted
@@ -92,14 +97,12 @@ EXAMPLES = """
 #                                   Eth1/1/4
 #1/11  1x100G         Completed     Eth1/11
 #
-
-- name: Merge users configurations
-  dellemc.enterprise_sonic.sonic_port_breakout:
-    config:
-      - name: 1/11
-        mode: 1x100G
-    state: deleted
-
+#    - name: Merge users configurations
+#      sonic_port_breakout:
+#        config:
+#          - name: 1/11
+#            mode: 1x100G
+#        state: deleted
 # After state:
 # ------------
 #
@@ -129,12 +132,10 @@ EXAMPLES = """
 #                                   Eth1/1/4
 #1/11  1x100G         Completed     Eth1/11
 #
-- name: Merge users configurations
-  dellemc.enterprise_sonic.sonic_port_breakout:
-    config:
-    state: deleted
-
-
+#    - name: Merge users configurations
+#      sonic_port_breakout:
+#        config:
+#        state: deleted
 # After state:
 # ------------
 #
@@ -160,14 +161,12 @@ EXAMPLES = """
 #                                   Eth1/1/3
 #                                   Eth1/1/4
 #
-- name: Merge users configurations
-  dellemc.enterprise_sonic.sonic_port_breakout:
-    config:
-      - name: 1/11
-        mode: 1x100G
-    state: merged
-
-
+#    - name: Merge users configurations
+#      sonic_port_breakout:
+#        config:
+#          - name: 1/11
+#            mode: 1x100G
+#        state: merged
 # After state:
 # ------------
 #
@@ -182,19 +181,87 @@ EXAMPLES = """
 #1/11  1x100G         Completed     Eth1/11
 
 
+# Using replaced
+#
+# Before state:
+# -------------
+#
+#do show interface breakout
+#-----------------------------------------------
+#Port  Breakout Mode  Status        Interfaces
+#-----------------------------------------------
+#1/49   4x25G         Completed     Eth1/49/1
+#                                   Eth1/49/2
+#                                   Eth1/49/3
+#                                   Eth1/49/4
+#
+#    - name: Replace users configurations
+#      sonic_port_breakout:
+#        config:
+#          - name: 1/49
+#            mode: 4x10G
+#        state: replaced
+# After state:
+# ------------
+#
+#do show interface breakout
+#-----------------------------------------------
+#Port  Breakout Mode  Status        Interfaces
+#-----------------------------------------------
+#1/49   4x10G         Completed     Eth1/49/1
+#                                   Eth1/49/2
+#                                   Eth1/49/3
+#                                   Eth1/49/4
+
+
+# Using overridden
+#
+# Before state:
+# -------------
+#
+#do show interface breakout
+#----------------------------------------------
+#Port  Breakout Mode  Status        Interfaces
+#-----------------------------------------------
+#1/49  4x10G          Completed     Eth1/49/1
+#                                   Eth1/49/2
+#                                   Eth1/49/3
+#                                   Eth1/49/4
+#1/50  2x50G          Completed     Eth1/50/1
+#                                   Eth1/50/2
+#1/51  1x100G         Completed     Eth1/51/1
+#
+#
+#    - name: Override users configurations
+#      sonic_port_breakout:
+#        config:
+#          - name: 1/56
+#            mode: 4x10G
+#        state: overridden
+# After state:
+# ------------
+#
+#do show interface breakout
+#-----------------------------------------------
+#Port  Breakout Mode  Status        Interfaces
+#-----------------------------------------------
+#1/56  4x10G          Completed     Eth1/56/1
+#                                   Eth1/56/2
+#                                   Eth1/56/3
+#                                   Eth1/56/4
+
+
 """
 RETURN = """
 before:
   description: The configuration prior to the model invocation.
   returned: always
-  type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
   description: The resulting configuration model invocation.
   returned: when changed
-  type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.

--- a/plugins/modules/sonic_port_breakout.py
+++ b/plugins/modules/sonic_port_breakout.py
@@ -29,23 +29,17 @@ The module file for sonic_port_breakout
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-  'metadata_version': '1.1',
-  'status': ['preview'],
-  'supported_by': 'community',
-  'license': 'Apache 2.0'
-}
-
 DOCUMENTATION = """
 ---
 module: sonic_port_breakout
-version_added: "1.0.0"
-author: "Niraimadaiselvam M (@niraimadaiselvamm)"
-short_description: Configures port breakout settings on Enterprise SONiC.
+version_added: 1.0.0
+notes:
+- Tested against Enterprise SONiC Distribution by Dell Technologies.
+- Supports C(check_mode).
+author: Niraimadaiselvam M (@niraimadaiselvamm)
+short_description: Configure port breakout settings on physical interfaces
 description:
   - This module provides configuration management of port breakout parameters on devices running Enterprise SONiC.
-notes:
-  - Tested against Enterprise SONiC, release 3.0.2.
 options:
   config:
     description:
@@ -69,7 +63,7 @@ options:
           - 2x100G
           - 2x200G
           - 2x50G
-          - 4x100G 
+          - 4x100G
           - 4x10G
           - 4x25G
           - 4x50G
@@ -80,6 +74,7 @@ options:
       - In case of deleted the existing port breakout mode configuration will be removed from the device.
     default: merged
     choices: ['merged', 'replaced', 'overridden', 'deleted']
+    type: str
 """
 EXAMPLES = """
 # Using deleted
@@ -97,12 +92,14 @@ EXAMPLES = """
 #                                   Eth1/1/4
 #1/11  1x100G         Completed     Eth1/11
 #
-#    - name: Merge users configurations
-#      sonic_port_breakout:
-#        config:
-#          - name: 1/11
-#            mode: 1x100G
-#        state: deleted
+
+- name: Merge users configurations
+  dellemc.enterprise_sonic.sonic_port_breakout:
+    config:
+      - name: 1/11
+        mode: 1x100G
+    state: deleted
+
 # After state:
 # ------------
 #
@@ -132,10 +129,12 @@ EXAMPLES = """
 #                                   Eth1/1/4
 #1/11  1x100G         Completed     Eth1/11
 #
-#    - name: Merge users configurations
-#      sonic_port_breakout:
-#        config:
-#        state: deleted
+- name: Merge users configurations
+  dellemc.enterprise_sonic.sonic_port_breakout:
+    config:
+    state: deleted
+
+
 # After state:
 # ------------
 #
@@ -161,12 +160,14 @@ EXAMPLES = """
 #                                   Eth1/1/3
 #                                   Eth1/1/4
 #
-#    - name: Merge users configurations
-#      sonic_port_breakout:
-#        config:
-#          - name: 1/11
-#            mode: 1x100G
-#        state: merged
+- name: Merge users configurations
+  dellemc.enterprise_sonic.sonic_port_breakout:
+    config:
+      - name: 1/11
+        mode: 1x100G
+    state: merged
+
+
 # After state:
 # ------------
 #
@@ -195,12 +196,12 @@ EXAMPLES = """
 #                                   Eth1/49/3
 #                                   Eth1/49/4
 #
-#    - name: Replace users configurations
-#      sonic_port_breakout:
-#        config:
-#          - name: 1/49
-#            mode: 4x10G
-#        state: replaced
+    - name: Replace users configurations
+      sonic_port_breakout:
+        config:
+          - name: 1/49
+            mode: 4x10G
+        state: replaced
 # After state:
 # ------------
 #
@@ -232,12 +233,12 @@ EXAMPLES = """
 #1/51  1x100G         Completed     Eth1/51/1
 #
 #
-#    - name: Override users configurations
-#      sonic_port_breakout:
-#        config:
-#          - name: 1/56
-#            mode: 4x10G
-#        state: overridden
+    - name: Override users configurations
+      sonic_port_breakout:
+        config:
+          - name: 1/56
+            mode: 4x10G
+        state: overridden
 # After state:
 # ------------
 #
@@ -251,17 +252,20 @@ EXAMPLES = """
 #                                   Eth1/56/4
 
 
+
 """
 RETURN = """
 before:
   description: The configuration prior to the model invocation.
   returned: always
+  type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
   description: The resulting configuration model invocation.
   returned: when changed
+  type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.

--- a/tests/regression/roles/sonic_port_breakout/defaults/main.yml
+++ b/tests/regression/roles/sonic_port_breakout/defaults/main.yml
@@ -26,10 +26,6 @@ tests:
     description: Configure breakout mode for ports
     state: merged
     input:
-      - name: 1/97
-        mode: 4x25G
-      - name: 1/98
-        mode: 1x40G
       - name: 1/99
         mode: 4x25G
       - name: 1/100
@@ -52,6 +48,18 @@ tests:
     input:
       - name: 1/98
   - name: test_case_04
+    description: Replace breakout mode for ports
+    state: replaced
+    input:
+      - name: 1/97
+        mode: 4x10G
+  - name: test_case_05
+    description: Override breakout ports
+    state: overridden
+    input:
+      - name: 1/98
+        mode: 4x25G
+  - name: test_case_06
     description: deleting all the port breakout modes
     state: deleted
     input: []

--- a/tests/regression/roles/sonic_port_breakout/tasks/main.yml
+++ b/tests/regression/roles/sonic_port_breakout/tasks/main.yml
@@ -16,15 +16,15 @@
     tasks_from: cli_tasks_template.yaml
   loop: "{{ tests_cli }}"
 
-# - name: Preparations test
-#   include_tasks: preparation_tests.yaml
+- name: Preparations test
+  include_tasks: preparation_tests.yaml
 
-# - name: "Test {{ module_name }} started ..."
-#   include_tasks: tasks_template.yaml
-#   loop: "{{ tests }}"
+- name: "Test {{ module_name }} started ..."
+  include_tasks: tasks_template.yaml
+  loop: "{{ tests }}"
 
-# - name: Cleanup tests
-#   include_tasks: cleanup_tests.yaml
+- name: Cleanup tests
+  include_tasks: cleanup_tests.yaml
 
 # - name: Display all variables/facts known for a host
 #   debug:

--- a/tests/regression/roles/sonic_port_breakout/tasks/tasks_template.yaml
+++ b/tests/regression/roles/sonic_port_breakout/tasks/tasks_template.yaml
@@ -8,14 +8,19 @@
 - import_role:
     name: common
     tasks_from: action.facts.report.yaml
-  
+
 - name: "{{ item.name}} , {{ item.description}} Idempotent"
   sonic_port_breakout:
     config: "{{ item.input }}"
     state: "{{ item.state }}"
   register: idempotent_task_output
   ignore_errors: yes
-  
+
 - import_role:
     name: common
     tasks_from: idempotent.facts.report.yaml
+
+- name: pause for 5 second(s)
+  ansible.builtin.pause:
+    seconds: 5
+

--- a/tests/regression/roles/sonic_port_breakout/tasks/tasks_template.yaml
+++ b/tests/regression/roles/sonic_port_breakout/tasks/tasks_template.yaml
@@ -23,4 +23,3 @@
 - name: pause for 5 second(s)
   ansible.builtin.pause:
     seconds: 5
-


### PR DESCRIPTION
##### SUMMARY
"Replaced" and "overridden" states support added for port_breakout


##### COMPONENT NAME
port_breakout

##### OUTPUT
Test execution detailed logs -  [port_breakout_execution.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11220344/port_breakout_execution.txt)
Test Report - [Port_breakout_regression.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11220351/Port_breakout_regression.pdf)

            
                                          