### PR TITLE
Enable contiguous execution of all regression integration tests on an S5296f.

### DIFF
--- a/changelogs/fragments/277-enable-running-all-regression-tests-on-s5296.yaml
+++ b/changelogs/fragments/277-enable-running-all-regression-tests-on-s5296.yaml
@@ -1,0 +1,2 @@
+trivial_changes:
+  - regression_test - Enable contiguous execution of all regression integration tests on an S5296f (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/277).

--- a/changelogs/fragments/277-enable-running-all-regression-tests-on-s5296.yaml
+++ b/changelogs/fragments/277-enable-running-all-regression-tests-on-s5296.yaml
@@ -1,2 +1,2 @@
-trivial_changes:
+minor_changes:
   - regression_test - Enable contiguous execution of all regression integration tests on an S5296f (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/277).

--- a/tests/regression/roles/common/defaults/main.yml
+++ b/tests/regression/roles/common/defaults/main.yml
@@ -50,6 +50,12 @@ native_eth3: Ethernet28
 native_eth4: Ethernet32
 native_eth5: Ethernet36
 native_eth6: Ethernet40
+native_eth7: Ethernet96
+native_eth8: Ethernet100
+native_eth9: Ethernet104
+native_eth10: Ethernet108
+native_eth11: Ethernet112
+native_eth12: Ethernet116
 
 std_eth1: Eth1/5
 std_eth2: Eth1/6
@@ -57,6 +63,12 @@ std_eth3: Eth1/7
 std_eth4: Eth1/8
 std_eth5: Eth1/9
 std_eth6: Eth1/10
+std_eth7: Eth1/97
+std_eth8: Eth1/98
+std_eth9: Eth1/99
+std_eth10: Eth1/100
+std_eth11: Eth1/101
+std_eth12: Eth1/102
 
 interface1: "{{ std_eth1 if std_name in interface_mode else native_eth1 }}"
 interface2: "{{ std_eth2 if std_name in interface_mode else native_eth2 }}"
@@ -64,3 +76,9 @@ interface3: "{{ std_eth3 if std_name in interface_mode else native_eth3 }}"
 interface4: "{{ std_eth4 if std_name in interface_mode else native_eth4 }}"
 interface5: "{{ std_eth5 if std_name in interface_mode else native_eth5 }}"
 interface6: "{{ std_eth6 if std_name in interface_mode else native_eth6 }}"
+interface7: "{{ std_eth7 if std_name in interface_mode else native_eth7 }}"
+interface8: "{{ std_eth8 if std_name in interface_mode else native_eth8 }}"
+interface9: "{{ std_eth9 if std_name in interface_mode else native_eth9 }}"
+interface10: "{{ std_eth10 if std_name in interface_mode else native_eth10 }}"
+interface11: "{{ std_eth11 if std_name in interface_mode else native_eth11 }}"
+interface12: "{{ std_eth12 if std_name in interface_mode else native_eth12 }}"

--- a/tests/regression/roles/sonic_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_interfaces/defaults/main.yml
@@ -29,41 +29,41 @@ tests:
     description: Update interface parameters
     state: merged
     input:
-      - name: "{{ interface1 }}"
-        description: ansible Ethernet4 descr
+      - name: "{{ interface7 }}"
+        description: ansible Ethernet96
         mtu: 6445
         enabled: false
   - name: test_case_02
     description: Update interface parameters
     state: merged
     input:
-      - name: "{{ interface1 }}"
-        description: ansible Ethernet4 descr
+      - name: "{{ interface7 }}"
+        description: ansible Ethernet96
         mtu: 6444
         enabled: true
-      - name: "{{ interface3 }}"
-        description: ansible Ethernet12 descr
+      - name: "{{ interface9 }}"
+        description: ansible Ethernet104
         mtu: 6000
         enabled: true
-      - name: "{{ interface2 }}"
-        description: ansible Ethernet8 descr
+      - name: "{{ interface8 }}"
+        description: ansible Ethernet100
         mtu: 5666
         enabled: false
-      - name: "{{ interface4 }}"
-        description: ansible Ethernet16 descr
+      - name: "{{ interface10 }}"
+        description: ansible Ethernet108
         mtu: 5222
         enabled: true
   - name: test_case_03
     description: Configure interface parameter speed
     state: merged
     input:
-      - name: "{{ interface1 }}"
+      - name: "{{ interface7 }}"
         speed: SPEED_40GB
   - name: test_case_04
     description: Configure interface parameters auto_negotiate and advertised_speed
     state: merged
     input:
-      - name: "{{ interface2 }}"
+      - name: "{{ interface8 }}"
         auto_negotiate: true
         advertised_speed:
           - 100000
@@ -72,31 +72,31 @@ tests:
     description: Configure interface parameters FEC
     state: merged
     input:
-      - name: "{{ interface3 }}"
+      - name: "{{ interface9 }}"
         fec: FEC_AUTO
   - name: test_case_06
-    description: Update interface parameters
+    description: Delete interface parameters
     state: deleted
     input:
-      - name: "{{ interface1 }}"
+      - name: "{{ interface7 }}"
         description:
-      - name: "{{ interface3 }}"
+      - name: "{{ interface9 }}"
         mtu:
-      - name: "{{ interface2 }}"
+      - name: "{{ interface8 }}"
         enabled:
-      - name: "{{ interface4 }}"
+      - name: "{{ interface10 }}"
   - name: test_case_07
     description: Update interface parameters
     state: merged
     input:
-      - name: "{{ interface1 }}"
-        description: ansible Ethernet4 descr
+      - name: "{{ interface7 }}"
+        description: ansible Ethernet96
         mtu: 6444
         enabled: true
-      - name: "{{ interface3 }}"
-        description: ansible Ethernet12 descr
-      - name: "{{ interface4 }}"
-        description: ansible eth56 descr
+      - name: "{{ interface9 }}"
+        description: ansible Ethernet104
+      - name: "{{ interface10 }}"
+        description: ansible eth108
 # Loopback test cases started
   - name: test_case_08
     description: Loopback interface parameters
@@ -168,8 +168,3 @@ tests:
         description: ansible PortChannel51 descr
         mtu: 5454
         enabled: true
-  - name: test_case_17
-    description: Update interface parameters
-    state: deleted
-    input: []
-    timeout: 60

--- a/tests/regression/roles/sonic_l3_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_l3_interfaces/defaults/main.yml
@@ -244,7 +244,3 @@ tests:
         - name: lo102
         - name: portchannel 100 # po100 or portchannel100
         - name: portchannel 101
-  - name: test_case_12
-    description: Delete all l3 interfaces config
-    state: deleted
-    input: []


### PR DESCRIPTION
Enable contiguous execution of all regression integration tests on an S5296f.


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Modify/add interface names to avoid port group interfaces for the "interfaces" test.
- Remove "interfaces" and "l3_interfaces" test cases that delete all interface configuration to prevent disabling the Management 0 interface connection.

These changes are a prerequisite for enabling automated regression test execution.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
regression_tests
##### OUTPUT
<!--- Paste the functionality test result below -->

[s5296f_all_resource_modules_regression.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11887943/s5296f_all_resource_modules_regression.pdf)


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [X] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Run the full suite of all enterprise_sonic Ansible resource module regression tests and verify a 100% pass rate.

