### PR TITLE
Increased command timeout for interfaces test cases

### DIFF
--- a/changelogs/fragments/257-vrfs-cli-test-case-fix.yaml
+++ b/changelogs/fragments/257-vrfs-cli-test-case-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sonic_vrfs - Fixed spacing issue in CLI test case (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/257)

--- a/changelogs/fragments/260-interfaces-timeout-fix.yaml
+++ b/changelogs/fragments/260-interfaces-timeout-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sonic_interfaces - Fixed command timeout issue (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/260)

--- a/tests/regression/roles/sonic_interfaces/tasks/tasks_template.yaml
+++ b/tests/regression/roles/sonic_interfaces/tasks/tasks_template.yaml
@@ -15,6 +15,8 @@
     state: "{{ item.state }}"
   register: idempotent_task_output
   ignore_errors: yes
+  vars:
+    ansible_command_timeout: 60
   
 - import_role:
     name: common


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Increased the command timeout in the task template for the interfaces test cases.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_interfaces

##### OUTPUT
[regression-2023-05-11-14-09-50.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11456500/regression-2023-05-11-14-09-50.html.pdf)



##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

