### PR TITLE
Add replaced and overridden states support for TACACS server resource module

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/argspec/tacacs_server/tacacs_server.py
@@ -69,12 +69,12 @@ class Tacacs_serverArgs(object):  # pylint: disable=R0903
                     'type': 'dict'
                 },
                 'source_interface': {'type': 'str'},
-                'timeout': {'type': 'int'}
+                'timeout': {'type': 'int', 'default': 5}
             },
             'type': 'dict'
         },
         'state': {
-            'choices': ['merged', 'deleted'],
+            'choices': ['merged', 'replaced', 'overridden', 'deleted'],
             'default': 'merged'
         }
     }  # pylint: disable=C0301

--- a/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
@@ -225,7 +225,8 @@ class Tacacs_server(ConfigBase):
         commands = []
         requests = []
 
-        if have and diff:
+        r_diff = get_diff(have, want, TEST_KEYS)
+        if have and (diff or r_diff):
             del_requests = self.get_delete_tacacs_server_requests(have, have)
             requests.extend(del_requests)
             commands.extend(update_states(have, "deleted"))

--- a/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
@@ -27,6 +27,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     update_states,
     get_diff,
+    get_replaced_config,
     get_normalize_interface_name,
 )
 
@@ -177,6 +178,66 @@ class Tacacs_server(ConfigBase):
 
         if command and len(requests) > 0:
             commands = update_states([command], "deleted")
+
+        return commands, requests
+
+    def _state_replaced(self, want, have, diff):
+        """ The command generator when state is replaced
+
+        :param want: the desired configuration as a dictionary
+        :param have: the current configuration as a dictionary
+        :param diff: the difference between want and have
+        :rtype: A list
+        :returns: the commands necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        commands = []
+        requests = []
+        replaced_config = get_replaced_config(want, have, TEST_KEYS)
+
+        add_commands = []
+        if replaced_config:
+            del_requests = self.get_delete_tacacs_server_requests(replaced_config, have)
+            requests.extend(del_requests)
+            commands.extend(update_states(replaced_config, "deleted"))
+            add_commands = want
+        else:
+            add_commands = diff
+
+        if add_commands:
+            add_requests = self.get_modify_tacacs_server_requests(add_commands, have)
+            if len(add_requests) > 0:
+                requests.extend(add_requests)
+                commands.extend(update_states(add_commands, "replaced"))
+
+        return commands, requests
+
+    def _state_overridden(self, want, have, diff):
+        """ The command generator when state is overridden
+
+        :param want: the desired configuration as a dictionary
+        :param have: the current configuration as a dictionary
+        :param diff: the difference between want and have
+        :rtype: A list
+        :returns: the commands necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        commands = []
+        requests = []
+
+        if have and diff:
+            del_requests = self.get_delete_tacacs_server_requests(have, have)
+            requests.extend(del_requests)
+            commands.extend(update_states(have, "deleted"))
+            have = []
+
+        if not have and want:
+            want_commands = want
+            want_requests = self.get_modify_tacacs_server_requests(want_commands, have)
+
+            if len(want_requests) > 0:
+                requests.extend(want_requests)
+                commands.extend(update_states(want_commands, "overridden"))
 
         return commands, requests
 

--- a/plugins/modules/sonic_tacacs_server.py
+++ b/plugins/modules/sonic_tacacs_server.py
@@ -123,6 +123,8 @@ options:
       - Specifies the operation to be performed on the tacacs server configured on the device.
       - In case of merged, the input mode configuration will be merged with the existing tacacs server configuration on the device.
       - In case of deleted the existing tacacs server mode configuration will be removed from the device.
+      - In case of replaced, the existing tacacs server configuration will be replaced with provided configuration.
+      - In case of overridden, the existing tacacs server configuration will be overridden with the provided configuration.
     default: merged
     choices: ['merged', 'replaced', 'overridden', 'deleted']
     type: str

--- a/plugins/modules/sonic_tacacs_server.py
+++ b/plugins/modules/sonic_tacacs_server.py
@@ -318,7 +318,7 @@ EXAMPLES = """
 #1.2.3.4              pap          No         49         1          5          default
 #11.12.13.14          chap         Yes        49         10         5          default
 #
-- name: Overridden tacacs configurations
+- name: Override tacacs configurations
   sonic_tacacs_server:
     config:
       auth_type: mschap

--- a/plugins/modules/sonic_tacacs_server.py
+++ b/plugins/modules/sonic_tacacs_server.py
@@ -64,6 +64,7 @@ options:
         description:
           - Specifies the timeout of the tacacs server.
         type: int
+        default: 5
       source_interface:
         description:
           - Specifies the source interface of the tacacs server.
@@ -123,7 +124,7 @@ options:
       - In case of merged, the input mode configuration will be merged with the existing tacacs server configuration on the device.
       - In case of deleted the existing tacacs server mode configuration will be removed from the device.
     default: merged
-    choices: ['merged', 'deleted']
+    choices: ['merged', 'replaced', 'overridden', 'deleted']
     type: str
 """
 EXAMPLES = """
@@ -249,8 +250,110 @@ EXAMPLES = """
 #HOST                 AUTH-TYPE       KEY        PORT       PRIORITY   TIMEOUT    VRF
 #------------------------------------------------------------------------------------------------
 #1.2.3.4              pap             1234       49         1          5          default
-
-
+#
+# Using replaced
+#
+# Before state:
+# -------------
+#
+#sonic(config)# do show tacacs-server
+#---------------------------------------------------------
+#TACACS Global Configuration
+#---------------------------------------------------------
+#source-interface  : Ethernet12
+#timeout           : 10
+#auth-type         : pap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST                 AUTH-TYPE    KEY-CONFIG PORT       PRIORITY   TIMEOUT    VRF
+#--------------------------------------------------------------------------------------
+#1.2.3.4              pap          No         49         1          5          default
+#
+- name: Replace tacacs configurations
+  sonic_tacacs_server:
+    config:
+      auth_type: pap
+      key: pap
+      source_interface: Ethernet12
+      timeout: 10
+      servers:
+        - host:
+            name: 1.2.3.4
+            auth_type: mschap
+            key: 1234
+    state: replaced
+#
+# After state:
+# ------------
+#
+#sonic(config)# do show tacacs-server
+#---------------------------------------------------------
+#TACACS Global Configuration
+#---------------------------------------------------------
+#source-interface  : Ethernet12
+#timeout           : 10
+#auth-type         : pap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST                 AUTH-TYPE    KEY-CONFIG PORT       PRIORITY   TIMEOUT    VRF
+#--------------------------------------------------------------------------------------
+#1.2.3.4              mschap       Yes        49         1          5          default
+#
+# Using overridden
+#
+# Before state:
+# -------------
+#
+#sonic(config)# do show tacacs-server
+#---------------------------------------------------------
+#TACACS Global Configuration
+#---------------------------------------------------------
+#source-interface  : Ethernet12
+#timeout           : 10
+#auth-type         : pap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST                 AUTH-TYPE    KEY-CONFIG PORT       PRIORITY   TIMEOUT    VRF
+#--------------------------------------------------------------------------------------
+#1.2.3.4              pap          No         49         1          5          default
+#11.12.13.14          chap         Yes        49         10         5          default
+#
+- name: Overridden tacacs configurations
+  sonic_tacacs_server:
+    config:
+      auth_type: mschap
+      key: mschap
+      source_interface: Ethernet12
+      timeout: 20
+      servers:
+        - host:
+            name: 1.2.3.4
+            auth_type: mschap
+            key: mschap
+        - host:
+            name: 10.10.11.12
+            auth_type: chap
+            timeout: 30
+            priority: 2
+    state: overridden
+#
+# After state:
+# ------------
+#
+#sonic(config)# do show tacacs-server
+#---------------------------------------------------------
+#TACACS Global Configuration
+#---------------------------------------------------------
+#source-interface  : Ethernet12
+#timeout           : 20
+#auth-type         : mschap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST                 AUTH-TYPE    KEY-CONFIG PORT       PRIORITY   TIMEOUT    VRF
+#--------------------------------------------------------------------------------------
+#1.2.3.4              mschap       Yes        49         1          5          default
+#10.10.11.12          chap         No         49         2          30         default
+#
 """
 RETURN = """
 before:

--- a/tests/regression/roles/sonic_tacacs_server/defaults/main.yml
+++ b/tests/regression/roles/sonic_tacacs_server/defaults/main.yml
@@ -64,7 +64,7 @@ tests:
       servers:
         host:
   - name: test_case_05
-    description: merge parameter of tacacs servers
+    description: Merge parameter of tacacs servers
     state: merged
     input:
       servers:
@@ -86,7 +86,7 @@ tests:
             priority: 4
 
   - name: test_case_06
-    description: replace some parameter of tacacs servers
+    description: Replace some parameter of tacacs servers
     state: replaced
     input:
       auth_type: mschap
@@ -101,7 +101,7 @@ tests:
             priority: 3
 
   - name: test_case_07
-    description: replace hosts of tacacs servers
+    description: Replace hosts of tacacs servers
     state: replaced
     input:
       auth_type: mschap
@@ -126,7 +126,7 @@ tests:
             priority: 8
 
   - name: test_case_08
-    description: overridden parameter of tacacs servers
+    description: Override parameter of tacacs servers
     state: overridden
     input:
       auth_type: chap
@@ -147,5 +147,5 @@ tests:
 
 test_delete_all:
   - name: test_case_09
-    description: delete all the configurations of tacacs server
+    description: Delete all the configurations of tacacs server
     state: deleted

--- a/tests/regression/roles/sonic_tacacs_server/defaults/main.yml
+++ b/tests/regression/roles/sonic_tacacs_server/defaults/main.yml
@@ -85,7 +85,67 @@ tests:
             timeout: 14
             priority: 4
 
-test_delete_all:
   - name: test_case_06
+    description: replace some parameter of tacacs servers
+    state: replaced
+    input:
+      auth_type: mschap
+      source_interface: "{{ interface3 }}"
+      timeout: 36
+      servers:
+        host:
+          - name: my_host
+            auth_type: chap
+            port: 55
+            timeout: 12
+            priority: 3
+
+  - name: test_case_07
+    description: replace hosts of tacacs servers
+    state: replaced
+    input:
+      auth_type: mschap
+      source_interface: "{{ interface3 }}"
+      timeout: 36
+      servers:
+        host:
+          - name: my_host
+            auth_type: chap
+            port: 55
+            timeout: 12
+            priority: 3
+          - name: 20.21.22.23
+            auth_type: login
+            port: 50
+            timeout: 38
+            priority: 4
+          - name: 18.21.22.23
+            auth_type: chap
+            port: 20
+            timeout: 19
+            priority: 8
+
+  - name: test_case_08
+    description: overridden parameter of tacacs servers
+    state: overridden
+    input:
+      auth_type: chap
+      source_interface: "{{ interface2 }}"
+      timeout: 20
+      servers:
+        host:
+          - name: 10.11.11.11
+            auth_type: pap
+            port: 55
+            timeout: 12
+            priority: 3
+          - name: your_host
+            auth_type: login
+            port: 50
+            timeout: 30
+            priority: 6
+
+test_delete_all:
+  - name: test_case_09
     description: delete all the configurations of tacacs server
     state: deleted


### PR DESCRIPTION
SUMMARY
This is to add "replaced" and "overridden" states support for sonic_tacacs_server resource module.

GitHub Issues
"N/A".

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
sonic_tacacs_server

OUTPUT
- regression test result: 
[regression-2023-04-13-10-48-02.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11236497/regression-2023-04-13-10-48-02.html.pdf)
- regression test log: 
[regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11236498/regression_test.log)
- unit test log: 
[unit_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11236501/unit_test.log)
- unit test script: 
[tacacs.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11236503/tacacs.txt)


Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

How Has This Been Tested?
Tested on real SONIC switchs.
