### PR TITLE
Added "replaced" and "overridden" states for the Interface module

### DIFF
--- a/plugins/module_utils/network/sonic/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/sonic/config/interfaces/interfaces.py
@@ -175,7 +175,7 @@ class Interfaces(ConfigBase):
         """
         commands = self.filter_comands_to_change(diff, have)
         requests = self.get_delete_interface_requests(commands, have)
-        requests.extend(self.get_modify_interface_requests(commands, have))
+        requests.extend(self.get_modify_interface_requests(want, have))
         if commands and len(requests) > 0:
             commands = update_states(commands, "replaced")
         else:
@@ -194,7 +194,9 @@ class Interfaces(ConfigBase):
         """
         commands = []
         requests = []
-        if not diff:
+
+        diff1 = get_diff(have, want)
+        if not diff and not diff1:
             return commands, requests
 
         commands = have
@@ -203,12 +205,10 @@ class Interfaces(ConfigBase):
             send_requests(self._module, requests)
         else:
             commands = []
-        exist_interfaces_facts = self.get_interfaces_facts()
-        have_new = exist_interfaces_facts
         commands_over = get_diff(want, have)
-        requests = self.get_modify_interface_requests(commands_over, have_new)
+        requests = self.get_modify_interface_requests(diff, have)
 
-        if commands_over and len(requests) > 0:
+        if len(requests) > 0:
             commands = update_states(commands_over, "overridden")
 
         return commands, requests

--- a/plugins/modules/sonic_interfaces.py
+++ b/plugins/modules/sonic_interfaces.py
@@ -289,12 +289,12 @@ EXAMPLES = """
       - name: Ethernet12
         description: 'Ethernet Twelve'
         mtu: 3500
-        enable: True
+        enabled: True
         auto_negotiate: True
       - name: Ethernet16
         description: 'Ethernet Sixteen'
         mtu: 3000
-        enable: False
+        enabled: False
         speed: SPEED_40GB
     state: overridden
 #
@@ -305,8 +305,8 @@ EXAMPLES = """
 #------------------------------------------------------------------------------------------
 #Name                Description         Admin     Oper      AutoNeg     Speed        MTU
 #------------------------------------------------------------------------------------------
-#Ethernet0           -                   up                              100000       9100
-#Ethernet4           -                   up                              100000       9100
+#Ethernet0           -                   down                            100000       9100
+#Ethernet4           -                   down                            100000       9100
 #Ethernet8           -                   up                              100000       9100
 #Ethernet12          Ethernet Twelve     up                  on          100000       3500
 #Ethernet16          Ethernet Sixteen    down                            40000        3000
@@ -349,12 +349,12 @@ EXAMPLES = """
       - name: Ethernet12
         description: 'Ethernet Twelve'
         mtu: 3500
-        enable: True
+        enabled: True
         auto_negotiate: True
       - name: Ethernet16
         description: 'Ethernet Sixteen'
         mtu: 3000
-        enable: False
+        enabled: False
         speed: SPEED_40GB
     state: replaced
 #

--- a/tests/regression/roles/sonic_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_interfaces/defaults/main.yml
@@ -170,7 +170,7 @@ tests:
         enabled: true
   # Ethernet testcases started...
   - name: test_case_17
-    description: Update interface parameters
+    description: Update interface parameters descr and mtu
     state: merged
     input:
       - name: "{{ interface1 }}"
@@ -182,6 +182,14 @@ tests:
         mtu: 7500
         enabled: true
   - name: test_case_18
+    description: Replace interface mtu parameters
+    state: replaced
+    input:
+      - name: "{{ interface1 }}"
+        mtu: 3300
+      - name: "{{ interface3 }}"
+        mtu: 3300
+  - name: test_case_19
     description: Update interface parameters
     state: replaced
     input:
@@ -191,15 +199,15 @@ tests:
       - name: "{{ interface3 }}"
         description: Ansible Interface2
         mtu: 3500
-  - name: test_case_19
+  - name: test_case_20
     description: Update interface parameters
     state: overridden
     input:
       - name: "{{ interface1 }}"
         description: Interface1
-        mtu: 3500
+        mtu: 3300
         enabled: true
-  - name: test_case_20
-    description: Update interface parameters
+  - name: test_case_21
+    description: Delete interface parameters
     state: deleted
     input: []

--- a/tests/regression/roles/sonic_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_interfaces/defaults/main.yml
@@ -168,7 +168,38 @@ tests:
         description: ansible PortChannel51 descr
         mtu: 5454
         enabled: true
+  # Ethernet testcases started...
   - name: test_case_17
+    description: Update interface parameters
+    state: merged
+    input:
+      - name: "{{ interface1 }}"
+        description: Ansible Interface1 descr
+        mtu: 6500
+        enabled: true
+      - name: "{{ interface3 }}"
+        description: ansible Interface2 descr
+        mtu: 7500
+        enabled: true
+  - name: test_case_18
+    description: Update interface parameters
+    state: replaced
+    input:
+      - name: "{{ interface1 }}"
+        description: Ansible Interface1
+        mtu: 3500
+      - name: "{{ interface3 }}"
+        description: Ansible Interface2
+        mtu: 3500
+  - name: test_case_19
+    description: Update interface parameters
+    state: overridden
+    input:
+      - name: "{{ interface1 }}"
+        description: Interface1
+        mtu: 3500
+        enabled: true
+  - name: test_case_20
     description: Update interface parameters
     state: deleted
     input: []


### PR DESCRIPTION
##### SUMMARY
Added "replaced" and "overridden" states for the Interface module

##### COMPONENT NAME
Interface

##### OUTPUT
Interface execution log - 
[Interface_execution_overridden.zip](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11271691/Interface_execution_overridden.zip)

Interface module report - 
[Regression_Interface_Report.pdf] (https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11271694/Regression_Interface_Report.pdf)

3 legacy test cases failed due to platform dependency. The same failures were observed without my changes as well.

Legacy run:-
            Interface module report -  [regression-legacy.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11271717/regression-legacy.pdf)
