### PR TITLE
Playbook check and diff modes util and radius-server implemetation

### DIFF
--- a/changelogs/fragments/279-playbook-check-diff-modes-and-radius-server-implement.yaml
+++ b/changelogs/fragments/279-playbook-check-diff-modes-and-radius-server-implement.yaml
@@ -1,0 +1,2 @@
+major_changes:
+  - Playbook check and diff modes utility functions and sonic_radius_server module support for the check and diff modes (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/279).

--- a/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
@@ -105,7 +105,7 @@ class Radius_server(ConfigBase):
             result.pop('after', None)
             new_config = get_new_config(commands, existing_radius_server_facts,
                                         TEST_KEYS_formatted_diff)
-            result["after(generated)"] = new_config
+            result['after(generated)'] = new_config
 
         if self._module._diff:
             result['config_diff'] = get_formatted_config_diff(existing_radius_server_facts,

--- a/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
@@ -30,11 +30,19 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     get_replaced_config,
     normalize_interface_name,
 )
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
+    __DELETE_CONFIG_IF_NO_SUBCONFIG,
+    get_new_config,
+    get_formatted_config_diff
+)
 
 PATCH = 'patch'
 DELETE = 'delete'
 TEST_KEYS = [
     {'host': {'name': ''}},
+]
+TEST_KEYS_formatted_diff = [
+    {'host': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
 ]
 
 
@@ -92,6 +100,16 @@ class Radius_server(ConfigBase):
         if result['changed']:
             result['after'] = changed_radius_server_facts
 
+        new_config = changed_radius_server_facts
+        if self._module.check_mode:
+            result.pop('after', None)
+            new_config = get_new_config(commands, existing_radius_server_facts,
+                                        TEST_KEYS_formatted_diff)
+            result["after(generated)"] = new_config
+
+        if self._module._diff:
+            result['config_diff'] = get_formatted_config_diff(existing_radius_server_facts,
+                                                              new_config)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -8,9 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import re
-import json
-import ast
 from copy import (
     deepcopy
 )

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -1,0 +1,427 @@
+#
+# -*- coding: utf-8 -*-
+# Copyright 2023 Dell Inc. or its subsidiaries. All Rights Reserved
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import re
+import json
+import ast
+from copy import (
+    deepcopy
+)
+from pprint import (
+    pformat
+)
+from difflib import (
+    context_diff
+)
+
+
+def get_key_sets(dict_conf):
+    key_set = set(dict_conf.keys())
+    trival_key_set = set()
+    dict_list_key_set = set()
+    for key in key_set:
+        if dict_conf[key] not in [None, [], {}]:
+            if isinstance(dict_conf[key], (list, dict)):
+                dict_list_key_set.add(key)
+            else:
+                trival_key_set.add(key)
+    return trival_key_set, dict_list_key_set
+
+#
+# Pre-defined Delete Operations
+#
+
+
+def __DELETE_CONFIG(key_set, command, exist_conf):
+    new_conf = []
+    return True, new_conf
+
+
+def __DELETE_CONFIG_IF_NO_SUBCONFIG(key_set, command, exist_conf):
+    nu, dict_list_cmd_key_set = get_key_sets(command)
+    if len(dict_list_cmd_key_set) == 0:
+        new_conf = []
+        return True, new_conf
+    else:
+        new_conf = exist_conf
+        return False, new_conf
+
+
+def __DELETE_SUBCONFIG_AND_LEAFS(key_set, command, exist_conf):
+    new_conf = exist_conf
+
+    trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
+    trival_cmd_key_not_key_set = trival_cmd_key_set.difference(key_set)
+    for key in trival_cmd_key_not_key_set:
+        new_conf.pop(key, None)
+
+    nu, dict_list_exist_key_set = get_key_sets(exist_conf)
+    common_dict_list_key_set = dict_list_cmd_key_set.intersection(dict_list_exist_key_set)
+    if len(common_dict_list_key_set) != 0:
+        for key in common_dict_list_key_set:
+            new_conf.pop(key, None)
+
+    return True, new_conf
+
+
+def __DELETE_SUBCONFIG_ONLY(key_set, command, exist_conf):
+    new_conf = exist_conf
+    nu, dict_list_cmd_key_set = get_key_sets(command)
+    nu, dict_list_exist_key_set = get_key_sets(exist_conf)
+    common_dict_list_key_set = dict_list_cmd_key_set.intersection(dict_list_exist_key_set)
+    for key in common_dict_list_key_set:
+        new_conf.pop(key, None)
+    return True, new_conf
+
+
+def __DELETE_OP_DEFAULT(key_set, command, exist_conf):
+    new_conf = exist_conf
+    trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
+
+    if (len(key_set) == len(trival_cmd_key_set)) and \
+       (len(dict_list_cmd_key_set) == 0):
+        new_conf = []
+        return True, new_conf
+
+    trival_cmd_key_not_key_set = trival_cmd_key_set.difference(key_set)
+    for key in trival_cmd_key_not_key_set:
+        new_conf.pop(key, None)
+
+    return False, new_conf
+
+
+def get_test_key_set_and_delete_op(key, test_keys):
+    tst_keys = deepcopy(test_keys)
+    del_op = __DELETE_OP_DEFAULT
+    t_key_set = set()
+    t_keys = next((t_key_item[key] for t_key_item in tst_keys if key in t_key_item), None)
+    if t_keys:
+        del_op = t_keys.get('__delete_op', __DELETE_OP_DEFAULT)
+        t_keys.pop('__delete_op', None)
+        t_key_set = set(t_keys.keys())
+
+    return del_op, t_key_set
+
+
+def get_new_config(commands, exist_conf, test_keys=None):
+
+    cmds = deepcopy(commands)
+
+    n_conf = list()
+    e_conf = exist_conf
+    for cmd in cmds:
+        state = cmd['state']
+        cmd.pop('state')
+
+        if state == 'merged':
+            n_conf = derive_config_from_merged_cmd(cmd, e_conf, test_keys)
+        elif state == 'deleted':
+            n_conf = derive_config_from_deleted_cmd(cmd, e_conf, test_keys)
+        elif state == 'replaced':
+            n_conf = derive_config_from_merged_cmd(cmd, e_conf, test_keys)
+        elif state == 'overridden':
+            n_conf = cmd
+
+        e_conf = n_conf
+
+    return n_conf
+
+
+def derive_config_from_merged_cmd(command, exist_conf, test_keys=None):
+
+    if not command:
+        return exist_conf
+    if not exist_conf:
+        return command
+
+    if isinstance(command, list) and isinstance(exist_conf, list):
+        nu, new_conf_dict = derive_config_from_merged_cmd_dict({"config": command},
+                                                               {"config": exist_conf},
+                                                               test_keys)
+        new_conf = new_conf_dict.get("config", [])
+    elif isinstance(command, dict) and isinstance(exist_conf, dict):
+        nu, new_conf = derive_config_from_merged_cmd_dict(command,
+                                                          exist_conf,
+                                                          test_keys)
+    elif isinstance(command, dict) and isinstance(exist_conf, list):
+        nu, new_conf_dict = derive_config_from_merged_cmd_dict({"config": [command]},
+                                                               {"config": exist_conf},
+                                                               test_keys)
+        new_conf = new_conf_dict.get("config", [])
+    else:
+        new_conf = exist_conf
+
+    return new_conf
+
+
+def derive_config_from_merged_cmd_dict(command, exist_conf, test_keys=None, key_set=None):
+
+    if test_keys is None:
+        test_keys = []
+    if key_set is None:
+        key_set = set()
+
+    new_conf = deepcopy(exist_conf)
+    if not command:
+        return False, new_conf
+
+    trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
+    trival_exist_key_set, dict_list_exist_key_set = get_key_sets(new_conf)
+
+    common_trival_key_set = trival_cmd_key_set.intersection(trival_exist_key_set)
+    common_dict_list_key_set = dict_list_cmd_key_set.intersection(dict_list_exist_key_set)
+
+    key_matched_cnt = 0
+    for key in common_trival_key_set:
+        if command[key] == new_conf[key]:
+            if key in key_set:
+                key_matched_cnt += 1
+
+    key_matched = (key_matched_cnt == len(key_set))
+    if key_matched:
+        for key in trival_cmd_key_set:
+            new_conf[key] = command[key]
+
+        only_cmd_dict_list_key_set = dict_list_cmd_key_set.difference(common_dict_list_key_set)
+        for key in only_cmd_dict_list_key_set:
+            new_conf[key] = command[key]
+    else:
+        return key_matched, new_conf
+
+    for key in common_dict_list_key_set:
+
+        cmd_value = command[key]
+        exist_value = new_conf[key]
+
+        if (isinstance(cmd_value, list) and isinstance(exist_value, list)):
+            c_list = cmd_value
+            e_list = exist_value
+            nu, t_key_set = get_test_key_set_and_delete_op(key, test_keys)
+
+            new_conf_list = list()
+            not_dict_item = False
+            dict_no_key_item = False
+            for c_item in c_list:
+                matched_key_dict = False
+                for e_item in e_list:
+                    if (isinstance(c_item, dict) and isinstance(e_item, dict)):
+                        if t_key_set:
+                            remaining_keys = [t_key_item for t_key_item in test_keys if key not in t_key_item]
+                            k_mtchd, new_conf_dict = derive_config_from_merged_cmd_dict(c_item, e_item,
+                                                                                        remaining_keys,
+                                                                                        t_key_set)
+                            if k_mtchd:
+                                new_conf[key].remove(e_item)
+                                if new_conf_dict:
+                                    new_conf_list.append(new_conf_dict)
+                                matched_key_dict = True
+                                break
+                        else:
+                            dict_no_key_item = True
+                            break
+
+                    else:
+                        not_dict_item = True
+                        break
+
+                if not matched_key_dict:
+                    new_conf_list.append(c_item)
+
+                if not_dict_item or dict_no_key_item:
+                    break
+
+            if dict_no_key_item:
+                new_conf_list = e_list + c_list
+
+            if not_dict_item:
+                c_set = set(c_list)
+                e_set = set(e_list)
+                merge_set = c_set.union(e_set)
+                if merge_set:
+                    new_conf[key] = list(merge_set)
+            elif new_conf_list:
+                new_conf[key].extend(new_conf_list)
+
+        elif (isinstance(cmd_value, dict) and isinstance(exist_value, dict)):
+            k_mtchd, new_conf_dict = derive_config_from_merged_cmd_dict(cmd_value,
+                                                                        exist_value,
+                                                                        test_keys)
+            if k_mtchd and new_conf_dict:
+                new_conf[key] = new_conf_dict
+
+        elif (isinstance(cmd_value, (list, dict)) or isinstance(exist_value, (list, dict))):
+            new_conf[key] = exist_value
+            break
+
+        else:
+            continue
+
+    return key_matched, new_conf
+
+
+def derive_config_from_deleted_cmd(command, exist_conf, test_keys=None):
+
+    if not command or not exist_conf:
+        return []
+
+    if isinstance(command, list) and isinstance(exist_conf, list):
+        nu, new_conf_dict = derive_config_from_deleted_cmd_dict({"config": command},
+                                                                {"config": exist_conf},
+                                                                test_keys)
+        new_conf = new_conf_dict.get("config", [])
+    elif isinstance(command, dict) and isinstance(exist_conf, dict):
+        nu, new_conf = derive_config_from_deleted_cmd_dict(command, exist_conf,
+                                                           test_keys)
+    elif isinstance(command, dict) and isinstance(exist_conf, list):
+        nu, new_conf_dict = derive_config_from_deleted_cmd_dict({"config": [command]},
+                                                                {"config": exist_conf},
+                                                                test_keys)
+        new_conf = new_conf_dict.get("config", [])
+    else:
+        new_conf = exist_conf
+
+    return new_conf
+
+
+def derive_config_from_deleted_cmd_dict(command, exist_conf, test_keys=None, key_set=None, delete_op=None):
+
+    if test_keys is None:
+        test_keys = []
+    if delete_op is None:
+        delete_op = __DELETE_OP_DEFAULT
+    if key_set is None:
+        key_set = set()
+
+    new_conf = deepcopy(exist_conf)
+    if not command:
+        return True, []
+
+    trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
+    trival_exist_key_set, dict_list_exist_key_set = get_key_sets(new_conf)
+
+    common_trival_key_set = trival_cmd_key_set.intersection(trival_exist_key_set)
+    common_dict_list_key_set = dict_list_cmd_key_set.intersection(dict_list_exist_key_set)
+
+    key_matched_cnt = 0
+    for key in common_trival_key_set:
+        if command[key] == new_conf[key]:
+            if key in key_set:
+                key_matched_cnt += 1
+
+    key_matched = (key_matched_cnt == len(key_set))
+    if key_matched:
+        done, new_conf = delete_op(key_set, command, new_conf)
+        if done:
+            return key_matched, new_conf
+        else:
+            nu, dict_list_exist_key_set = get_key_sets(new_conf)
+            common_dict_list_key_set = dict_list_cmd_key_set.intersection(dict_list_exist_key_set)
+    else:
+        return key_matched, new_conf
+
+    for key in common_dict_list_key_set:
+
+        cmd_value = command[key]
+        exist_value = new_conf[key]
+
+        if (isinstance(cmd_value, list) and isinstance(exist_value, list)):
+            c_list = cmd_value
+            e_list = exist_value
+            delete_op, t_key_set = get_test_key_set_and_delete_op(key, test_keys)
+
+            new_conf_list = list()
+            not_dict_item = False
+            dict_no_key_item = False
+            for c_item in c_list:
+                for e_item in e_list:
+                    if (isinstance(c_item, dict) and isinstance(e_item, dict)):
+                        if t_key_set:
+                            remaining_keys = [t_key_item for t_key_item in test_keys if key not in t_key_item]
+                            k_mtchd, new_conf_dict = derive_config_from_deleted_cmd_dict(c_item, e_item,
+                                                                                         remaining_keys,
+                                                                                         t_key_set,
+                                                                                         delete_op)
+                            if k_mtchd:
+                                new_conf[key].remove(e_item)
+                                if new_conf_dict:
+                                    new_conf_list.append(new_conf_dict)
+                                break
+                        else:
+                            dict_no_key_item = True
+                            break
+
+                    else:
+                        not_dict_item = True
+                        break
+
+                if not_dict_item or dict_no_key_item:
+                    break
+
+            if dict_no_key_item:
+                new_conf_list = e_list
+
+            if not_dict_item:
+                c_set = set(c_list)
+                e_set = set(e_list)
+                delete_set = e_set.difference(c_set)
+                if delete_set:
+                    new_conf[key] = list(delete_set)
+            elif new_conf_list:
+                new_conf[key].extend(new_conf_list)
+
+        elif (isinstance(cmd_value, dict) and isinstance(exist_value, dict)):
+            k_mtchd, new_conf_dict = derive_config_from_deleted_cmd_dict(cmd_value,
+                                                                         exist_value,
+                                                                         test_keys,
+                                                                         None,
+                                                                         delete_op)
+            if k_mtchd:
+                new_conf.pop(key, None)
+                if new_conf_dict:
+                    new_conf[key] = new_conf_dict
+
+        elif (isinstance(cmd_value, (list, dict)) or isinstance(exist_value, (list, dict))):
+            new_conf[key] = exist_value
+            break
+
+        else:
+            continue
+
+    return key_matched, new_conf
+
+
+def get_formatted_config_diff(exist_conf, new_conf):
+
+    diff_correction = [
+        {'python_str': ': None', 'ansible_str': ': null'},
+        {'python_str': ': True', 'ansible_str': ': true'},
+        {'python_str': ': False', 'ansible_str': ': false'},
+    ]
+
+    bfr = pformat(exist_conf)
+    for d_correct in diff_correction:
+        bfr = bfr.replace(d_correct['python_str'], d_correct['ansible_str'])
+
+    aft = pformat(new_conf)
+    for d_correct in diff_correction:
+        aft = aft.replace(d_correct['python_str'], d_correct['ansible_str'])
+
+    bfr_list = list(bfr.split(',\n'))
+    aft_list = list(aft.split(',\n'))
+    diffs = context_diff(aft_list, bfr_list,
+                         fromfile='after_config',
+                         tofile='before_config')
+    formatted_diff = list()
+    for diff in diffs:
+        if diff.endswith('\n'):
+            diff = diff.rstrip('\n')
+        formatted_diff.append(diff)
+
+    return formatted_diff

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -412,9 +412,9 @@ def get_formatted_config_diff(exist_conf, new_conf):
 
     bfr_list = list(bfr.split(',\n'))
     aft_list = list(aft.split(',\n'))
-    diffs = context_diff(aft_list, bfr_list,
-                         fromfile='after_config',
-                         tofile='before_config')
+    diffs = context_diff(bfr_list, aft_list,
+                         fromfile='before_config',
+                         tofile='after_config')
     formatted_diff = list()
     for diff in diffs:
         if diff.endswith('\n'):

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -124,7 +124,10 @@ def get_new_config(commands, exist_conf, test_keys=None):
         elif state == 'replaced':
             n_conf = derive_config_from_merged_cmd(cmd, e_conf, test_keys)
         elif state == 'overridden':
-            n_conf = cmd
+            n_conf = derive_config_from_merged_cmd(cmd, e_conf, test_keys)
+            # If the "cmd" is derived from playbook, that is "want", the below
+            # line should be good enough:
+            # n_conf = cmd
 
         e_conf = n_conf
 

--- a/plugins/module_utils/network/sonic/utils/utils.py
+++ b/plugins/module_utils/network/sonic/utils/utils.py
@@ -545,6 +545,8 @@ def send_requests(module, requests):
 def get_replaced_config(new_conf, exist_conf, test_keys=None):
 
     replace_conf = []
+    if not new_conf or not exist_conf:
+        return replace_conf
 
     if isinstance(new_conf, list) and isinstance(exist_conf, list):
 


### PR DESCRIPTION
SUMMARY
This is to add playbook check and diff modes utility functions and radius-server support for check and diff modes.

GitHub Issues
N/A

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
sonic_radius_server

OUTPUT
- test script: 
[radius.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/11984116/radius.txt)
- test log with --diff option: 
[ut_diff.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12030189/ut_diff.log)
- test log with --diff and --check: 
[ut_diff_check.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12030193/ut_diff_check.log)
- regression test log: 
[regression.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12022305/regression.log)
- regression test result:
[regression-2023-07-11-16-47-34.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12022307/regression-2023-07-11-16-47-34.html.pdf)


ADDITIONAL INFORMATION
playbook result:

- if without --check and --diff options: the result includes "after" and "before". 
- if without --check, but with --diff: the result includes  "after", "before" and "config_diff". The "config_diff" is diffrence between "after" and "before".
- if with --check and without --diff: the result includes: "after(generated)" and "before".
- if with --check and --diff: the result includes: "after(generated)", "before" and "config_diff". The "config_diff" is diffrence between "after(generated)" and "before".

Checklist:

- [x ] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x ] I have verified that new and existing unit tests pass locally with my changes
- [x ] I have not allowed coverage numbers to degenerate
- [x ] I have maintained at least 90% code coverage
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x ] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

How Has This Been Tested?
tested on real SONIC systems with various playbook --check and --diff option mixes.

