### PR TITLE
dhcp_relay - Add support for 'replaced' and 'overridden' states

### DIFF
--- a/changelogs/fragments/248-dhcp-relay-replaced-overridden-support.yaml
+++ b/changelogs/fragments/248-dhcp-relay-replaced-overridden-support.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - sonic_dhcp_relay - Add support for replaced and overridden states (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/248).

--- a/changelogs/fragments/248-dhcp-relay-replaced-overridden-support.yaml
+++ b/changelogs/fragments/248-dhcp-relay-replaced-overridden-support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sonic_dhcp_relay - Add support for replaced and overridden states (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/248).

--- a/changelogs/fragments/249-dhcp-relay-replaced-overridden-support.yaml
+++ b/changelogs/fragments/249-dhcp-relay-replaced-overridden-support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sonic_dhcp_relay - Add support for replaced and overridden states (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/249).

--- a/plugins/module_utils/network/sonic/argspec/dhcp_relay/dhcp_relay.py
+++ b/plugins/module_utils/network/sonic/argspec/dhcp_relay/dhcp_relay.py
@@ -87,7 +87,7 @@ class Dhcp_relayArgs(object):  # pylint: disable=R0903
             'type': 'list'
         },
         'state': {
-            'choices': ['merged', 'deleted'],
+            'choices': ['merged', 'deleted', 'replaced', 'overridden'],
             'default': 'merged',
             'type': 'str'
         }

--- a/plugins/module_utils/network/sonic/facts/dhcp_relay/dhcp_relay.py
+++ b/plugins/module_utils/network/sonic/facts/dhcp_relay/dhcp_relay.py
@@ -86,7 +86,7 @@ class Dhcp_relayFacts(object):
         facts = {}
         if objs:
             params = utils.validate_config(self.argument_spec, {'config': objs})
-            facts['dhcp_relay'] = params['config']
+            facts['dhcp_relay'] = utils.remove_empties({'config': params['config']})['config']
 
         ansible_facts['ansible_network_resources'].update(facts)
         return ansible_facts
@@ -113,14 +113,18 @@ class Dhcp_relayFacts(object):
             ipv4_dict['vrf_select'] = SELECT_VALUE_TO_BOOL.get(ipv4_dict['vrf_select'])
 
             config['ipv4'] = ipv4_dict
+        else:
+            config.pop('ipv4')
 
         if conf[1].get('ipv6'):
             ipv6_dict = conf[1]['ipv6']
             ipv6_dict['vrf_select'] = SELECT_VALUE_TO_BOOL.get(ipv6_dict['vrf_select'])
 
             config['ipv6'] = ipv6_dict
+        else:
+            config.pop('ipv6')
 
-        return utils.remove_empties(config)
+        return config
 
     def get_dhcp_relay(self):
         """Get all DHCP relay configurations available in chassis"""

--- a/tests/regression/roles/sonic_dhcp_relay/defaults/main.yml
+++ b/tests/regression/roles/sonic_dhcp_relay/defaults/main.yml
@@ -226,6 +226,125 @@ tests:
       - name: '{{ po2 }}'
 
   - name: test_case_10
+    description: Add DHCP and DHCPv6 relay configuration for replace
+    state: merged
+    input:
+      - name: '{{ interface1 }}'
+        ipv4:
+          server_addresses:
+            - address: 100.1.1.2
+            - address: 100.1.1.3
+          vrf_name: '{{ vrf1 }}'
+          vrf_select: true
+          source_interface: '{{ vlan2 }}'
+          link_select: true
+          max_hop_count: 8
+          policy_action: 'replace'
+        ipv6:
+          server_addresses:
+            - address: 100::2
+            - address: 100::3
+          vrf_name: '{{ vrf2 }}'
+          vrf_select: true
+          source_interface: '{{ vlan2 }}'
+          max_hop_count: 8
+      - name: '{{ interface2 }}'
+        ipv4:
+          server_addresses:
+            - address: 101.1.1.2
+            - address: 101.1.1.3
+          vrf_name: '{{ vrf1 }}'
+          circuit_id: '%h:%p'
+          max_hop_count: 8
+        ipv6:
+          server_addresses:
+            - address: 101::2
+            - address: 101::3
+          vrf_name: '{{ vrf2 }}'
+          max_hop_count: 8
+      - name: '{{ po1 }}'
+        ipv4:
+          server_addresses:
+            - address: 120.1.1.2
+            - address: 120.1.1.3
+          source_interface: '{{ vlan2 }}'
+          link_select: false
+          circuit_id: '%p'
+          max_hop_count: 8
+
+  - name: test_case_11
+    description: Replace DHCP and DHCPv6 relay configurations
+    state: replaced
+    input:
+      - name: '{{ interface1 }}'
+        ipv4:
+          server_addresses:
+            - address: 100.1.1.2
+            - address: 100.1.1.3
+          vrf_name: '{{ vrf2 }}'
+          vrf_select: true
+          source_interface: '{{ vlan2 }}'
+          max_hop_count: 8
+          policy_action: 'append'
+        ipv6:
+          server_addresses:
+            - address: 100::2
+            - address: 100::4
+            - address: 100::6
+          vrf_name: '{{ vrf2 }}'
+          vrf_select: true
+      - name: '{{ interface2 }}'
+        ipv4:
+          server_addresses:
+            - address: 101.1.1.2
+            - address: 101.1.1.4
+            - address: 101.1.1.6
+          circuit_id: '%h:%p'
+          max_hop_count: 8
+        ipv6:
+          server_addresses:
+            - address: 101::2
+            - address: 101::3
+          max_hop_count: 8
+      - name: '{{ po2 }}'
+        ipv4:
+          server_addresses:
+            - address: 120.1.1.2
+            - address: 120.1.1.3
+          source_interface: '{{ vlan2 }}'
+          link_select: false
+          circuit_id: '%p'
+          max_hop_count: 8
+
+  - name: test_case_12
+    description: Override DHCP and DHCPv6 relay configurations
+    state: overridden
+    input:
+      - name: '{{ interface1 }}'
+        ipv4:
+          server_addresses:
+            - address: 100.1.1.10
+            - address: 100.1.1.11
+          vrf_name: '{{ vrf2 }}'
+          vrf_select: true
+          source_interface: '{{ vlan2 }}'
+          max_hop_count: 12
+          policy_action: 'replace'
+      - name: '{{ interface2 }}'
+        ipv6:
+          server_addresses:
+            - address: 101::20
+            - address: 101::30
+          max_hop_count: 8
+      - name: '{{ po2 }}'
+        ipv6:
+          server_addresses:
+            - address: 121::2
+            - address: 121::3
+          source_interface: '{{ vlan2 }}'
+          max_hop_count: 8
+
+  - name: test_case_13
     description: Delete all DHCP and DHCPv6 relay configurations
     state: deleted
     input: []

--- a/tests/unit/modules/network/sonic/fixtures/sonic_dhcp_relay.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_dhcp_relay.yaml
@@ -276,8 +276,8 @@ deleted_01:
                   config:
                     id: 'Eth1/3'
                     helper-address:
-                      - '101.1.1.2'
-                      - '101.1.1.3'
+                      - '102::2'
+                      - '102::3'
                     openconfig-relay-agent-ext:max-hop-count: 12
                   options:
                     config:
@@ -412,8 +412,8 @@ deleted_02:
                   config:
                     id: 'Eth1/3'
                     helper-address:
-                      - '101.1.1.2'
-                      - '101.1.1.3'
+                      - '102::2'
+                      - '102::3'
                     openconfig-relay-agent-ext:max-hop-count: 10
                   options:
                     config:
@@ -505,3 +505,413 @@ deleted_04:
         code: 200
         value: {}
   config_requests: []
+replaced_01:
+  module_args:
+    config:
+      - name: 'Eth1/1'
+        ipv4:
+          server_addresses:
+            - address: '100.1.1.2'
+            - address: '100.1.1.3'
+          source_interface: 'Vlan100'
+          policy_action: 'append'
+        ipv6:
+          server_addresses:
+            - address: '100::2'
+            - address: '100::3'
+      - name: 'Eth1/2'
+        ipv4:
+          server_addresses:
+            - address: '101.1.1.2'
+            - address: '101.1.1.4'
+            - address: '101.1.1.6'
+          vrf_name: 'VrfReg2'
+          vrf_select: false
+          max_hop_count: 10
+      - name: 'Eth1/3'
+        ipv6:
+          server_addresses:
+            - address: '102::2'
+            - address: '102::4'
+            - address: '102::6'
+          vrf_name: 'VrfReg2'
+          vrf_select: false
+    state: replaced
+  facts_get_requests:
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp"
+      response:
+        code: 200
+        value:
+          openconfig-relay-agent:dhcp:
+            interfaces:
+              interface:
+                - id: 'Eth1/1'
+                  config:
+                    id: 'Eth1/1'
+                    helper-address:
+                      - '100.1.1.2'
+                      - '100.1.1.3'
+                    openconfig-relay-agent-ext:src-intf: 'Vlan100'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 8
+                    openconfig-relay-agent-ext:policy-action: 'REPLACE'
+                  agent-information-option:
+                    config:
+                      circuit-id: '%i'
+                      openconfig-relay-agent-ext:vrf-select: 'ENABLE'
+                      openconfig-relay-agent-ext:link-select: 'ENABLE'
+                - id: 'Eth1/2'
+                  config:
+                    id: 'Eth1/2'
+                    helper-address:
+                      - '101.1.1.2'
+                      - '101.1.1.3'
+                    openconfig-relay-agent-ext:src-intf: 'Vlan100'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 8
+                    openconfig-relay-agent-ext:policy-action: 'DISCARD'
+                  agent-information-option:
+                    config:
+                      circuit-id: '%i'
+                      openconfig-relay-agent-ext:vrf-select: 'ENABLE'
+                      openconfig-relay-agent-ext:link-select: 'ENABLE'
+                - id: 'Eth1/3'
+                  config:
+                    id: 'Eth1/3'
+                    helper-address:
+                      - '102.1.1.2'
+                      - '102.1.1.3'
+                    openconfig-relay-agent-ext:max-hop-count: 10
+                    openconfig-relay-agent-ext:policy-action: 'DISCARD'
+                  agent-information-option:
+                    config:
+                      circuit-id: '%p'
+                      openconfig-relay-agent-ext:vrf-select: 'DISABLE'
+                      openconfig-relay-agent-ext:link-select: 'DISABLE'
+                - id: 'Eth1/4'
+                  config:
+                    id: 'Eth1/4'
+                    helper-address:
+                      - '103.1.1.2'
+                      - '103.1.1.3'
+                    openconfig-relay-agent-ext:max-hop-count: 10
+                    openconfig-relay-agent-ext:policy-action: 'DISCARD'
+                  agent-information-option:
+                    config:
+                      circuit-id: '%p'
+                      openconfig-relay-agent-ext:vrf-select: 'DISABLE'
+                      openconfig-relay-agent-ext:link-select: 'DISABLE'
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6"
+      response:
+        code: 200
+        value:
+          openconfig-relay-agent:dhcpv6:
+            interfaces:
+              interface:
+                - id: 'Eth1/1'
+                  config:
+                    id: 'Eth1/1'
+                    helper-address:
+                      - '100::2'
+                      - '100::3'
+                    openconfig-relay-agent-ext:src-intf: 'Vlan100'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 8
+                  options:
+                    config:
+                      openconfig-relay-agent-ext:vrf-select: 'ENABLE'
+                - id: 'Eth1/2'
+                  config:
+                    id: 'Eth1/2'
+                    helper-address:
+                      - '101::2'
+                      - '101::3'
+                    openconfig-relay-agent-ext:src-intf: 'Vlan100'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 8
+                  options:
+                    config:
+                      openconfig-relay-agent-ext:vrf-select: 'ENABLE'
+                - id: 'Eth1/3'
+                  config:
+                    id: 'Eth1/3'
+                    helper-address:
+                      - '102::2'
+                      - '102::3'
+                    openconfig-relay-agent-ext:src-intf: 'Vlan100'
+                    openconfig-relay-agent-ext:max-hop-count: 8
+                  options:
+                    config:
+                      openconfig-relay-agent-ext:vrf-select: 'ENABLE'
+  config_requests:
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f1/config/helper-address"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f1/config/helper-address"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/config/helper-address=101.1.1.3"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/config/openconfig-relay-agent-ext:src-intf"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/agent-information-option/config/openconfig-relay-agent-ext:link-select"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/agent-information-option/config/circuit-id"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f2/config/helper-address"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f3/config/helper-address"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f3/config/helper-address=102::3"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f3/config/openconfig-relay-agent-ext:src-intf"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f3/config/openconfig-relay-agent-ext:max-hop-count"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f1/config/helper-address"
+      method: "patch"
+      data:
+        openconfig-relay-agent:helper-address:
+          - '100.1.1.2'
+          - '100.1.1.3'
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f1/config/openconfig-relay-agent-ext:src-intf"
+      method: "patch"
+      data:
+        openconfig-relay-agent-ext:src-intf: "Vlan100"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f1/config/openconfig-relay-agent-ext:policy-action"
+      method: "patch"
+      data:
+        openconfig-relay-agent-ext:policy-action: "APPEND"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f1/config/helper-address"
+      method: "patch"
+      data:
+        openconfig-relay-agent:helper-address:
+          - '100::2'
+          - '100::3'
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/config/helper-address"
+      method: "patch"
+      data:
+        openconfig-relay-agent:helper-address:
+          - '101.1.1.4'
+          - '101.1.1.6'
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/config/openconfig-relay-agent-ext:vrf"
+      method: "patch"
+      data:
+        openconfig-relay-agent-ext:vrf: "VrfReg2"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/agent-information-option/config/openconfig-relay-agent-ext:vrf-select"
+      method: "patch"
+      data:
+        openconfig-relay-agent-ext:vrf-select: "DISABLE"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/config/openconfig-relay-agent-ext:max-hop-count"
+      method: "patch"
+      data:
+        openconfig-relay-agent-ext:max-hop-count: 10
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f3/config/helper-address"
+      method: "patch"
+      data:
+        openconfig-relay-agent:helper-address:
+          - '102::4'
+          - '102::6'
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f3/config/openconfig-relay-agent-ext:vrf"
+      method: "patch"
+      data:
+        openconfig-relay-agent-ext:vrf: "VrfReg2"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f3/options/config/openconfig-relay-agent-ext:vrf-select"
+      method: "patch"
+      data:
+        openconfig-relay-agent-ext:vrf-select: "DISABLE"
+replaced_02:
+  module_args:
+    config:
+      - name: 'Eth1/2'
+        ipv4:
+          server_addresses:
+            - address: '101.1.1.2'
+            - address: '101.1.1.4'
+          vrf_name: 'VrfReg1'
+          max_hop_count: 12
+      - name: 'Eth1/3'
+        ipv6:
+          server_addresses:
+            - address: '102::2'
+            - address: '102::4'
+          vrf_name: 'VrfReg1'
+    state: replaced
+  facts_get_requests:
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp"
+      response:
+        code: 200
+        value:
+          openconfig-relay-agent:dhcp:
+            interfaces:
+              interface:
+                - id: 'Eth1/1'
+                  config:
+                    id: 'Eth1/1'
+                    helper-address:
+                      - '100.1.1.2'
+                      - '100.1.1.3'
+                    openconfig-relay-agent-ext:src-intf: 'Vlan100'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 8
+                    openconfig-relay-agent-ext:policy-action: 'REPLACE'
+                  agent-information-option:
+                    config:
+                      circuit-id: '%i'
+                      openconfig-relay-agent-ext:vrf-select: 'ENABLE'
+                      openconfig-relay-agent-ext:link-select: 'ENABLE'
+                - id: 'Eth1/2'
+                  config:
+                    id: 'Eth1/2'
+                    helper-address:
+                      - '101.1.1.2'
+                      - '101.1.1.4'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 12
+                    openconfig-relay-agent-ext:policy-action: 'DISCARD'
+                  agent-information-option:
+                    config:
+                      circuit-id: '%p'
+                      openconfig-relay-agent-ext:vrf-select: 'DISABLE'
+                      openconfig-relay-agent-ext:link-select: 'DISABLE'
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6"
+      response:
+        code: 200
+        value:
+          openconfig-relay-agent:dhcpv6:
+            interfaces:
+              interface:
+                - id: 'Eth1/1'
+                  config:
+                    id: 'Eth1/1'
+                    helper-address:
+                      - '100::2'
+                      - '100::3'
+                    openconfig-relay-agent-ext:src-intf: 'Vlan100'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 8
+                  options:
+                    config:
+                      openconfig-relay-agent-ext:vrf-select: 'ENABLE'
+                - id: 'Eth1/3'
+                  config:
+                    id: 'Eth1/3'
+                    helper-address:
+                      - '102::2'
+                      - '102::4'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 10
+                  options:
+                    config:
+                      openconfig-relay-agent-ext:vrf-select: 'DISABLE'
+  config_requests: []
+overridden_01:
+  module_args:
+    config:
+      - name: 'Eth1/2'
+        ipv4:
+          server_addresses:
+            - address: '110.1.1.2'
+            - address: '110.1.1.3'
+          vrf_name: 'VrfReg1'
+      - name: 'Eth1/3'
+        ipv6:
+          server_addresses:
+            - address: '120::2'
+            - address: '120::3'
+          vrf_name: 'VrfReg1'
+    state: overridden
+  facts_get_requests:
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp"
+      response:
+        code: 200
+        value:
+          openconfig-relay-agent:dhcp:
+            interfaces:
+              interface:
+                - id: 'Eth1/1'
+                  config:
+                    id: 'Eth1/1'
+                    helper-address:
+                      - '100.1.1.2'
+                      - '100.1.1.3'
+                    openconfig-relay-agent-ext:src-intf: 'Vlan100'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 8
+                    openconfig-relay-agent-ext:policy-action: 'REPLACE'
+                  agent-information-option:
+                    config:
+                      circuit-id: '%i'
+                      openconfig-relay-agent-ext:vrf-select: 'ENABLE'
+                      openconfig-relay-agent-ext:link-select: 'ENABLE'
+                - id: 'Eth1/2'
+                  config:
+                    id: 'Eth1/2'
+                    helper-address:
+                      - '101.1.1.2'
+                      - '101.1.1.4'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 12
+                    openconfig-relay-agent-ext:policy-action: 'DISCARD'
+                  agent-information-option:
+                    config:
+                      circuit-id: '%p'
+                      openconfig-relay-agent-ext:vrf-select: 'DISABLE'
+                      openconfig-relay-agent-ext:link-select: 'DISABLE'
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6"
+      response:
+        code: 200
+        value:
+          openconfig-relay-agent:dhcpv6:
+            interfaces:
+              interface:
+                - id: 'Eth1/1'
+                  config:
+                    id: 'Eth1/1'
+                    helper-address:
+                      - '100::2'
+                      - '100::3'
+                    openconfig-relay-agent-ext:src-intf: 'Vlan100'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 8
+                  options:
+                    config:
+                      openconfig-relay-agent-ext:vrf-select: 'ENABLE'
+                - id: 'Eth1/3'
+                  config:
+                    id: 'Eth1/3'
+                    helper-address:
+                      - '102::2'
+                      - '102::4'
+                    openconfig-relay-agent-ext:vrf: 'VrfReg1'
+                    openconfig-relay-agent-ext:max-hop-count: 10
+                  options:
+                    config:
+                      openconfig-relay-agent-ext:vrf-select: 'DISABLE'
+  config_requests:
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f1/config/helper-address"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f1/config/helper-address"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/config/helper-address"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f3/config/helper-address"
+      method: "delete"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/config/helper-address"
+      method: "patch"
+      data:
+        openconfig-relay-agent:helper-address:
+          - '110.1.1.2'
+          - '110.1.1.3'
+    - path: "data/openconfig-relay-agent:relay-agent/dhcp/interfaces/interface=Eth1%2f2/config/openconfig-relay-agent-ext:vrf"
+      method: "patch"
+      data:
+        openconfig-relay-agent-ext:vrf: "VrfReg1"
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f3/config/helper-address"
+      method: "patch"
+      data:
+        openconfig-relay-agent:helper-address:
+          - '120::2'
+          - '120::3'
+    - path: "data/openconfig-relay-agent:relay-agent/dhcpv6/interfaces/interface=Eth1%2f3/config/openconfig-relay-agent-ext:vrf"
+      method: "patch"
+      data:
+        openconfig-relay-agent-ext:vrf: "VrfReg1"

--- a/tests/unit/modules/network/sonic/test_sonic_dhcp_relay.py
+++ b/tests/unit/modules/network/sonic/test_sonic_dhcp_relay.py
@@ -94,3 +94,27 @@ class TestSonicDhcpRelayModule(TestSonicModule):
 
         result = self.execute_module(changed=False)
         self.validate_config_requests()
+
+    def test_sonic_dhcp_relay_replaced_01(self):
+        set_module_args(self.fixture_data['replaced_01']['module_args'])
+        self.initialize_facts_get_requests(self.fixture_data['replaced_01']['facts_get_requests'])
+        self.initialize_config_requests(self.fixture_data['replaced_01']['config_requests'])
+
+        result = self.execute_module(changed=True)
+        self.validate_config_requests()
+
+    def test_sonic_dhcp_relay_replaced_02(self):
+        set_module_args(self.fixture_data['replaced_02']['module_args'])
+        self.initialize_facts_get_requests(self.fixture_data['replaced_02']['facts_get_requests'])
+        self.initialize_config_requests(self.fixture_data['replaced_02']['config_requests'])
+
+        result = self.execute_module(changed=False)
+        self.validate_config_requests()
+
+    def test_sonic_dhcp_relay_overridden_01(self):
+        set_module_args(self.fixture_data['overridden_01']['module_args'])
+        self.initialize_facts_get_requests(self.fixture_data['overridden_01']['facts_get_requests'])
+        self.initialize_config_requests(self.fixture_data['overridden_01']['config_requests'])
+
+        result = self.execute_module(changed=True)
+        self.validate_config_requests()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Add support for replaced, overridden states in `dhcp_relay` module.
- Add regression and unit test cases to cover replaced and overridden states.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| N/A  |


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- sonic_dhcp_relay

##### OUTPUT
<!--- Paste the functionality test result below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
- Regression test HTML report:
[dhcp_relay_regression_report.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11344375/dhcp_relay_regression_report.pdf)

- Regression test detailed log:
[dhcp_relay_regression_terminal_output.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11344379/dhcp_relay_regression_terminal_output.txt)
