### PR TITLE
Fix the bgp CLI automated regression test external playbook failure 

### DIFF
--- a/changelogs/fragments/282-bgp-cli-auto-regression-fix.yaml
+++ b/changelogs/fragments/282-bgp-cli-auto-regression-fix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - regression_test - Fix the bgp CLI test base_cfg_path derivation of the bgp role_path by avoiding relative pathing from the possibly external playbook_dir (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/282).

--- a/changelogs/fragments/282-bgp-cli-auto-regression-fix.yaml
+++ b/changelogs/fragments/282-bgp-cli-auto-regression-fix.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - regression_test - Fix the bgp CLI test base_cfg_path derivation of the bgp role_path by avoiding relative pathing from the possibly external playbook_dir (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/282).

--- a/changelogs/fragments/283-bgp-cli-auto-regression-fix.yaml
+++ b/changelogs/fragments/283-bgp-cli-auto-regression-fix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - bgp - Fix the bgp CLI test base_cfg_path derivation of the bgp role_path by avoiding relative pathing from the possibly external playbook_dir (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/283).

--- a/tests/regression/roles/sonic_bgp/tasks/main.yml
+++ b/tests/regression/roles/sonic_bgp/tasks/main.yml
@@ -1,7 +1,7 @@
 - debug: msg="sonic_interfaces Test started ..."
 
 - set_fact: 
-    base_cfg_path: "{{ playbook_dir + '/roles/' + role_name + '/' + 'templates/' }}"
+    base_cfg_path: "{{ role_path + '/' + 'templates/' }}"
 
 - name: Preparations test
   include_tasks: preparation_tests.yaml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the bgp CLI test base_cfg_path derivation of the bgp role_path by avoiding relative pathing from the possibly external playbook_dir.

Explanation: The automated regression test infrastructure runs the regression suite using a top level playbook file that is located outside of the repo being tested. This is valid. The failure seen with the regression suite in the bgp resource module "CLI" test was caused by the fact that the path to the bgp resource module regression test "role" was derived in the bgp regression test "main" task using an assumed relative path from the playbook instead of explicitly using the known path to the role.
##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bgp
##### OUTPUT
<!--- Paste the functionality test result below -->

### HTML summary result in a local workspace

[bgp_auto_regression_cli_fix.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12176512/bgp_auto_regression_cli_fix.pdf)

### Detailed log from a local workspace

[bgp_cli_regression_fix.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12176528/bgp_cli_regression_fix.log)

### HTML summary from an automated nightly run with the fix applied
[bgp_auto_regression_cli_fix_all_tests.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12176551/bgp_auto_regression_cli_fix_all_tests.pdf)



##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
### Example failing run without the fix
[bgp_auto_regression_without_cli_fix_all_tests.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12176631/bgp_auto_regression_without_cli_fix_all_tests.pdf)

<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- automated test without the fix
- manual test with the fix, looking at log file details
- automated test with the fix