### PR TITLE
bgp_as_paths - Add support for 'replaced' and 'overridden' states

### DIFF
--- a/changelogs/fragments/290-bgp-as-paths-replaced-overridden-support.yaml
+++ b/changelogs/fragments/290-bgp-as-paths-replaced-overridden-support.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - sonic_bgp_as_paths - Add support for replaced and overridden states (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/290).

--- a/plugins/module_utils/network/sonic/argspec/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_as_paths/bgp_as_paths.py
@@ -43,6 +43,6 @@ class Bgp_as_pathsArgs(object):  # pylint: disable=R0903
                                                         'type': 'list'},
                                             'name': {'required': True, 'type': 'str'}},
                                 'type': 'list'},
-                     'state': {'choices': ['merged', 'deleted'],
+                     'state': {'choices': ['merged', 'deleted', 'replaced', 'overridden'],
                                'default': 'merged',
                                'type': 'str'}}  # pylint: disable=C0301

--- a/plugins/module_utils/network/sonic/config/bgp_as_paths/bgp_as_paths.py
+++ b/plugins/module_utils/network/sonic/config/bgp_as_paths/bgp_as_paths.py
@@ -17,6 +17,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.c
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
+    search_obj_in_list
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.facts import Facts
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
@@ -119,38 +120,142 @@ class Bgp_as_paths(ConfigBase):
         commands = []
         requests = []
         state = self._module.params['state']
-        diff = get_diff(want, have)
         if state == 'overridden':
-            commands, requests = self._state_overridden(want, have, diff)
+            commands, requests = self._state_overridden(want, have)
         elif state == 'deleted':
             commands, requests = self._state_deleted(want, have)
         elif state == 'merged':
+            diff = get_diff(want, have)
             commands, requests = self._state_merged(want, have, diff)
         elif state == 'replaced':
-            commands, requests = self._state_replaced(want, have, diff)
+            commands, requests = self._state_replaced(want, have)
         return commands, requests
 
-    @staticmethod
-    def _state_replaced(**kwargs):
+    def _state_replaced(self, want, have):
         """ The command generator when state is replaced
 
         :rtype: A list
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
+        add_commands = []
+        del_commands = []
         commands = []
-        return commands
+        requests = []
 
-    @staticmethod
-    def _state_overridden(**kwargs):
+        for cmd in want:
+            # Set action to deny if not specfied for as-path-list
+            if cmd.get('permit') is None:
+                cmd['permit'] = False
+
+            match = search_obj_in_list(cmd['name'], have, 'name')
+            # Replace existing as-path-list
+            if match:
+                # Delete entire as-path-list if no members are specified
+                if not cmd.get('members'):
+                    del_commands.append(match)
+                    requests.append(self.get_delete_single_as_path_request(cmd['name']))
+                else:
+                    if cmd['permit'] != match['permit']:
+                        # If action is changed, delete the entire as-path list
+                        # and add the given configuration
+                        del_commands.append(match)
+                        requests.append(self.get_delete_single_as_path_request(cmd['name']))
+                        add_commands.append(cmd)
+                        requests.append(self.get_new_add_request(cmd))
+                    else:
+                        want_members_set = set(cmd['members'])
+                        have_members_set = set(match['members'])
+                        members_to_delete = list(have_members_set.difference(want_members_set))
+                        members_to_add = list(want_members_set.difference(have_members_set))
+                        if members_to_delete:
+                            del_commands.append({'name': cmd['name'], 'permit': cmd['permit'], 'members': members_to_delete})
+                            if len(members_to_delete) == len(match['members']):
+                                requests.append(self.get_delete_single_as_path_request(cmd['name']))
+                            else:
+                                requests.append(self.get_delete_single_as_path_member_request(cmd['name'], members_to_delete))
+
+                        if members_to_add:
+                            add_commands.append({'name': cmd['name'], 'permit': cmd['permit'], 'members': members_to_add})
+                            requests.append(self.get_new_add_request({'name': cmd['name'], 'permit': cmd['permit'], 'members': members_to_add}))
+            else:
+                if cmd.get('members'):
+                    add_commands.append(cmd)
+                    requests.append(self.get_new_add_request(cmd))
+
+        if del_commands:
+            commands = update_states(del_commands, 'deleted')
+
+        if add_commands:
+            commands.extend(update_states(add_commands, 'replaced'))
+
+        return commands, requests
+
+    def _state_overridden(self, want, have):
         """ The command generator when state is overridden
 
         :rtype: A list
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
+        add_commands = []
+        del_commands = []
         commands = []
-        return commands
+        requests = []
+
+        # Delete as-path-lists that are not specified
+        for cfg in have:
+            if not search_obj_in_list(cfg['name'], want, 'name'):
+                del_commands.append(cfg)
+                requests.append(self.get_delete_single_as_path_request(cfg['name']))
+
+        for cmd in want:
+            # Set action to deny if not specfied for as-path-list
+            if cmd.get('permit') is None:
+                cmd['permit'] = False
+
+            match = search_obj_in_list(cmd['name'], have, 'name')
+            # Override existing as-path-list
+            if match:
+                # Delete entire as-path-list if no members are specified
+                if not cmd.get('members'):
+                    del_commands.append(match)
+                    requests.append(self.get_delete_single_as_path_request(cmd['name']))
+                else:
+                    if cmd['permit'] != match['permit']:
+                        # If action is changed, delete the entire as-path list
+                        # and add the given configuration
+                        del_commands.append(match)
+                        requests.append(self.get_delete_single_as_path_request(cmd['name']))
+                        add_commands.append(cmd)
+                        requests.append(self.get_new_add_request(cmd))
+                    else:
+                        want_members_set = set(cmd['members'])
+                        have_members_set = set(match['members'])
+                        members_to_delete = list(have_members_set.difference(want_members_set))
+                        members_to_add = list(want_members_set.difference(have_members_set))
+                        if members_to_delete:
+                            del_commands.append({'name': cmd['name'], 'permit': cmd['permit'], 'members': members_to_delete})
+                            if len(members_to_delete) == len(match['members']):
+                                requests.append(self.get_delete_single_as_path_request(cmd['name']))
+                            else:
+                                requests.append(self.get_delete_single_as_path_member_request(cmd['name'], members_to_delete))
+
+                        if members_to_add:
+                            add_commands.append({'name': cmd['name'], 'permit': cmd['permit'], 'members': members_to_add})
+                            requests.append(self.get_new_add_request({'name': cmd['name'], 'permit': cmd['permit'], 'members': members_to_add}))
+            else:
+                if cmd.get('members'):
+                    add_commands.append(cmd)
+                    requests.append(self.get_new_add_request(cmd))
+
+        if del_commands:
+            commands = update_states(del_commands, 'deleted')
+
+        if add_commands:
+            commands.extend(update_states(add_commands, 'overridden'))
+
+        return commands, requests
 
     def _state_merged(self, want, have, diff):
         """ The command generator when state is merged
@@ -239,7 +344,7 @@ class Bgp_as_paths(ConfigBase):
             requests.append(request)
         return requests
 
-    def get_delete_single_as_path_member_requests(self, name, members):
+    def get_delete_single_as_path_member_request(self, name, members):
         url = "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:"
         url = url + "bgp-defined-sets/as-path-sets/as-path-set={name}/config/{members_param}"
         method = "DELETE"
@@ -248,7 +353,7 @@ class Bgp_as_paths(ConfigBase):
         request = {"path": url.format(name=name, members_param=members_str), "method": method}
         return request
 
-    def get_delete_single_as_path_requests(self, name):
+    def get_delete_single_as_path_request(self, name):
         url = "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set={}"
         method = "DELETE"
         request = {"path": url.format(name), "method": method}
@@ -270,11 +375,11 @@ class Bgp_as_paths(ConfigBase):
                             del_members = set(match['members']).intersection(set(members))
                             if del_members:
                                 if len(del_members) == len(match['members']):
-                                    requests.append(self.get_delete_single_as_path_requests(name))
+                                    requests.append(self.get_delete_single_as_path_request(name))
                                 else:
-                                    requests.append(self.get_delete_single_as_path_member_requests(name, del_members))
+                                    requests.append(self.get_delete_single_as_path_member_request(name, del_members))
                     else:
-                        requests.append(self.get_delete_single_as_path_requests(name))
+                        requests.append(self.get_delete_single_as_path_request(name))
 
         return requests
 

--- a/plugins/modules/sonic_bgp_as_paths.py
+++ b/plugins/modules/sonic_bgp_as_paths.py
@@ -71,6 +71,8 @@ options:
     choices:
     - merged
     - deleted
+    - replaced
+    - overridden
     default: merged
 """
 EXAMPLES = """
@@ -84,14 +86,14 @@ EXAMPLES = """
 #   action: permit
 #   members: 808.*,909.*
 
-- name: Delete BGP as path list
-  dellemc.enterprise_sonic.sonic_bgp_as_paths:
-    config:
-      - name: test
-        members:
-        - 909.*
-        permit: true
-    state: deleted
+  - name: Delete BGP as path list
+    dellemc.enterprise_sonic.sonic_bgp_as_paths:
+      config:
+        - name: test
+          members:
+            - 909.*
+          permit: true
+      state: deleted
 
 # After state:
 # ------------
@@ -115,12 +117,12 @@ EXAMPLES = """
 #   action: deny
 #   members: 608.*,709.*
 
-- name: Deletes BGP as-path list
-  dellemc.enterprise_sonic.sonic_bgp_as_paths:
-    config:
-      - name: test
-        members:
-    state: deleted
+  - name: Deletes BGP as-path list
+    dellemc.enterprise_sonic.sonic_bgp_as_paths:
+      config:
+        - name: test
+          members:
+      state: deleted
 
 # After state:
 # ------------
@@ -141,10 +143,10 @@ EXAMPLES = """
 #   action: permit
 #   members: 808.*,909.*
 
-- name: Deletes BGP as-path list
-  dellemc.enterprise_sonic.sonic_bgp_as_paths:
-    config:
-    state: deleted
+  - name: Deletes BGP as-path list
+    dellemc.enterprise_sonic.sonic_bgp_as_paths:
+      config:
+      state: deleted
 
 # After state:
 # ------------
@@ -159,16 +161,16 @@ EXAMPLES = """
 # -------------
 #
 # show bgp as-path-access-list
-# AS path list test:
+# (No bgp as-path-access-list configuration present)
 
-- name: Adds 909.* to test as-path list
-  dellemc.enterprise_sonic.sonic_bgp_as_paths:
-    config:
-      - name: test
-        members:
-        - 909.*
-        permit: true
-    state: merged
+  - name: Create a BGP as-path list
+    dellemc.enterprise_sonic.sonic_bgp_as_paths:
+      config:
+        - name: test
+          members:
+            - 909.*
+          permit: true
+      state: merged
 
 # After state:
 # ------------
@@ -177,6 +179,78 @@ EXAMPLES = """
 # AS path list test:
 #   action: permit
 #   members: 909.*
+
+
+# Using replaced
+
+# Before state:
+# -------------
+#
+# show bgp as-path-access-list
+# AS path list test:
+#    action: permit
+#    members: 800.*,808.*
+# AS path list test1:
+#    action: deny
+#    members: 500.*
+
+  - name: Replace device configuration of specified BGP as-path lists with provided configuration
+    dellemc.enterprise_sonic.sonic_bgp_as_paths:
+      config:
+        - name: test
+          members:
+            - 900.*
+            - 901.*
+          permit: true
+        - name: test1
+        - name: test2
+          members:
+            - 100.*
+          permit: true
+      state: replaced
+
+# After state:
+# ------------
+#
+# show bgp as-path-access-list
+# AS path list test:
+#    action: permit
+#    members: 900.*,901.*
+# AS path list test2:
+#    action: permit
+#    members: 100.*
+
+
+# Using overridden
+
+# Before state:
+# -------------
+#
+# show bgp as-path-access-list
+# AS path list test:
+#    action: permit
+#    members: 800.*,808.*
+# AS path list test1:
+#    action: deny
+#    members: 500.*
+
+  - name: Override device configuration of all BGP as-path lists with provided configuration
+    dellemc.enterprise_sonic.sonic_bgp_as_paths:
+      config:
+        - name: test
+          members:
+            - 900.*
+            - 901.*
+          permit: true
+      state: overridden
+
+# After state:
+# ------------
+#
+# show bgp as-path-access-list
+# AS path list test:
+#    action: permit
+#    members: 900.*,901.*
 
 
 """

--- a/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_as_paths/defaults/main.yml
@@ -10,7 +10,7 @@ vrf_2: VrfReg2
 
 tests:
   - name: test_case_01
-    description: BGP properties
+    description: Add BGP as-path lists
     state: merged
     input:
       - name: test
@@ -22,58 +22,124 @@ tests:
           - "101.101"
         permit: False
   - name: test_case_02
-    description: Update created BGP properties
+    description: Update BGP as-path lists
     state: merged
     input:
-        - name: test
-          members:
-            - "11"
-            - "22"
-            - "33"
-            - 44
-          permit: True
-        - name: test_1
-          members:
-            - "101.101"
-            - "201.201"
-            - "301.301"
-          permit: False
-        - name: test_2
-          members:
-            - "110"
-            - "111*"
-            - "112*"
-            - "^113"
-            - "45$"
-          permit: True
+      - name: test
+        members:
+          - "11"
+          - "22"
+          - "33"
+          - 44
+        permit: True
+      - name: test_1
+        members:
+          - "101.101"
+          - "201.201"
+          - "301.301"
+        permit: False
+      - name: test_2
+        members:
+          - "110"
+          - "111*"
+          - "112*"
+          - "^113"
+          - "45$"
+        permit: True
   - name: test_case_03
-    description: Delete BGP properties
+    description: Delete BGP as-path lists' members
     state: deleted
     input:
-        - name: test
-          members:
-            - "33"
-        - name: test_1
-          members:
-            - "101.101"
-            - "201.201"
-            - "301.301"
-          permit: False
-        - name: test_2
-          members:
-            - "111*"
-            - "112*"
-            - "^113"
-            - "45$"
-          permit: True
+      - name: test
+        members:
+          - "33"
+      - name: test_1
+        members:
+          - "101.101"
+          - "201.201"
+          - "301.301"
+        permit: False
+      - name: test_2
+        members:
+          - "111*"
+          - "112*"
+          - "^113"
+          - "45$"
+        permit: True
   - name: test_case_04
-    description: Delete BGP properties
+    description: Add BGP as-path lists
+    state: merged
+    input:
+      - name: test_1
+        members:
+          - "100.*"
+          - "200.*"
+        permit: False
+      - name: test_2
+        members:
+          - "110"
+          - "120"
+          - "^800"
+          - "25$"
+        permit: True
+      - name: test_3
+        members:
+          - "900.*"
+          - "910.*"
+        permit: False
+  - name: test_case_05
+    description: Replace BGP as-path lists
+    state: replaced
+    input:
+      - name: test
+      - name: test_1
+        members:
+          - "301.301"
+        permit: False
+      - name: test_2
+        members:
+          - "111*"
+          - "112*"
+          - "^800"
+          - "25$"
+        permit: True
+      - name: test_3
+        members:
+          - "900.*"
+          - "910.*"
+        permit: True
+      - name: test_4
+        members:
+          - "800.*"
+        permit: True
+  - name: test_case_06
+    description: Override BGP as-path lists
+    state: overridden
+    input:
+      - name: test
+        members:
+          - "33.*"
+          - "44.*"
+        permit: True
+      - name: test_1
+        members:
+          - "201.201"
+          - "301.301"
+        permit: False
+      - name: test_2
+        members:
+          - "111*"
+          - "^800"
+          - "25$"
+        permit: True
+  - name: test_case_07
+    description: Delete BGP as-path list
     state: deleted
     input:
-        - name: test
-          members:
-          permit:
-  - name: test_case_05
-    description: Delete BGP properties
+      - name: test
+        members:
+        permit:
+  - name: test_case_08
+    description: Delete all BGP as-path list
     state: deleted
     input: []

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_as_paths.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_as_paths.yaml
@@ -144,3 +144,351 @@ deleted_02:
   expected_config_requests:
     - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test"
       method: "delete"
+
+replaced_01:
+  module_args:
+    state: replaced
+    config:
+      - name: test
+      - name: test_1
+        members:
+          - "301.301"
+        permit: False
+      - name: test_2
+        members:
+          - "111*"
+          - "120"
+          - "^800"
+          - "25$"
+        permit: True
+      - name: test_3
+        members:
+          - "900.*"
+          - "910.*"
+        permit: True
+      - name: test_4
+        members:
+          - "200"
+          - "210"
+          - "220"
+      - name: test_5
+        members:
+          - "300"
+      - name: test_6
+        members:
+          - "800.*"
+        permit: True
+  existing_bgp_config:
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/global"
+      response:
+        code: 200
+        value:
+          openconfig-network-instance:global:
+            config:
+              as: 4
+    - path: "data/sonic-vrf:sonic-vrf/VRF/VRF_LIST"
+      response:
+        code: 200
+        value:
+          sonic-vrf:VRF_LIST:
+            - vrf_name: default
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      response:
+        code: 200
+        value:
+          openconfig-bgp-policy:as-path-sets:
+            as-path-set:
+              - as-path-set-name: 'test'
+                config:
+                  as-path-set-name: 'test'
+                  as-path-set-member:
+                    - "11"
+                    - "22"
+                    - "44"
+                  openconfig-bgp-policy-ext:action: 'PERMIT'
+              - as-path-set-name: 'test_1'
+                config:
+                  as-path-set-name: 'test_1'
+                  as-path-set-member:
+                    - "100.*"
+                    - "200.*"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+              - as-path-set-name: 'test_2'
+                config:
+                  as-path-set-name: 'test_2'
+                  as-path-set-member:
+                    - "110"
+                    - "120"
+                    - "^800"
+                    - "25$"
+                  openconfig-bgp-policy-ext:action: 'PERMIT'
+              - as-path-set-name: 'test_3'
+                config:
+                  as-path-set-name: 'test_3'
+                  as-path-set-member:
+                    - "900.*"
+                    - "910.*"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+              - as-path-set-name: 'test_4'
+                config:
+                  as-path-set-name: 'test_4'
+                  as-path-set-member:
+                    - "200"
+                    - "210"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+              - as-path-set-name: 'test_5'
+                config:
+                  as-path-set-name: 'test_5'
+                  as-path-set-member:
+                    - "300"
+                    - "310"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+              - as-path-set-name: 'test_def'
+                config:
+                  as-path-set-name: 'test_def'
+                  as-path-set-member:
+                    - "50.*"
+                    - "60.*"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+  expected_config_requests:
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_1"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_2/config/as-path-set-member=110"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_3"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_5/config/as-path-set-member=310"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_1'
+              config:
+                as-path-set-name: 'test_1'
+                as-path-set-member:
+                  - "301.301"
+                openconfig-bgp-policy-ext:action: 'DENY'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_2'
+              config:
+                as-path-set-name: 'test_2'
+                as-path-set-member:
+                  - "111*"
+                openconfig-bgp-policy-ext:action: 'PERMIT'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_3'
+              config:
+                as-path-set-name: 'test_3'
+                as-path-set-member:
+                  - "900.*"
+                  - "910.*"
+                openconfig-bgp-policy-ext:action: 'PERMIT'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_4'
+              config:
+                as-path-set-name: 'test_4'
+                as-path-set-member:
+                  - "220"
+                openconfig-bgp-policy-ext:action: 'DENY'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_6'
+              config:
+                as-path-set-name: 'test_6'
+                as-path-set-member:
+                  - "800.*"
+                openconfig-bgp-policy-ext:action: 'PERMIT'
+
+overridden_01:
+  module_args:
+    state: overridden
+    config:
+      - name: test
+      - name: test_1
+        members:
+          - "301.301"
+        permit: False
+      - name: test_2
+        members:
+          - "111*"
+          - "120"
+          - "^800"
+          - "25$"
+        permit: True
+      - name: test_3
+        members:
+          - "900.*"
+          - "910.*"
+        permit: True
+      - name: test_4
+        members:
+          - "200"
+          - "210"
+          - "220"
+      - name: test_5
+        members:
+          - "300"
+      - name: test_6
+        members:
+          - "800.*"
+        permit: True
+  existing_bgp_config:
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/global"
+      response:
+        code: 200
+        value:
+          openconfig-network-instance:global:
+            config:
+              as: 4
+    - path: "data/sonic-vrf:sonic-vrf/VRF/VRF_LIST"
+      response:
+        code: 200
+        value:
+          sonic-vrf:VRF_LIST:
+            - vrf_name: default
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      response:
+        code: 200
+        value:
+          openconfig-bgp-policy:as-path-sets:
+            as-path-set:
+              - as-path-set-name: 'test'
+                config:
+                  as-path-set-name: 'test'
+                  as-path-set-member:
+                    - "11"
+                    - "22"
+                    - "44"
+                  openconfig-bgp-policy-ext:action: 'PERMIT'
+              - as-path-set-name: 'test_1'
+                config:
+                  as-path-set-name: 'test_1'
+                  as-path-set-member:
+                    - "100.*"
+                    - "200.*"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+              - as-path-set-name: 'test_2'
+                config:
+                  as-path-set-name: 'test_2'
+                  as-path-set-member:
+                    - "110"
+                    - "120"
+                    - "^800"
+                    - "25$"
+                  openconfig-bgp-policy-ext:action: 'PERMIT'
+              - as-path-set-name: 'test_3'
+                config:
+                  as-path-set-name: 'test_3'
+                  as-path-set-member:
+                    - "900.*"
+                    - "910.*"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+              - as-path-set-name: 'test_4'
+                config:
+                  as-path-set-name: 'test_4'
+                  as-path-set-member:
+                    - "200"
+                    - "210"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+              - as-path-set-name: 'test_5'
+                config:
+                  as-path-set-name: 'test_5'
+                  as-path-set-member:
+                    - "300"
+                    - "310"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+              - as-path-set-name: 'test_def'
+                config:
+                  as-path-set-name: 'test_def'
+                  as-path-set-member:
+                    - "50.*"
+                    - "60.*"
+                  openconfig-bgp-policy-ext:action: 'DENY'
+  expected_config_requests:
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_1"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_2/config/as-path-set-member=110"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_3"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_5/config/as-path-set-member=310"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets/as-path-set=test_def"
+      method: "delete"
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_1'
+              config:
+                as-path-set-name: 'test_1'
+                as-path-set-member:
+                  - "301.301"
+                openconfig-bgp-policy-ext:action: 'DENY'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_2'
+              config:
+                as-path-set-name: 'test_2'
+                as-path-set-member:
+                  - "111*"
+                openconfig-bgp-policy-ext:action: 'PERMIT'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_3'
+              config:
+                as-path-set-name: 'test_3'
+                as-path-set-member:
+                  - "900.*"
+                  - "910.*"
+                openconfig-bgp-policy-ext:action: 'PERMIT'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_4'
+              config:
+                as-path-set-name: 'test_4'
+                as-path-set-member:
+                  - "220"
+                openconfig-bgp-policy-ext:action: 'DENY'
+    - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/as-path-sets"
+      method: "patch"
+      data:
+        openconfig-bgp-policy:as-path-sets:
+          as-path-set:
+            - as-path-set-name: 'test_6'
+              config:
+                as-path-set-name: 'test_6'
+                as-path-set-member:
+                  - "800.*"
+                openconfig-bgp-policy-ext:action: 'PERMIT'

--- a/tests/unit/modules/network/sonic/test_sonic_bgp_as_paths.py
+++ b/tests/unit/modules/network/sonic/test_sonic_bgp_as_paths.py
@@ -14,7 +14,7 @@ from ansible_collections.dellemc.enterprise_sonic.tests.unit.modules.utils impor
 from .sonic_module import TestSonicModule
 
 
-class TestSonicBgpModule(TestSonicModule):
+class TestSonicBgpAsPathsModule(TestSonicModule):
     module = sonic_bgp_as_paths
 
     @classmethod
@@ -31,7 +31,7 @@ class TestSonicBgpModule(TestSonicModule):
         cls.fixture_data = cls.load_fixtures('sonic_bgp_as_paths.yaml')
 
     def setUp(self):
-        super(TestSonicBgpModule, self).setUp()
+        super(TestSonicBgpAsPathsModule, self).setUp()
         self.facts_edit_config = self.mock_facts_edit_config.start()
         self.config_edit_config = self.mock_config_edit_config.start()
 
@@ -42,7 +42,7 @@ class TestSonicBgpModule(TestSonicModule):
         self.utils_edit_config.side_effect = self.facts_side_effect
 
     def tearDown(self):
-        super(TestSonicBgpModule, self).tearDown()
+        super(TestSonicBgpAsPathsModule, self).tearDown()
         self.mock_facts_edit_config.stop()
         self.mock_config_edit_config.stop()
         self.mock_utils_edit_config.stop()
@@ -65,5 +65,19 @@ class TestSonicBgpModule(TestSonicModule):
         set_module_args(self.fixture_data['deleted_02']['module_args'])
         self.initialize_facts_get_requests(self.fixture_data['deleted_02']['existing_bgp_config'])
         self.initialize_config_requests(self.fixture_data['deleted_02']['expected_config_requests'])
+        result = self.execute_module(changed=True)
+        self.validate_config_requests()
+
+    def test_sonic_bgp_as_paths_replaced_01(self):
+        set_module_args(self.fixture_data['replaced_01']['module_args'])
+        self.initialize_facts_get_requests(self.fixture_data['replaced_01']['existing_bgp_config'])
+        self.initialize_config_requests(self.fixture_data['replaced_01']['expected_config_requests'])
+        result = self.execute_module(changed=True)
+        self.validate_config_requests()
+
+    def test_sonic_bgp_as_paths_overridden_01(self):
+        set_module_args(self.fixture_data['overridden_01']['module_args'])
+        self.initialize_facts_get_requests(self.fixture_data['overridden_01']['existing_bgp_config'])
+        self.initialize_config_requests(self.fixture_data['overridden_01']['expected_config_requests'])
         result = self.execute_module(changed=True)
         self.validate_config_requests()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Add support for replaced, overridden states in `bgp_as_paths` module.
- Add regression test cases to cover replaced and overridden states.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
|  N/A |


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- sonic_bgp_as_paths

##### OUTPUT
<!--- Paste the functionality test result below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?

- Regression test HTML report: [bgp_as_paths_regression_report.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12407059/bgp_as_paths_regression_report.pdf)

- Regression test detailed log: [bgp_as_paths_regression_terminal_output.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12407065/bgp_as_paths_regression_terminal_output.txt)