### PR TITLE
Add diff and check modes support for NTP module

### DIFF
--- a/changelogs/fragments/281-playbook-check-diff-modes-for-ntp-module.yaml
+++ b/changelogs/fragments/281-playbook-check-diff-modes-for-ntp-module.yaml
@@ -1,2 +1,2 @@
 major_changes:
-  - Playbook check and diff modes support for sonic_ntp module (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/281).
+        - ntp_and_tacacs - Playbook check and diff modes support for sonic_ntp and sonic_tacacs_server modules (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/281).

--- a/changelogs/fragments/281-playbook-check-diff-modes-for-ntp-module.yaml
+++ b/changelogs/fragments/281-playbook-check-diff-modes-for-ntp-module.yaml
@@ -1,0 +1,2 @@
+major_changes:
+  - Playbook check and diff modes support for sonic_ntp module (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/281).

--- a/plugins/module_utils/network/sonic/config/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/config/ntp/ntp.py
@@ -33,6 +33,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
     __DELETE_CONFIG_IF_NO_SUBCONFIG,
+    __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF,
     get_new_config,
     get_formatted_config_diff
 )
@@ -47,6 +48,7 @@ TEST_KEYS = [
     {"ntp_keys": {"key_id": ""}}
 ]
 TEST_KEYS_formatted_diff = [
+    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF}},
     {"servers": {"address": "", '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
     {"ntp_keys": {"key_id": "", '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}}
 ]

--- a/plugins/module_utils/network/sonic/config/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/config/ntp/ntp.py
@@ -28,10 +28,15 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     get_diff,
     get_replaced_config,
-    send_requests,
     update_states,
     normalize_interface_name_list
 )
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
+    __DELETE_CONFIG_IF_NO_SUBCONFIG,
+    get_new_config,
+    get_formatted_config_diff
+)
+
 from ansible.module_utils.connection import ConnectionError
 
 PATCH = 'PATCH'
@@ -40,6 +45,10 @@ DELETE = 'DELETE'
 TEST_KEYS = [
     {"servers": {"address": ""}},
     {"ntp_keys": {"key_id": ""}}
+]
+TEST_KEYS_formatted_diff = [
+    {"servers": {"address": "", '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
+    {"ntp_keys": {"key_id": "", '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}}
 ]
 
 
@@ -102,6 +111,17 @@ class Ntp(ConfigBase):
         result['before'] = existing_ntp_facts
         if result['changed']:
             result['after'] = changed_ntp_facts
+
+        new_config = changed_ntp_facts
+        if self._module.check_mode:
+            result.pop('after', None)
+            new_config = get_new_config(commands, existing_ntp_facts,
+                                        TEST_KEYS_formatted_diff)
+            result['after(generated)'] = new_config
+
+        if self._module._diff:
+            result['config_diff'] = get_formatted_config_diff(existing_ntp_facts,
+                                                              new_config)
 
         result['warnings'] = warnings
         return result
@@ -220,32 +240,31 @@ class Ntp(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
+        commands = []
+        requests = []
         replaced_config = get_replaced_config(want, have, TEST_KEYS)
 
+        add_commands = []
         if replaced_config:
             self.sort_lists_in_config(replaced_config)
             self.sort_lists_in_config(have)
             delete_all = (replaced_config == have)
-            requests = self.get_delete_requests(replaced_config, delete_all)
-            send_requests(self._module, requests)
+            del_requests = self.get_delete_requests(replaced_config, delete_all)
+            requests.extend(del_requests)
+            commands.extend(update_states(replaced_config, "deleted"))
 
-            commands = want
+            add_commands = want
         else:
             diff = get_diff(want, have, TEST_KEYS)
-            commands = diff
+            add_commands = diff
 
-        requests = []
+        if add_commands:
+            self.preprocess_merge_commands(add_commands, want)
+            add_requests = self.get_merge_requests(add_commands, have)
 
-        if commands:
-            self.preprocess_merge_commands(commands, want)
-            requests = self.get_merge_requests(commands, have)
-
-            if len(requests) > 0:
-                commands = update_states(commands, "replaced")
-            else:
-                commands = []
-        else:
-            commands = []
+            if len(add_requests) > 0:
+                requests.extend(add_requests)
+                commands.extend(update_states(add_commands, "replaced"))
 
         return commands, requests
 
@@ -262,23 +281,23 @@ class Ntp(ConfigBase):
         self.sort_lists_in_config(want)
         self.sort_lists_in_config(have)
 
-        if have and have != want:
-            delete_all = True
-            requests = self.get_delete_requests(have, delete_all)
-            send_requests(self._module, requests)
-            have = []
-
         commands = []
         requests = []
 
+        if have and have != want:
+            delete_all = True
+            del_requests = self.get_delete_requests(have, delete_all)
+            requests.extend(del_requests)
+            commands.extend(update_states(have, "deleted"))
+            have = []
+
         if not have and want:
-            commands = want
-            requests = self.get_merge_requests(commands, have)
+            add_commands = want
+            add_requests = self.get_merge_requests(add_commands, have)
 
             if len(requests) > 0:
-                commands = update_states(commands, "overridden")
-            else:
-                commands = []
+                requests.extend(add_requests)
+                commands.extend(update_states(add_commands, "overridden"))
 
         return commands, requests
 

--- a/plugins/module_utils/network/sonic/config/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/config/ntp/ntp.py
@@ -33,7 +33,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
     __DELETE_CONFIG_IF_NO_SUBCONFIG,
-    __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF,
+    __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF,
     get_new_config,
     get_formatted_config_diff
 )
@@ -48,7 +48,7 @@ TEST_KEYS = [
     {"ntp_keys": {"key_id": ""}}
 ]
 TEST_KEYS_formatted_diff = [
-    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF}},
+    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF}},
     {"servers": {"address": "", '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
     {"ntp_keys": {"key_id": "", '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}}
 ]
@@ -297,7 +297,7 @@ class Ntp(ConfigBase):
             add_commands = want
             add_requests = self.get_merge_requests(add_commands, have)
 
-            if len(requests) > 0:
+            if len(add_requests) > 0:
                 requests.extend(add_requests)
                 commands.extend(update_states(add_commands, "overridden"))
 

--- a/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
@@ -32,7 +32,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
     __DELETE_CONFIG_IF_NO_SUBCONFIG,
-    __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF,
+    __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF,
     get_new_config,
     get_formatted_config_diff
 )
@@ -43,7 +43,7 @@ TEST_KEYS = [
     {'host': {'name': ''}},
 ]
 TEST_KEYS_formatted_diff = [
-    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF}},
+    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF}},
     {'host': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
 ]
 

--- a/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
@@ -32,6 +32,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
     __DELETE_CONFIG_IF_NO_SUBCONFIG,
+    __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF,
     get_new_config,
     get_formatted_config_diff
 )
@@ -42,6 +43,7 @@ TEST_KEYS = [
     {'host': {'name': ''}},
 ]
 TEST_KEYS_formatted_diff = [
+    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF}},
     {'host': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
 ]
 

--- a/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
@@ -32,7 +32,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
     __DELETE_CONFIG_IF_NO_SUBCONFIG,
-    __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF,
+    __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF,
     get_new_config,
     get_formatted_config_diff
 )
@@ -43,7 +43,7 @@ TEST_KEYS = [
     {'host': {'name': ''}},
 ]
 TEST_KEYS_formatted_diff = [
-    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF}},
+    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF}},
     {'host': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
 ]
 

--- a/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
@@ -30,11 +30,21 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     get_replaced_config,
     get_normalize_interface_name,
 )
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
+    __DELETE_CONFIG_IF_NO_SUBCONFIG,
+    __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF,
+    get_new_config,
+    get_formatted_config_diff
+)
 
 PATCH = 'patch'
 DELETE = 'delete'
 TEST_KEYS = [
     {'host': {'name': ''}},
+]
+TEST_KEYS_formatted_diff = [
+    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF}},
+    {'host': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
 ]
 
 
@@ -92,6 +102,16 @@ class Tacacs_server(ConfigBase):
         if result['changed']:
             result['after'] = changed_tacacs_server_facts
 
+        new_config = changed_tacacs_server_facts
+        if self._module.check_mode:
+            result.pop('after', None)
+            new_config = get_new_config(commands, existing_tacacs_server_facts,
+                                        TEST_KEYS_formatted_diff)
+            result['after(generated)'] = new_config
+
+        if self._module._diff:
+            result['config_diff'] = get_formatted_config_diff(existing_tacacs_server_facts,
+                                                              new_config)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -151,7 +151,9 @@ def get_test_key_set_and_delete_op(key, test_keys):
     tst_keys = deepcopy(test_keys)
     del_op = __DELETE_OP_DEFAULT
     t_key_set = set()
-    if key is None:
+    if not test_keys:
+        return del_op, t_key_set
+    if not key:
         key = '__delete_op_default'
     t_keys = next((t_key_item[key] for t_key_item in tst_keys if key in t_key_item), None)
     if t_keys:

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -268,7 +268,9 @@ def derive_config_from_merged_cmd_dict(command, exist_conf, test_keys=None, key_
 
 def derive_config_from_deleted_cmd(command, exist_conf, test_keys=None):
 
-    if not command or not exist_conf:
+    if not command:
+        return exist_conf
+    if not exist_conf:
         return []
 
     if isinstance(command, list) and isinstance(exist_conf, list):
@@ -373,6 +375,8 @@ def derive_config_from_deleted_cmd_dict(command, exist_conf, test_keys=None, key
                 delete_set = e_set.difference(c_set)
                 if delete_set:
                     new_conf[key] = list(delete_set)
+                else:
+                    new_conf[key] = []
             elif new_conf_list:
                 new_conf[key].extend(new_conf_list)
 

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -36,11 +36,17 @@ def get_key_sets(dict_conf):
 #
 
 
+"""
+Delete entire configuration.
+"""
 def __DELETE_CONFIG(key_set, command, exist_conf):
     new_conf = []
     return True, new_conf
 
 
+"""
+Delete entire configuration if there is no sub-configuration.
+"""
 def __DELETE_CONFIG_IF_NO_SUBCONFIG(key_set, command, exist_conf):
     nu, dict_list_cmd_key_set = get_key_sets(command)
     if len(dict_list_cmd_key_set) == 0:
@@ -51,6 +57,9 @@ def __DELETE_CONFIG_IF_NO_SUBCONFIG(key_set, command, exist_conf):
         return False, new_conf
 
 
+"""
+Delete sub-configuration and leaf configuration, if any.
+"""
 def __DELETE_SUBCONFIG_AND_LEAFS(key_set, command, exist_conf):
     new_conf = exist_conf
 
@@ -68,6 +77,9 @@ def __DELETE_SUBCONFIG_AND_LEAFS(key_set, command, exist_conf):
     return True, new_conf
 
 
+"""
+Delete sub-configuration only, if any.
+"""
 def __DELETE_SUBCONFIG_ONLY(key_set, command, exist_conf):
     new_conf = exist_conf
     nu, dict_list_cmd_key_set = get_key_sets(command)
@@ -78,7 +90,11 @@ def __DELETE_SUBCONFIG_ONLY(key_set, command, exist_conf):
     return True, new_conf
 
 
-def __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF(key_set, command, exist_conf):
+"""
+Delete configuration if there is no non-key leaf, and
+delete non-key leaf configuration, if any.
+"""
+def __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF(key_set, command, exist_conf):
     new_conf = exist_conf
     trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
 
@@ -94,6 +110,12 @@ def __DELETE_LEAFS_OR_CONFIG_IF_NO_NONE_KEY_LEAF(key_set, command, exist_conf):
     return False, new_conf
 
 
+"""
+This is default deletion operation.
+Delete configuration if there is no non-key leaf, and
+delete non-key leaf configuration, if any, if the values of non-key leaf are
+equal between command and existing configuration.
+"""
 def __DELETE_OP_DEFAULT(key_set, command, exist_conf):
     new_conf = exist_conf
     trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -138,8 +138,6 @@ def derive_config_from_merged_cmd(command, exist_conf, test_keys=None):
 
     if not command:
         return exist_conf
-    if not exist_conf:
-        return command
 
     if isinstance(command, list) and isinstance(exist_conf, list):
         nu, new_conf_dict = derive_config_from_merged_cmd_dict({"config": command},
@@ -268,10 +266,8 @@ def derive_config_from_merged_cmd_dict(command, exist_conf, test_keys=None, key_
 
 def derive_config_from_deleted_cmd(command, exist_conf, test_keys=None):
 
-    if not command:
+    if not command or not exist_conf:
         return exist_conf
-    if not exist_conf:
-        return []
 
     if isinstance(command, list) and isinstance(exist_conf, list):
         nu, new_conf_dict = derive_config_from_deleted_cmd_dict({"config": command},

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -109,6 +109,9 @@ def get_test_key_set_and_delete_op(key, test_keys):
 
 def get_new_config(commands, exist_conf, test_keys=None):
 
+    if not commands:
+        return exist_conf
+
     cmds = deepcopy(commands)
 
     n_conf = list()

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -39,6 +39,8 @@ def get_key_sets(dict_conf):
 """
 Delete entire configuration.
 """
+
+
 def __DELETE_CONFIG(key_set, command, exist_conf):
     new_conf = []
     return True, new_conf
@@ -47,6 +49,8 @@ def __DELETE_CONFIG(key_set, command, exist_conf):
 """
 Delete entire configuration if there is no sub-configuration.
 """
+
+
 def __DELETE_CONFIG_IF_NO_SUBCONFIG(key_set, command, exist_conf):
     nu, dict_list_cmd_key_set = get_key_sets(command)
     if len(dict_list_cmd_key_set) == 0:
@@ -60,6 +64,8 @@ def __DELETE_CONFIG_IF_NO_SUBCONFIG(key_set, command, exist_conf):
 """
 Delete sub-configuration and leaf configuration, if any.
 """
+
+
 def __DELETE_SUBCONFIG_AND_LEAFS(key_set, command, exist_conf):
     new_conf = exist_conf
 
@@ -80,6 +86,8 @@ def __DELETE_SUBCONFIG_AND_LEAFS(key_set, command, exist_conf):
 """
 Delete sub-configuration only, if any.
 """
+
+
 def __DELETE_SUBCONFIG_ONLY(key_set, command, exist_conf):
     new_conf = exist_conf
     nu, dict_list_cmd_key_set = get_key_sets(command)
@@ -94,6 +102,8 @@ def __DELETE_SUBCONFIG_ONLY(key_set, command, exist_conf):
 Delete configuration if there is no non-key leaf, and
 delete non-key leaf configuration, if any.
 """
+
+
 def __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF(key_set, command, exist_conf):
     new_conf = exist_conf
     trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
@@ -116,6 +126,8 @@ Delete configuration if there is no non-key leaf, and
 delete non-key leaf configuration, if any, if the values of non-key leaf are
 equal between command and existing configuration.
 """
+
+
 def __DELETE_OP_DEFAULT(key_set, command, exist_conf):
     new_conf = exist_conf
     trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)


### PR DESCRIPTION
SUMMARY
- add diff and check modes support for NTP and TACACS modules.
- add some change on get_new_config utility functions.

GitHub Issues
N/A

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
sonic_ntp, sonic_tacacs_server

OUTPUT
- NTP regression test log: 
[regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12088333/regression_test.log)
- NTP regression test result: 
[regression-2023-07-18-10-46-56.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12088336/regression-2023-07-18-10-46-56.html.pdf)
- NTP unit test script:
[ntp.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12088337/ntp.txt)
- NTP unit test with --diff option log:
[ut_diff.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12088340/ut_diff.log)
- NTP unit test with --diff and --check options log:
[ut_diff_check.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12088345/ut_diff_check.log)
- TACACS regression test log: 
[regression_tacacs.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12163895/regression_tacacs.log)
- TACACS regression test result:
[regression-2023-07-21-09-33-31.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12163898/regression-2023-07-21-09-33-31.html.pdf)
- TACACS unit test script:
[tacacs.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12163900/tacacs.txt)
- TACACS unit test with --diff option:
[ut_tacacs_diff.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12163908/ut_tacacs_diff.log)
- TACACS unit test with --diff and --check: 
[ut_tacacs_diff_check.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12163911/ut_tacacs_diff_check.log)


Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

How Has This Been Tested?
Tested with real SONIC system. Did regression and unit test with test script.
