### PR TITLE
Add replaced and overridden states support for sonic_radius_server module

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/argspec/radius_server/radius_server.py
@@ -59,7 +59,7 @@ class Radius_serverArgs(object):  # pylint: disable=R0903
                                 },
                                 'key': {'type': 'str', 'no_log': True},
                                 'name': {'type': 'str'},
-                                'port': {'type': 'int'},
+                                'port': {'type': 'int', 'default': 1812},
                                 'priority': {'type': 'int'},
                                 'retransmit': {'type': 'int'},
                                 'source_interface': {'type': 'str'},
@@ -72,12 +72,12 @@ class Radius_serverArgs(object):  # pylint: disable=R0903
                     'type': 'dict'
                 },
                 'statistics': {'type': 'bool'},
-                'timeout': {'type': 'int'}
+                'timeout': {'type': 'int', 'default': 5}
             },
             'type': 'dict'
         },
         'state': {
-            'choices': ['merged', 'deleted'],
+            'choices': ['merged', 'replaced', 'overridden', 'deleted'],
             'default': 'merged'
         }
     }  # pylint: disable=C0301

--- a/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
@@ -27,6 +27,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     update_states,
     get_diff,
+    get_replaced_config,
     normalize_interface_name,
 )
 
@@ -177,6 +178,67 @@ class Radius_server(ConfigBase):
 
         if command and len(requests) > 0:
             commands = update_states([command], "deleted")
+
+        return commands, requests
+
+    def _state_replaced(self, want, have, diff):
+        """ The command generator when state is replaced
+
+        :param want: the desired configuration as a dictionary
+        :param have: the current configuration as a dictionary
+        :param diff: the difference between want and have
+        :rtype: A list
+        :returns: the commands necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        commands = []
+        requests = []
+        replaced_config = get_replaced_config(want, have, TEST_KEYS)
+
+        add_commands = []
+        if replaced_config:
+            del_requests = self.get_delete_radius_server_requests(replaced_config, have)
+            requests.extend(del_requests)
+            commands.extend(update_states(replaced_config, "deleted"))
+            add_commands = want
+        else:
+            add_commands = diff
+
+        if add_commands:
+            add_requests = self.get_modify_radius_server_requests(add_commands, have)
+            if len(add_requests) > 0:
+                requests.extend(add_requests)
+                commands.extend(update_states(add_commands, "replaced"))
+
+        return commands, requests
+
+    def _state_overridden(self, want, have, diff):
+        """ The command generator when state is overridden
+
+        :param want: the desired configuration as a dictionary
+        :param have: the current configuration as a dictionary
+        :param diff: the difference between want and have
+        :rtype: A list
+        :returns: the commands necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        commands = []
+        requests = []
+
+        r_diff = get_diff(have, want, TEST_KEYS)
+        if have and (diff or r_diff):
+            del_requests = self.get_delete_radius_server_requests(have, have)
+            requests.extend(del_requests)
+            commands.extend(update_states(have, "deleted"))
+            have = []
+
+        if not have and want:
+            want_commands = want
+            want_requests = self.get_modify_radius_server_requests(want_commands, have)
+
+            if len(want_requests) > 0:
+                requests.extend(want_requests)
+                commands.extend(update_states(want_commands, "overridden"))
 
         return commands, requests
 

--- a/plugins/module_utils/network/sonic/facts/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/facts/radius_server/radius_server.py
@@ -101,7 +101,7 @@ class Radius_serverFacts(object):
 
             if 'auth-type' in raw_radius_global_data:
                 radius_server_data['auth_type'] = raw_radius_global_data['auth-type']
-            if 'secret-key' in raw_radius_global_data:
+            if 'secret-key' in raw_radius_global_data and raw_radius_global_data['secret-key']:
                 radius_server_data['key'] = raw_radius_global_data['secret-key']
             if 'timeout' in raw_radius_global_data:
                 radius_server_data['timeout'] = raw_radius_global_data['timeout']

--- a/plugins/modules/sonic_radius_server.py
+++ b/plugins/modules/sonic_radius_server.py
@@ -133,6 +133,8 @@ options:
       - Specifies the operation to be performed on the radius server configured on the device.
       - In case of merged, the input mode configuration will be merged with the existing radius server configuration on the device.
       - In case of deleted the existing radius server mode configuration will be removed from the device.
+      - In case of replaced, the existing radius server configuration will be replaced with provided configuration.
+      - In case of overridden, the existing radius server configuration will be overridden with the provided configuration.
     default: merged
     choices: ['merged', 'replaced', 'overridden', 'deleted']
     type: str
@@ -346,7 +348,7 @@ EXAMPLES = """
 #1.2.3.4     pap       No         49        1         5      -     -       Ethernet0
 #11.12.13.14 chap      Yes        49        10        5      3     -       -
 #
-- name: Overridden radius configurations
+- name: Override radius configurations
   sonic_radius_server:
     config:
       auth_type: mschapv2

--- a/tests/regression/roles/sonic_radius_server/defaults/main.yml
+++ b/tests/regression/roles/sonic_radius_server/defaults/main.yml
@@ -109,7 +109,7 @@ tests:
             retransmit: 9
 
   - name: test_case_06
-    description: replace some configuration of radius servers
+    description: Replace some configuration of radius servers
     state: replaced
     input:
       auth_type: mschapv2
@@ -127,7 +127,7 @@ tests:
             source_interface: "{{ interface3 }}"
 
   - name: test_case_07
-    description: replace hosts of radius servers
+    description: Replace hosts of radius servers
     state: replaced
     input:
       auth_type: mschapv2
@@ -157,7 +157,7 @@ tests:
             source_interface: "{{ interface1 }}"
 
   - name: test_case_08
-    description: overridden configuration of radius server
+    description: Override configuration of radius server
     state: overridden
     input:
       auth_type: mschapv2
@@ -182,5 +182,5 @@ tests:
 
 test_delete_all:
   - name: test_case_09
-    description: delete all the configurations of radius server
+    description: Delete all the configurations of radius server
     state: deleted

--- a/tests/regression/roles/sonic_radius_server/defaults/main.yml
+++ b/tests/regression/roles/sonic_radius_server/defaults/main.yml
@@ -108,7 +108,79 @@ tests:
             source_interface: "{{ interface3 }}"
             retransmit: 9
 
-test_delete_all:
   - name: test_case_06
+    description: replace some configuration of radius servers
+    state: replaced
+    input:
+      auth_type: mschapv2
+      timeout: 36
+      nas_ip: 11.11.11.22
+      retransmit: 5
+      statistics: true
+      servers:
+        host:
+          - name: my_host
+            auth_type: chap
+            port: 55
+            timeout: 12
+            priority: 3
+            source_interface: "{{ interface3 }}"
+
+  - name: test_case_07
+    description: replace hosts of radius servers
+    state: replaced
+    input:
+      auth_type: mschapv2
+      timeout: 36
+      nas_ip: 11.11.11.22
+      retransmit: 5
+      statistics: true
+      servers:
+        host:
+          - name: my_host
+            auth_type: chap
+            port: 55
+            timeout: 21
+            priority: 3
+            source_interface: "{{ interface3 }}"
+          - name: 20.21.22.23
+            auth_type: pap
+            port: 50
+            timeout: 38
+            priority: 4
+            source_interface: "{{ interface2 }}"
+          - name: 18.21.22.23
+            auth_type: chap
+            port: 20
+            timeout: 19
+            priority: 8
+            source_interface: "{{ interface1 }}"
+
+  - name: test_case_08
+    description: overridden configuration of radius server
+    state: overridden
+    input:
+      auth_type: mschapv2
+      timeout: 20
+      nas_ip: 10.10.10.20
+      retransmit: 3
+      servers:
+        host:
+          - name: 10.11.11.11
+            auth_type: pap
+            port: 55
+            timeout: 12
+            priority: 3
+            retransmit: 8
+            source_interface: "{{ interface2 }}"
+          - name: your_host
+            auth_type: chap
+            port: 50
+            timeout: 30
+            priority: 6
+            source_interface: "{{ interface3 }}"
+
+test_delete_all:
+  - name: test_case_09
     description: delete all the configurations of radius server
     state: deleted


### PR DESCRIPTION
SUMMARY
This is to add "replaced" and "overridden" states support for sonic_radius_server resource module.

GitHub Issues
N/A

ISSUE TYPE
- Feature Pull Request


COMPONENT NAME
sonic_radius_server

OUTPUT
- regression test result: 
[regression-2023-04-18-10-08-35.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11275185/regression-2023-04-18-10-08-35.html.pdf)
- regression test log: 
[regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11275187/regression_test.log)
- unit test script: 
[radius.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11275193/radius.txt)
- unit test log: 
[unit_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11275198/unit_test.log)


Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

How Has This Been Tested?
Did regression test and unit test on real SONIC switches.
