### PR TITLE
Fixed failing CLI test case for vrfs module

### DIFF
--- a/tests/regression/roles/sonic_vrfs/templates/cli_test_case_01.cfg
+++ b/tests/regression/roles/sonic_vrfs/templates/cli_test_case_01.cfg
@@ -4,7 +4,7 @@ interface Vlan100
  ip vrf forwarding VrfReg1
 interface Loopback 100
  ip vrf forwarding VrfReg1
-interface PortChannel 100
+interface PortChannel100
  ip vrf forwarding VrfReg1
 interface {{ interface1 }}
  ip vrf forwarding VrfReg1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I removed the space between the PortChannel and ID that was causing the CLI test case to fail


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_vrfs

##### OUTPUT
[regression-2023-05-09-13-08-56.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11435751/regression-2023-05-09-13-08-56.html.pdf)


##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [ ] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)
