### PR TITLE
Fixed BGP neighbors prefix-limit bug

### DIFF
--- a/changelogs/fragments/289-bgp-neighbors-prefix-limit-fix.yaml
+++ b/changelogs/fragments/289-bgp-neighbors-prefix-limit-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sonic_bgp_neighbors - Fixed prefix-limit issue (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/289)

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors/bgp_neighbors.py
@@ -403,7 +403,7 @@ class Bgp_neighbors(ConfigBase):
                             if each.get('prefix_limit', None) is not None:
                                 pfx_lmt_cfg = get_prefix_limit_payload(each['prefix_limit'])
                             if pfx_lmt_cfg and afi_safi == 'L2VPN_EVPN':
-                                samp.update({'l2vpn-evpn': {'prefix-limit': {'config': pfx_lmt_cfg}}})
+                                self._module.fail_json('Prefix limit configuration not supported for l2vpn evpn')
                             else:
                                 if each.get('ip_afi', None) is not None:
                                     afi_safi_cfg = get_ip_afi_cfg_payload(each['ip_afi'])
@@ -838,9 +838,6 @@ class Bgp_neighbors(ConfigBase):
                                 requests.extend(self.delete_ip_afi_requests(ip_afi, afi_safi_name, 'ipv6-unicast', delete_static_path))
                             if prefix_limit:
                                 requests.extend(self.delete_prefix_limit_requests(prefix_limit, afi_safi_name, 'ipv6-unicast', delete_static_path))
-                        elif afi_safi == 'L2VPN_EVPN':
-                            if prefix_limit:
-                                requests.extend(self.delete_prefix_limit_requests(prefix_limit, afi_safi_name, 'l2vpn-evpn', delete_static_path))
 
         return requests
 

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -283,7 +283,7 @@ class Bgp_neighbors_af(ConfigBase):
                 if conf_prefix_limit:
                     pfx_lmt_cfg = get_prefix_limit_payload(conf_prefix_limit)
                 if pfx_lmt_cfg and afi_safi_val == 'L2VPN_EVPN':
-                    afi_safi['l2vpn-evpn'] = {'prefix-limit': {'config': pfx_lmt_cfg}}
+                    self._module.fail_json('Prefix limit configuration not supported for l2vpn evpn')
                 else:
                     if conf_ip_afi:
                         ip_afi_cfg = get_ip_afi_cfg_payload(conf_ip_afi)

--- a/plugins/module_utils/network/sonic/facts/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_neighbors_af/bgp_neighbors_af.py
@@ -120,7 +120,6 @@ class Bgp_neighbors_afFacts(object):
 
                     ipv4_unicast = norm_nei_af.get('ipv4_unicast', None)
                     ipv6_unicast = norm_nei_af.get('ipv6_unicast', None)
-                    l2vpn_evpn = norm_nei_af.get('l2vpn_evpn', None)
                     if ipv4_unicast:
                         if 'config' in ipv4_unicast:
                             ip_afi = update_bgp_nbr_pg_ip_afi_dict(ipv4_unicast['config'])
@@ -141,12 +140,6 @@ class Bgp_neighbors_afFacts(object):
                             if prefix_limit:
                                 norm_nei_af['prefix_limit'] = prefix_limit
                         norm_nei_af.pop('ipv6_unicast')
-                    elif l2vpn_evpn:
-                        if 'config' in l2vpn_evpn:
-                            prefix_limit = update_bgp_nbr_pg_prefix_limit_dict(l2vpn_evpn['config'])
-                            if prefix_limit:
-                                norm_nei_af['prefix_limit'] = prefix_limit
-                        norm_nei_af.pop('l2vpn_evpn')
 
                     norm_neighbor_afs.append(norm_nei_af)
             if norm_neighbor_afs:

--- a/plugins/module_utils/network/sonic/utils/bgp_utils.py
+++ b/plugins/module_utils/network/sonic/utils/bgp_utils.py
@@ -189,11 +189,6 @@ def get_peergroups(module, vrf_name):
                                 prefix_limit = update_bgp_nbr_pg_prefix_limit_dict(pfx_lmt_conf)
                                 if prefix_limit:
                                     samp.update({'prefix_limit': prefix_limit})
-                        elif 'l2vpn-evpn' in each and 'prefix-limit' in each['l2vpn-evpn'] and 'config' in each['l2vpn-evpn']['prefix-limit']:
-                            pfx_lmt_conf = each['l2vpn-evpn']['prefix-limit']['config']
-                            prefix_limit = update_bgp_nbr_pg_prefix_limit_dict(pfx_lmt_conf)
-                            if prefix_limit:
-                                samp.update({'prefix_limit': prefix_limit})
                         if 'prefix-list' in each and 'config' in each['prefix-list']:
                             pfx_lst_conf = each['prefix-list']['config']
                             if 'import-policy' in pfx_lst_conf and pfx_lst_conf['import-policy']:

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -296,7 +296,7 @@ options:
                         default: False
                   prefix_limit:
                     description:
-                      - Specifies prefix limit attributes.
+                      - Specifies prefix limit attributes for ipv4-unicast and ipv6-unicast.
                     type: dict
                     suboptions:
                       max_prefixes:

--- a/plugins/modules/sonic_bgp_neighbors_af.py
+++ b/plugins/modules/sonic_bgp_neighbors_af.py
@@ -127,7 +127,7 @@ options:
                     default: False
               prefix_limit:
                 description:
-                  - Specifies prefix limit attributes.
+                  - Specifies prefix limit attributes for ipv4-unicast and ipv6-unicast.
                 type: dict
                 suboptions:
                   max_prefixes:

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -116,10 +116,6 @@ deleted_tests:
                   prefix_list_out: p2
                 - afi: l2vpn
                   safi: evpn
-                  prefix_limit:
-                    max_prefixes: 4
-                    warning_threshold: 66
-                    restart_timer: 15
                   prefix_list_in: p2
                   prefix_list_out: p1
 
@@ -830,10 +826,6 @@ merged_tests:
                   prefix_list_out: p1
                 - afi: l2vpn
                   safi: evpn
-                  prefix_limit:
-                    max_prefixes: 3
-                    warning_threshold: 60
-                    restart_timer: 8
                   prefix_list_in: p1
                   prefix_list_out: p2
   - name: test_case_09
@@ -870,9 +862,5 @@ merged_tests:
                   prefix_list_out: p2
                 - afi: l2vpn
                   safi: evpn
-                  prefix_limit:
-                    max_prefixes: 4
-                    warning_threshold: 66
-                    restart_timer: 15
                   prefix_list_in: p2
                   prefix_list_out: p1

--- a/tests/regression/roles/sonic_bgp_neighbors_af/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors_af/defaults/main.yml
@@ -382,10 +382,6 @@ tests:
                 prefix_list_out: p1
               - afi: l2vpn
                 safi: evpn
-                prefix_limit:
-                  max_prefixes: 3
-                  warning_threshold: 60
-                  restart_timer: 8
                 prefix_list_in: p1
                 prefix_list_out: p2
   - name: test_case_06
@@ -421,10 +417,6 @@ tests:
                 prefix_list_out: p2
               - afi: l2vpn
                 safi: evpn
-                prefix_limit:
-                  max_prefixes: 4
-                  warning_threshold: 66
-                  restart_timer: 15
                 prefix_list_in: p2
                 prefix_list_out: p1
   - name: test_case_07
@@ -460,9 +452,5 @@ tests:
                 prefix_list_out: p2
               - afi: l2vpn
                 safi: evpn
-                prefix_limit:
-                  max_prefixes: 4
-                  warning_threshold: 66
-                  restart_timer: 15
                 prefix_list_in: p2
                 prefix_list_out: p1

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
@@ -51,10 +51,6 @@ merged_01:
                 safi: evpn
                 allowas_in:
                   value: 22
-                prefix_limit:
-                  max_prefixes: 1
-                  prevent_teardown: true
-                  warning_threshold: 11
                 prefix_list_in: p5
                 prefix_list_out: p6
   existing_bgp_config:
@@ -128,12 +124,6 @@ merged_01:
                 config:
                   import-policy: p5
                   export-policy: p6
-              l2vpn-evpn:
-                prefix-limit: 
-                  config:
-                    max-prefixes: 1
-                    prevent-teardown: True
-                    warning-threshold-pct: 11
               allow-own-as:
                 config:
                   as-count: 22


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
SONiC code no longer supports prefix-limit configuration for l2vpn evpn. I updated module code and test cases to reflect this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_bgp_neighbors
sonic_bgp_neighbors_af

##### OUTPUT
[regression-2023-08-21-10-39-08.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12399348/regression-2023-08-21-10-39-08.html.pdf)
[regression-2023-08-21-11-39-02.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12399686/regression-2023-08-21-11-39-02.html.pdf)
[prefix_limit_test_case_err_msg.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12399700/prefix_limit_test_case_err_msg.txt)


##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

