### PR TITLE
Add diff check modes support for vrfs logging and ip_neighbor modules

### DIFF
--- a/changelogs/fragments/285-playbook-check-diff-modes-for-vrfs-logging-ip-neighbor.yaml
+++ b/changelogs/fragments/285-playbook-check-diff-modes-for-vrfs-logging-ip-neighbor.yaml
@@ -1,0 +1,2 @@
+major_changes:
+        - vrfs_logging_ip_neighbor - Playbook check and diff modes supports for sonic_vrfs, sonic_logging and sonic_ip_neighbor modules (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/285).


### PR DESCRIPTION
SUMMARY
This is to add diff and check modes supports for ip_neigbor, vrfs and logging modules.

GitHub Issues
N/A

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
sonic_vrfs, sonic_ip_neighbor, sonic_logging

OUTPUT
- ip_neighbor regression result:
[ip_regression-2023-08-07-09-19-08.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283155/ip_regression-2023-08-07-09-19-08.html.pdf)
- ip_neigbor: unit test script:
[ip_neighbor.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283159/ip_neighbor.txt)
- ip_neighbor unit test with --diff option:
[ip_log_diff.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283162/ip_log_diff.log)
- ip_neighbor unit test with --diff and --check options:
[ip_log_diff_check.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283169/ip_log_diff_check.log)

- logging regression result:
[log_regression-2023-08-07-09-26-32.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283173/log_regression-2023-08-07-09-26-32.html.pdf)
- logging unit test script:
[logging.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283183/logging.txt)
- logging unit test with --diff option:
[log_log_diff.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283188/log_log_diff.log)
- logging unit test with --diff and --check options:
[log_log_diff_check.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283191/log_log_diff_check.log)

- vrfs regression result:
[vrf_regression-2023-08-07-09-34-08.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283195/vrf_regression-2023-08-07-09-34-08.html.pdf)
- vrfs unit test script:
[vrfs.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283199/vrfs.txt)
- vrfs unit test with --diff option:
[vrf_log_diff.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283200/vrf_log_diff.log)
- vrfs unit test with --diff and --check options:
[vrf_log_diff_check.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12283203/vrf_log_diff_check.log)

Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

How Has This Been Tested?
Used real SONIC systems and tested regression and unit tests.
