### PR TITLE
Add check and diff modes support for system and port group modules

### DIFF
--- a/changelogs/fragments/284-playbook-check-diff-modes-for-system-and-port-group-modules.yaml
+++ b/changelogs/fragments/284-playbook-check-diff-modes-for-system-and-port-group-modules.yaml
@@ -1,0 +1,2 @@
+major_changes:
+        - system_and_port_group - Playbook check and diff modes support for sonic_system and sonic_port_group modules (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/284).

--- a/plugins/module_utils/network/sonic/config/port_group/port_group.py
+++ b/plugins/module_utils/network/sonic/config/port_group/port_group.py
@@ -16,11 +16,11 @@ __metaclass__ = type
 """
 The use of natsort causes sanity error due to it is not available in python version currently used.
 When natsort becomes available, the code here and below using it will be applied.
-"""
 from natsort import (
     natsorted,
     ns
 )
+"""
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/port_group/port_group.py
+++ b/plugins/module_utils/network/sonic/config/port_group/port_group.py
@@ -13,6 +13,10 @@ created
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from natsort import (
+    natsorted,
+    ns
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )
@@ -31,6 +35,11 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     update_states,
     remove_empties_from_list
 )
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
+    __DELETE_CONFIG_IF_NO_SUBCONFIG,
+    get_new_config,
+    get_formatted_config_diff
+)
 from ansible.module_utils.connection import ConnectionError
 
 GET = "get"
@@ -42,6 +51,9 @@ TEST_KEYS = [
     {
         'config': {'id': ''}
     }
+]
+TEST_KEYS_formatted_diff = [
+    {'config': {'id': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}}
 ]
 
 
@@ -107,6 +119,17 @@ class Port_group(ConfigBase):
         if result['changed']:
             result['after'] = changed_port_group_facts
 
+        new_config = changed_port_group_facts
+        if self._module.check_mode:
+            result.pop('after', None)
+            new_config = get_new_config(commands, existing_port_group_facts,
+                                        TEST_KEYS_formatted_diff)
+            new_config = natsorted(new_config, key=lambda x: x['id'])
+            result['after(generated)'] = new_config
+
+        if self._module._diff:
+            result['config_diff'] = get_formatted_config_diff(existing_port_group_facts,
+                                                              new_config)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/port_group/port_group.py
+++ b/plugins/module_utils/network/sonic/config/port_group/port_group.py
@@ -13,6 +13,10 @@ created
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+"""
+The use of natsort causes sanity error due to it is not available in python version currently used.
+When natsort becomes available, the code here and below using it will be applied.
+"""
 from natsort import (
     natsorted,
     ns
@@ -124,7 +128,8 @@ class Port_group(ConfigBase):
             result.pop('after', None)
             new_config = get_new_config(commands, existing_port_group_facts,
                                         TEST_KEYS_formatted_diff)
-            new_config = natsorted(new_config, key=lambda x: x['id'])
+            # See the above comment about natsort module
+            # new_config = natsorted(new_config, key=lambda x: x['id'])
             result['after(generated)'] = new_config
 
         if self._module._diff:

--- a/plugins/module_utils/network/sonic/config/system/system.py
+++ b/plugins/module_utils/network/sonic/config/system/system.py
@@ -33,9 +33,36 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     to_request,
     edit_config
 )
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
+    get_new_config,
+    get_formatted_config_diff
+)
 
 PATCH = 'patch'
 DELETE = 'delete'
+
+
+def __derive_system_config_delete_op(key_set, command, exist_conf):
+    new_conf = exist_conf
+
+    if 'hostname' in command:
+        new_conf['hostname'] = 'sonic'
+    if 'interface_naming' in command:
+        new_conf['interface_naming'] = 'native'
+    if 'anycast_address' in command and 'anycast_address' in new_conf:
+        if 'ipv4' in command['anycast_address']:
+            new_conf['anycast_address']['ipv4'] = True
+        if 'ipv6' in command['anycast_address']:
+            new_conf['anycast_address']['ipv6'] = True
+        if 'mac_address' in command['anycast_address']:
+            new_conf['anycast_address']['mac_address'] = None
+
+    return True, new_conf
+
+
+TEST_KEYS_formatted_diff = [
+    {'__delete_op_default': {'__delete_op': __derive_system_config_delete_op}},
+]
 
 
 class System(ConfigBase):
@@ -91,6 +118,16 @@ class System(ConfigBase):
         if result['changed']:
             result['after'] = changed_system_facts
 
+        new_config = changed_system_facts
+        if self._module.check_mode:
+            result.pop('after', None)
+            new_config = get_new_config(commands, existing_system_facts,
+                                        TEST_KEYS_formatted_diff)
+            result['after(generated)'] = new_config
+
+        if self._module._diff:
+            result['config_diff'] = get_formatted_config_diff(existing_system_facts,
+                                                              new_config)
         result['warnings'] = warnings
         return result
 


### PR DESCRIPTION
SUMMARY
This is to add check and diff modes support for system and port-group modules.

GitHub Issues
N/A

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
sonic_system, sonic_port_group

OUTPUT
- system regression result: 
[system_regression-2023-08-02-09-29-53.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12242936/system_regression-2023-08-02-09-29-53.html.pdf)
- system unit test script: 
[system.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12242951/system.txt)
- system unit test log with --diff option: 
[sys_log_diff.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12242952/sys_log_diff.log)
- system unit test with --diff and --check options:
[sys_log_diff_check.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12242955/sys_log_diff_check.log)
- port group regression result:
[port_group_regression-2023-08-02-09-14-56.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12242959/port_group_regression-2023-08-02-09-14-56.html.pdf)
- port group unit test script:
[port_group.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12242965/port_group.txt)
- port group unit test log with --diff option:
[pg_log_diff.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12242975/pg_log_diff.log)
- port group unit test log with --diff and -- check options:
[pg_log_diff_check.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12242977/pg_log_diff_check.log)

Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

How Has This Been Tested?
- used real SONIC systems and tested regression and unit tests.
