### PR TITLE
Removed repetitive get_diff call in replace function

### DIFF
--- a/plugins/module_utils/network/sonic/config/bfd/bfd.py
+++ b/plugins/module_utils/network/sonic/config/bfd/bfd.py
@@ -137,10 +137,10 @@ class Bfd(ConfigBase):
         elif state == 'merged':
             commands, requests = self._state_merged(diff)
         elif state == 'replaced':
-            commands, requests = self._state_replaced(want, have)
+            commands, requests = self._state_replaced(want, have, diff)
         return commands, requests
 
-    def _state_replaced(self, want, have):
+    def _state_replaced(self, want, have, diff):
         """ The command generator when state is replaced
         :rtype: A list
         :returns: the commands necessary to migrate the current configuration
@@ -157,7 +157,6 @@ class Bfd(ConfigBase):
 
             commands = want
         else:
-            diff = get_diff(want, have, TEST_KEYS)
             commands = diff
 
         requests = []

--- a/plugins/module_utils/network/sonic/config/copp/copp.py
+++ b/plugins/module_utils/network/sonic/config/copp/copp.py
@@ -162,10 +162,10 @@ class Copp(ConfigBase):
         elif state == 'merged':
             commands, requests = self._state_merged(diff)
         elif state == 'replaced':
-            commands, requests = self._state_replaced(want, have)
+            commands, requests = self._state_replaced(want, have, diff)
         return commands, requests
 
-    def _state_replaced(self, want, have):
+    def _state_replaced(self, want, have, diff):
         """ The command generator when state is replaced
         :rtype: A list
         :returns: the commands necessary to migrate the current configuration
@@ -180,7 +180,6 @@ class Copp(ConfigBase):
 
             commands = want
         else:
-            diff = get_diff(want, have, TEST_KEYS)
             commands = diff
 
         requests = []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I removed repetitive get diff call in replaced for bfd and copp modules.

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_bfd
sonic_copp

##### OUTPUT
<!--- Paste the functionality test result below -->
[regression-2023-05-03-11-35-12.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11389957/regression-2023-05-03-11-35-12.html.pdf)


##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [ ] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)