### PR TITLE
bgp_as_paths - Fix issues in merged and deleted states

### DIFF
--- a/changelogs/fragments/250-bgp-as-paths-fix-merged-deleted.yaml
+++ b/changelogs/fragments/250-bgp-as-paths-fix-merged-deleted.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_bgp_as_paths - Fix issues with merged and deleted states (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/250)

--- a/plugins/module_utils/network/sonic/facts/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_as_paths/bgp_as_paths.py
@@ -72,8 +72,6 @@ class Bgp_as_pathsFacts(object):
             else:
                 result['permit'] = False
             as_path_list_configs.append(result)
-        # with open('/root/ansible_log.log', 'a+') as fp:
-        #     fp.write('as_path_list: ' + str(as_path_list_configs) + '\n')
         return as_path_list_configs
 
     def populate_facts(self, connection, ansible_facts, data=None):

--- a/plugins/modules/sonic_bgp_as_paths.py
+++ b/plugins/modules/sonic_bgp_as_paths.py
@@ -62,7 +62,8 @@ options:
         required: False
         type: bool
         description:
-        - Permits or denies this as path.
+        - Permits or denies this as-path.
+        - Default value while adding a new as-path-list is C(False).
   state:
     description:
     - The state of the configuration after module completion.
@@ -97,7 +98,7 @@ EXAMPLES = """
 #
 # show bgp as-path-access-list
 # AS path list test:
-#   action:
+#   action: permit
 #   members: 808.*
 
 

--- a/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
@@ -7,7 +7,7 @@ bgp_as_2: 52
 
 vrf_1: VrfReg1
 vrf_2: VrfReg2
-    
+
 tests:
   - name: test_case_01
     description: BGP properties
@@ -40,10 +40,11 @@ tests:
           permit: False
         - name: test_2
           members:
-            - '111\\:'
-            - '11\\d+'
-            - '113\\*'
-            - '114\\'
+            - "110"
+            - "111*"
+            - "112*"
+            - "^113"
+            - "45$"
           permit: True
   - name: test_case_03
     description: Delete BGP properties
@@ -60,10 +61,10 @@ tests:
           permit: False
         - name: test_2
           members:
-            - '111\\:'
-            - '11\\d+'
-            - '113\\*'
-            - '114\\'
+            - "111*"
+            - "112*"
+            - "^113"
+            - "45$"
           permit: True
   - name: test_case_04
     description: Delete BGP properties

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_as_paths.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_as_paths.yaml
@@ -6,6 +6,12 @@ merged_01:
         members:
         - 909.*
         permit: true
+      - name: test_1
+        members:
+        - 908.*
+      - name: test_2
+        members:
+        - 907.*
   existing_bgp_config:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/global"
       response:
@@ -23,6 +29,15 @@ merged_01:
     - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
       response:
         code: 200
+        value:
+          openconfig-bgp-policy:as-path-sets:
+            as-path-set:
+              - as-path-set-name: 'test_2'
+                config:
+                  as-path-set-name: 'test_2'
+                  as-path-set-member:
+                    - 800.*
+                  openconfig-bgp-policy-ext:action: 'PERMIT'
   expected_config_requests:
     - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
       method: "patch"
@@ -35,12 +50,39 @@ merged_01:
                 as-path-set-member:
                   - 909.*
                 openconfig-bgp-policy-ext:action: 'PERMIT'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_1'
+              config:
+                as-path-set-name: 'test_1'
+                as-path-set-member:
+                  - 908.*
+                openconfig-bgp-policy-ext:action: 'DENY'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_2'
+              config:
+                as-path-set-name: 'test_2'
+                as-path-set-member:
+                  - 907.*
+                openconfig-bgp-policy-ext:action: 'PERMIT'
+
 deleted_01:
   module_args:
     config:
       - name: test
         members:
         - 808.*
+        permit: true
+      - name: test_1
+        members:
+        - 807.*
         permit: true
     state: deleted
   existing_bgp_config:
@@ -56,6 +98,13 @@ deleted_01:
                   as-path-set-member:
                     - 808.*
                   openconfig-bgp-policy-ext:action: 'PERMIT'
+              - as-path-set-name: 'test_1'
+                config:
+                  as-path-set-name: 'test_1'
+                  as-path-set-member:
+                    - 806.*
+                    - 807.*
+                  openconfig-bgp-policy-ext:action: 'PERMIT'
     - path: "data/sonic-vrf:sonic-vrf/VRF/VRF_LIST"
       response:
         code: 200
@@ -63,7 +112,9 @@ deleted_01:
           sonic-vrf:VRF_LIST:
             - vrf_name: default
   expected_config_requests:
-    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test/config/as-path-set-member=808.%2A"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_1/config/as-path-set-member=807.%2A"
       method: "delete"
 
 deleted_02:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Incorporate the below fixes in bgp_as_paths:
- In merged, do not overwrite the action of an existing as-path-list.
- In deleted, delete the as-path-list if all members in it are to be deleted.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
|  N/A |


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- sonic_bgp_as_paths

##### OUTPUT
<!--- Paste the functionality test result below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?

- Regression test HTML report:
[bgp_as_paths _regression_report.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11354338/bgp_as_paths._regression_report.pdf)

- Regression test detailed log:
[bgp_as_paths_regression_terminal_output.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11354333/bgp_as_paths_regression_terminal_output.txt)