### PR TITLE
"overridden" and  "replaced" states  support for MCLAG module

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/mclag/mclag.py
+++ b/plugins/module_utils/network/sonic/argspec/mclag/mclag.py
@@ -89,7 +89,7 @@ class MclagArgs(object):  # pylint: disable=R0903
             'type': 'dict'
         },
         'state': {
-            'choices': ['merged', 'deleted'],
+            'choices': ['merged', 'deleted', 'replaced', 'overridden'],
             'default': 'merged',
             'type': 'str'
         }

--- a/plugins/module_utils/network/sonic/config/mclag/mclag.py
+++ b/plugins/module_utils/network/sonic/config/mclag/mclag.py
@@ -209,8 +209,21 @@ class Mclag(ConfigBase):
         """
         requests = []
         commands = []
-        if diff:
-            requests = self.get_create_mclag_request(want, diff)
+
+        diff1 = get_diff(have, want, TEST_KEYS, is_skeleton=True)
+        if diff1:
+            requests = self.get_delete_all_mclag_domain_request(have)
+            if len(requests) > 0:
+                send_requests(self._module, requests)
+            else:
+                commands = []
+
+        exist_mclag_facts = self.get_mclag_facts()
+        have_new = exist_mclag_facts
+        diff_new = get_diff(want, have_new)
+
+        if diff_new:
+            requests = self.get_create_mclag_request(want, diff_new)
             if len(requests) > 0:
                 commands = update_states(diff, "replaced")
         return commands, requests
@@ -226,7 +239,8 @@ class Mclag(ConfigBase):
         commands = []
         requests = []
 
-        if not diff:
+        diff1 = get_diff(have, want)
+        if not diff and not diff1:
             return commands, requests
 
         requests = self.get_delete_all_mclag_domain_request(have)
@@ -240,7 +254,6 @@ class Mclag(ConfigBase):
         diff_new = get_diff(want, have_new)
 
         requests = self.get_create_mclag_request(want, diff_new)
-
         if len(requests) > 0:
             commands = update_states(diff, "overridden")
         return commands, requests

--- a/plugins/module_utils/network/sonic/config/mclag/mclag.py
+++ b/plugins/module_utils/network/sonic/config/mclag/mclag.py
@@ -202,17 +202,15 @@ class Mclag(ConfigBase):
         return commands, requests
 
     def _state_replaced(self, want, have, diff):
-        """ The command generator when state is merged
+        """ The command generator when state is replaced
 
         :rtype: A list
-        :returns: the commands necessary to merge the provided into
-                  the current configuration
+        :returns: the commands necessary to delete the existing configuration for
+                  the affected section and the commands to apply/merge the specified new
+                  configuration to replace the deleted configuration.
         """
         requests = []
         commands = []
-
-        if not diff:
-            return commands, requests
 
         replaced_cfg = get_replaced_config(want, have, TEST_KEYS)
         if replaced_cfg:

--- a/plugins/module_utils/network/sonic/config/mclag/mclag.py
+++ b/plugins/module_utils/network/sonic/config/mclag/mclag.py
@@ -210,22 +210,18 @@ class Mclag(ConfigBase):
         requests = []
         commands = []
 
-        diff1 = get_diff(have, want, TEST_KEYS, is_skeleton=True)
-        if diff1:
-            requests = self.get_delete_all_mclag_domain_request(have)
-            if len(requests) > 0:
-                send_requests(self._module, requests)
-            else:
-                commands = []
+        if not diff:
+            return commands, requests
 
-        exist_mclag_facts = self.get_mclag_facts()
-        have_new = exist_mclag_facts
-        diff_new = get_diff(want, have_new)
+        requests = self.get_delete_mclag_attribute_request(want, diff)
+        if len(requests) > 0:
+            send_requests(self._module, requests)
+        else:
+            commands = []
 
-        if diff_new:
-            requests = self.get_create_mclag_request(want, diff_new)
-            if len(requests) > 0:
-                commands = update_states(diff, "replaced")
+        requests = self.get_create_mclag_request(want, diff)
+        if len(requests) > 0:
+            commands = update_states(diff, "replaced")
         return commands, requests
 
     def _state_overridden(self, want, have, diff):
@@ -249,11 +245,7 @@ class Mclag(ConfigBase):
         else:
             commands = []
 
-        exist_mclag_facts = self.get_mclag_facts()
-        have_new = exist_mclag_facts
-        diff_new = get_diff(want, have_new)
-
-        requests = self.get_create_mclag_request(want, diff_new)
+        requests = self.get_create_mclag_request(want, want)
         if len(requests) > 0:
             commands = update_states(diff, "overridden")
         return commands, requests

--- a/plugins/module_utils/network/sonic/config/mclag/mclag.py
+++ b/plugins/module_utils/network/sonic/config/mclag/mclag.py
@@ -212,7 +212,9 @@ class Mclag(ConfigBase):
         requests = []
         commands = []
 
-        replaced_cfg = get_replaced_config(want, have, TEST_KEYS)
+        new_want = self.remove_default_entries(want)
+        new_have = self.remove_default_entries(have)
+        replaced_cfg = get_replaced_config(new_want, new_have, TEST_KEYS)
         if replaced_cfg:
             del_requests = self.get_delete_mclag_attribute_request(want, replaced_cfg)
             requests.extend(del_requests)

--- a/plugins/modules/sonic_mclag.py
+++ b/plugins/modules/sonic_mclag.py
@@ -129,6 +129,8 @@ options:
     choices:
       - merged
       - deleted
+      - replaced
+      - overridden
     default: merged
 """
 EXAMPLES = """
@@ -565,6 +567,224 @@ EXAMPLES = """
 # sonic#
 # sonic# show mclag peer-gateway-interfaces
 # MCLAG Peer Gateway interface not configured
+# sonic#
+
+# Using replaced
+#
+# Before state:
+# ------------
+#
+# sonic# show mclag brief
+#
+# Domain ID            : 1
+# Role                 : standby
+# Session Status       : down
+# Peer Link Status     : down
+# Source Address       : 2.2.2.2
+# Peer Address         : 1.1.1.1
+# Peer Link            : PortChannel1
+# Keepalive Interval   : 1 secs
+# Session Timeout      : 3 secs
+# Delay Restore        : 240 secs
+# System Mac           : 20:04:0f:37:bd:c9
+# Mclag System Mac     : 00:00:00:11:11:11
+# Gateway Mac          : 00:00:00:12:12:12
+#
+#
+# Number of MLAG Interfaces:1
+#-----------------------------------------------------------
+# MLAG Interface       Local/Remote Status
+#-----------------------------------------------------------
+# PortChannel10            down/down
+#
+# sonic# show mclag separate-ip-interfaces
+# Interface Name
+# ==============
+# Vlan4
+# ==============
+# Total count :    1
+# ==============
+# sonic#
+# sonic# show mclag peer-gateway-interfaces
+# Interface Name
+# ==============
+# Vlan4
+# ==============
+# Total count :    1
+# ==============
+# sonic#
+
+- name: Replace device configuration with the provided configuration
+  dellemc.enterprise_sonic.sonic_mclag:
+    config:
+      domain_id: 1
+      source_address: 3.3.3.3
+      keepalive: 10
+      session_timeout: 30
+      delay_restore: 360
+      unique_ip:
+        vlans:
+          - vlan: Vlan5
+      peer_gateway:
+        vlans:
+          - vlan: Vlan5
+      members:
+        portchannels:
+          - lag: PortChannel12
+    state: replaced
+
+# After state:
+# ------------
+#
+# sonic# show mclag brief
+#
+# Domain ID            : 1
+# Role                 : standby
+# Session Status       : down
+# Peer Link Status     : down
+# Source Address       : 3.3.3.3
+# Peer Address         : 1.1.1.1
+# Peer Link            : PortChannel1
+# Keepalive Interval   : 10 secs
+# Session Timeout      : 30 secs
+# Delay Restore        : 360 secs
+# System Mac           : 20:04:0f:37:bd:c9
+# Mclag System Mac     : 00:00:00:11:11:11
+# Gateway Mac          : 00:00:00:12:12:12
+#
+#
+# Number of MLAG Interfaces:2
+#-----------------------------------------------------------
+# MLAG Interface       Local/Remote Status
+#-----------------------------------------------------------
+# PortChannel10            down/down
+# PortChannel12            down/down
+#
+# sonic# show mclag separate-ip-interfaces
+# Interface Name
+# ==============
+# Vlan4
+# Vlan5
+# ==============
+# Total count :    2
+# ==============
+# sonic# show mclag peer-gateway-interfaces
+# Interface Name
+# ==============
+# Vlan4
+# Vlan5
+# ==============
+# Total count :    2
+# ==============
+# sonic#
+
+
+# Using overridden
+#
+# Before state:
+# ------------
+#
+# sonic# show mclag brief
+#
+# Domain ID            : 1
+# Role                 : standby
+# Session Status       : down
+# Peer Link Status     : down
+# Source Address       : 2.2.2.2
+# Peer Address         : 1.1.1.1
+# Peer Link            : PortChannel1
+# Keepalive Interval   : 1 secs
+# Session Timeout      : 3 secs
+# Delay Restore        : 240 secs
+# System Mac           : 20:04:0f:37:bd:c9
+# Mclag System Mac     : 00:00:00:11:11:11
+# Gateway Mac          : 00:00:00:12:12:12
+#
+#
+# Number of MLAG Interfaces:1
+#-----------------------------------------------------------
+# MLAG Interface       Local/Remote Status
+#-----------------------------------------------------------
+# PortChannel10            down/down
+#
+# sonic# show mclag separate-ip-interfaces
+# Interface Name
+# ==============
+# Vlan4
+# ==============
+# Total count :    1
+# ==============
+# sonic#
+# sonic# show mclag peer-gateway-interfaces
+# Interface Name
+# ==============
+# Vlan4
+# ==============
+# Total count :    1
+# ==============
+# sonic#
+
+- name: Overridden device configuration with the provided configuration
+  dellemc.enterprise_sonic.sonic_mclag:
+    config:
+      domain_id: 10
+      source_address: 3.3.3.3
+      keepalive: 10
+      session_timeout: 30
+      delay_restore: 360
+      unique_ip:
+        vlans:
+          - vlan: Vlan5
+      peer_gateway:
+        vlans:
+          - vlan: Vlan5
+      members:
+        portchannels:
+          - lag: PortChannel12
+      system_mac: '00:00:00:21:21:21'
+      gateway_mac: '00:00:00:22:22:22'
+    state: overridden
+
+# After state:
+# ------------
+#
+# sonic# show mclag brief
+#
+# Domain ID            : 10
+# Role                 : standby
+# Session Status       : down
+# Peer Link Status     : down
+# Source Address       : 3.3.3.3
+# Peer Address         : 2.2.2.2
+# Peer Link            : PortChannel12
+# Keepalive Interval   : 10 secs
+# Session Timeout      : 30 secs
+# Delay Restore        : 360 secs
+# System Mac           : 20:04:0f:37:bd:c9
+# Mclag System Mac     : 00:00:00:21:21:21
+# Gateway Mac          : 00:00:00:22:22:22
+#
+#
+# Number of MLAG Interfaces:1
+#-----------------------------------------------------------
+# MLAG Interface       Local/Remote Status
+#-----------------------------------------------------------
+# PortChannel12            down/down
+#
+# sonic# show mclag separate-ip-interfaces
+# Interface Name
+# ==============
+# Vlan5
+# ==============
+# Total count :
+# ==============
+# sonic# show mclag peer-gateway-interfaces
+# Interface Name
+# ==============
+# Vlan5
+# ==============
+# Total count :
+# ==============
 # sonic#
 """
 RETURN = """

--- a/tests/regression/roles/sonic_mclag/defaults/main.yml
+++ b/tests/regression/roles/sonic_mclag/defaults/main.yml
@@ -151,27 +151,36 @@ replaced_overridden_tests:
           - lag: Po13
 
   - name: test_case_07
-    description: Replace MCLAG with all properties including vlans and portchannels
+    description: Replace MCLAG properties unique_ip and gateway vlans
     state: replaced
     input:
       domain_id: 2
-      source_address: 3.3.3.3
-      peer_address: 1.1.1.1
-      peer_link: "{{ interface3 }}"
-      keepalive: 30
-      session_timeout: 200
-      delay_restore: 400
       unique_ip:
         vlans:
           - vlan: vlan6
+          - vlan: vlan4
+          - vlan: vlan5
       peer_gateway:
         vlans:
           - vlan: vlan6
-      members:
-        portchannels:
-          - lag: Po12
+          - vlan: vlan4
+          - vlan: vlan5
 
   - name: test_case_08
+    description: Replace MCLAG properties
+    state: replaced
+    input:
+      domain_id: 2
+      source_address: 3.3.3.5
+      peer_address: 1.1.1.3
+      peer_link: "{{ interface3 }}"
+      keepalive: 3
+      session_timeout: 300
+      delay_restore: 450
+      system_mac: 00:00:00:01:01:01
+      gateway_mac: 00:00:00:03:03:03
+
+  - name: test_case_09
     description: Overridden MCLAG with all properties including vlans and portchannels
     state: overridden
     input:

--- a/tests/regression/roles/sonic_mclag/defaults/main.yml
+++ b/tests/regression/roles/sonic_mclag/defaults/main.yml
@@ -125,3 +125,74 @@ updated_tests:
         vlans:
       members:
         portchannels:
+
+replaced_overridden_tests:
+  - name: test_case_06
+    description: Create new MCLAG with all properties including vlans and portchannels
+    state: merged
+    input:
+      domain_id: 2
+      source_address: 3.3.3.5
+      peer_address: 1.1.1.3
+      peer_link: "{{ interface3 }}"
+      keepalive: 3
+      session_timeout: 300
+      delay_restore: 450
+      system_mac: 00:00:00:01:01:01
+      gateway_mac: 00:00:00:03:03:03
+      unique_ip:
+        vlans:
+          - vlan: vlan2
+      peer_gateway:
+        vlans:
+          - vlan: vlan2
+      members:
+        portchannels:
+          - lag: Po13
+
+  - name: test_case_07
+    description: Replace MCLAG with all properties including vlans and portchannels
+    state: replaced
+    input:
+      domain_id: 2
+      source_address: 3.3.3.3
+      peer_address: 1.1.1.1
+      peer_link: "{{ interface3 }}"
+      keepalive: 30
+      session_timeout: 200
+      delay_restore: 400
+      unique_ip:
+        vlans:
+          - vlan: vlan6
+      peer_gateway:
+        vlans:
+          - vlan: vlan6
+      members:
+        portchannels:
+          - lag: Po12
+
+  - name: test_case_08
+    description: Overridden MCLAG with all properties including vlans and portchannels
+    state: overridden
+    input:
+      domain_id: 20
+      source_address: 3.3.3.5
+      peer_address: 1.1.1.5
+      peer_link: "{{ interface3 }}"
+      keepalive: 30
+      session_timeout: 250
+      delay_restore: 450
+      unique_ip:
+        vlans:
+          - vlan: vlan2
+      peer_gateway:
+        vlans:
+          - vlan: vlan2
+      members:
+        portchannels:
+          - lag: Po13
+
+delete_all_mclag:
+  - name: del_all_test_case_02
+    description: Delete MCLAG properties
+    state: deleted

--- a/tests/regression/roles/sonic_mclag/tasks/main.yml
+++ b/tests/regression/roles/sonic_mclag/tasks/main.yml
@@ -16,6 +16,15 @@
   include_tasks: tasks_template.yaml
   loop: "{{ updated_tests }}"
 
+- name: "Test {{ module_name }} started ..."
+  include_tasks: tasks_template.yaml
+  loop: "{{ replaced_overridden_tests }}"
+
+- name: "delete_all_mclag {{ module_name }} stated ..."
+  include_tasks: tasks_template_del.yaml
+  loop: "{{ delete_all_mclag }}"
+  when: delete_all_mclag is defined
+
 - name: Cleanup test
   include_tasks: cleanup_tests.yaml
 


### PR DESCRIPTION
##### SUMMARY
"overridden" and  "replaced" states  support for MCLAG module

##### COMPONENT NAME
mclag

##### OUTPUT
Test execution log -  
[MCLAG_Execution_LOG.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11768429/MCLAG_Execution_LOG.txt)

MCLAG regression report -  

[MCLAG_regression-2023-06-16-14-27-40.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11768438/MCLAG_regression-2023-06-16-14-27-40.pdf)
