### PR TITLE
Add Ansible support for all port breakout modes currently supported by SONiC

### DIFF
--- a/changelogs/fragments/276-add-new-port-breakout-modes.yaml
+++ b/changelogs/fragments/276-add-new-port-breakout-modes.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sonic_port_breakout - Add Ansible support for all port breakout modes now allowed in Enterprise SONiC (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/269).

--- a/changelogs/fragments/276-add-new-port-breakout-modes.yaml
+++ b/changelogs/fragments/276-add-new-port-breakout-modes.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - sonic_port_breakout - Add Ansible support for all port breakout modes now allowed in Enterprise SONiC (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/269).
+  - sonic_port_breakout - Add Ansible support for all port breakout modes now allowed in Enterprise SONiC (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/276).

--- a/plugins/module_utils/network/sonic/argspec/port_breakout/port_breakout.py
+++ b/plugins/module_utils/network/sonic/argspec/port_breakout/port_breakout.py
@@ -42,8 +42,10 @@ class Port_breakoutArgs(object):  # pylint: disable=R0903
             'elements': 'dict',
             'options': {
                 'mode': {
-                    'choices': ['1x100G', '1x400G', '1x40G', '2x100G', '2x200G',
-                                '2x50G', '4x100G', '4x10G', '4x25G', '4x50G'],
+                    'choices': ['1x10G', '1x25G', '1x40G', '1x50G', '1x100G',
+                                '1x200G', '1x400G', '2x10G', '2x25G', '2x40G',
+                                '2x50G', '2x100G', '2x200G', '4x10G', '4x25G',
+                                '4x50G', '4x100G', '8x10G', '8x25G', '8x50G'],
                     'type': 'str'
                 },
                 'name': {'required': True, 'type': 'str'}

--- a/plugins/module_utils/network/sonic/utils/utils.py
+++ b/plugins/module_utils/network/sonic/utils/utils.py
@@ -455,14 +455,7 @@ def get_normalize_interface_name(intf_name, module):
 
 
 def get_speed_from_breakout_mode(breakout_mode):
-    speed = None
-    speed_breakout_mode_map = {
-        "4x10G": "SPEED_10GB", "1x100G": "SPEED_100GB", "1x40G": "SPEED_40GB", "4x25G": "SPEED_25GB", "2x50G": "SPEED_50GB",
-        "1x400G": "SPEED_400GB", "4x100G": "SPEED_100GB", "4x50G": "SPEED_50GB", "2x100G": "SPEED_100GB", "2x200G": "SPEED_200GB"
-    }
-    if breakout_mode in speed_breakout_mode_map:
-        speed = speed_breakout_mode_map[breakout_mode]
-    return speed
+    return 'SPEED_' + breakout_mode.split('x')[1].replace('G', 'GB')
 
 
 def get_breakout_mode(module, name):

--- a/plugins/modules/sonic_port_breakout.py
+++ b/plugins/modules/sonic_port_breakout.py
@@ -57,16 +57,26 @@ options:
           - Specifies the mode of the port breakout.
         type: str
         choices:
-          - 1x100G
-          - 1x400G
+          - 1x10G
+          - 1x25G
           - 1x40G
+          - 1x50G
+          - 1x100G
+          - 1x200G
+          - 1x400G
+          - 2x10G
+          - 2x25G
+          - 2x40G
+          - 2x50G
           - 2x100G
           - 2x200G
-          - 2x50G
-          - 4x100G
           - 4x10G
           - 4x25G
           - 4x50G
+          - 4x100G
+          - 8x10G
+          - 8x25G
+          - 8x50G
   state:
     description:
       - Specifies the operation to be performed on the port breakout configured on the device.

--- a/tests/regression/roles/sonic_port_breakout/defaults/main.yml
+++ b/tests/regression/roles/sonic_port_breakout/defaults/main.yml
@@ -2,40 +2,21 @@
 ansible_connection: httpapi
 module_name: port_breakout
 
-preparations_tests:
-  delete_port_breakouts:
-    - "no interface breakout port 1/97"
-    - "no interface breakout port 1/98"
-    - "no interface breakout port 1/99"
-    - "no interface breakout port 1/100"
-    - "no interface breakout port 1/101"
-    - "no interface breakout port 1/102"
-
-tests_cli:
-  - name: cli_test_case_01
-    description: Configure breakout mode for ports
-    state: merged
-    input:
-      - name: 1/97
-        mode: 4x25G
-      - name: 1/98
-        mode: 1x40G
-
 tests:
   - name: test_case_01
     description: Configure breakout mode for ports
     state: merged
     input:
       - name: 1/97
-        mode: 4x25G
+        mode: 1x40G
       - name: 1/98
-        mode: 1x40G
+        mode: 1x50G
       - name: 1/99
-        mode: 4x25G
+        mode: 1x100G
       - name: 1/100
-        mode: 4x10G
+        mode: 2x50G
       - name: 1/101
-        mode: 1x40G
+        mode: 4x10G
       - name: 1/102
         mode: 4x25G
   - name: test_case_02
@@ -43,7 +24,7 @@ tests:
     state: merged
     input:
       - name: 1/97
-        mode: 1x40G
+        mode: 2x50G
       - name: 1/98
         mode: 4x10G
   - name: test_case_03

--- a/tests/regression/roles/sonic_port_breakout/tasks/main.yml
+++ b/tests/regression/roles/sonic_port_breakout/tasks/main.yml
@@ -1,31 +1,15 @@
 - debug: msg="sonic_port_breakout Test started ..."
 
-- set_fact: 
-    base_cfg_path: "{{ playbook_dir + '/roles/' + role_name + '/' + 'templates/' }}"
-
-- name: Preparations test
+- name: Preparation test
   include_tasks: preparation_tests.yaml
 
-- name: "Test {{ module_name }} CLI validation started ..."
+- name: "Test {{ module_name }} started ..."
   include_tasks: tasks_template.yaml
-  loop: "{{ tests_cli }}"
+  loop: "{{ tests }}"
 
-- name: "Test CLI validation started ..."
-  include_role:
-    name: common
-    tasks_from: cli_tasks_template.yaml
-  loop: "{{ tests_cli }}"
+- name: Cleanup tests
+  include_tasks: cleanup_tests.yaml
 
-# - name: Preparations test
-#   include_tasks: preparation_tests.yaml
-
-# - name: "Test {{ module_name }} started ..."
-#   include_tasks: tasks_template.yaml
-#   loop: "{{ tests }}"
-
-# - name: Cleanup tests
-#   include_tasks: cleanup_tests.yaml
-
-# - name: Display all variables/facts known for a host
-#   debug:
-#     var: hostvars[inventory_hostname].ansible_facts.test_reports
+- name: Display the full test report
+  debug:
+    var: hostvars[inventory_hostname].ansible_facts.test_reports

--- a/tests/regression/roles/sonic_port_breakout/tasks/tasks_template.yaml
+++ b/tests/regression/roles/sonic_port_breakout/tasks/tasks_template.yaml
@@ -19,3 +19,7 @@
 - import_role:
     name: common
     tasks_from: idempotent.facts.report.yaml
+
+- name: "Pause before the next test"
+  ansible.builtin.pause:
+    seconds: 10

--- a/tests/regression/roles/sonic_port_breakout/templates/cli_test_case_01.cfg
+++ b/tests/regression/roles/sonic_port_breakout/templates/cli_test_case_01.cfg
@@ -1,2 +1,0 @@
-interface breakout port 1/97 mode 4x25G
-interface breakout port 1/98 mode 1x40G


### PR DESCRIPTION
##### SUMMARY
Add Ansible support for all port breakout modes currently supported by SONiC

- Add support for all currently supported port breakout modes.
- Fix deficiencies and duplication in test case definitions for the port_breakout resource module.
- Add a 10 second pause between test sections to avoid SONiC errors due to back-to-back
port breakout configuration commands.
- Reorder breakout modes in the argspec and module files to facilitate verification of the list of supported modes.
- Use an algorithm instead of a map to obtain the openconfig "speed" value to be set for each specified breakout mode. This eliminates the need to manually add a map entry when adding support for a new breakout mode.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/189

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
port_breakout
##### OUTPUT
<!--- Paste the functionality test result below -->

[new_port_breakout_modes_regression_summary.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11751426/new_port_breakout_modes_regression_summary.pdf)

[new_port_breakout_modes_regression_test_detailed.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11751430/new_port_breakout_modes_regression_test_detailed.log)

[z9432f_port_breakout_merged.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11751431/z9432f_port_breakout_merged.log)

[z9432f_port_breakout_deleted.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11751432/z9432f_port_breakout_deleted.log)


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

[All SONiC 4.1 port breakout modes.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11751435/All.SONiC.4.1.port.breakout.modes.txt)


<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Manual playbook execution on a z9432f to verify merged and deleted handling for all available z9432f port breakout modes
-  Enhanced port_breakout regression sanity testing for an increased set of port breakout modes.
