### PR TITLE
port_breakout - Add support for 'replaced' and 'overridden' states

### DIFF
--- a/changelogs/fragments/291-port-breakout-replaced-overridden-support.yaml
+++ b/changelogs/fragments/291-port-breakout-replaced-overridden-support.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - sonic_port_breakout - Add support for replaced and overridden states (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/291).

--- a/plugins/module_utils/network/sonic/argspec/port_breakout/port_breakout.py
+++ b/plugins/module_utils/network/sonic/argspec/port_breakout/port_breakout.py
@@ -53,7 +53,7 @@ class Port_breakoutArgs(object):  # pylint: disable=R0903
             'type': 'list'
         },
         'state': {
-            'choices': ['merged', 'deleted'],
+            'choices': ['merged', 'deleted', 'replaced', 'overridden'],
             'default': 'merged'
         }
     }  # pylint: disable=C0301

--- a/plugins/modules/sonic_port_breakout.py
+++ b/plugins/modules/sonic_port_breakout.py
@@ -81,9 +81,11 @@ options:
     description:
       - Specifies the operation to be performed on the port breakout configured on the device.
       - In case of merged, the input mode configuration will be merged with the existing port breakout configuration on the device.
-      - In case of deleted the existing port breakout mode configuration will be removed from the device.
+      - In case of deleted, the existing port breakout mode configuration will be removed from the device.
+      - In case of replaced, on-device port breakout configuration of the specified interfaces is replaced with provided configuration.
+      - In case of overridden, all on-device port breakout configurations are overridden with the provided configuration.
     default: merged
-    choices: ['merged', 'deleted']
+    choices: ['merged', 'deleted', 'replaced', 'overridden']
     type: str
 """
 EXAMPLES = """
@@ -92,18 +94,18 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-#do show interface breakout
-#-----------------------------------------------
-#Port  Breakout Mode  Status        Interfaces
-#-----------------------------------------------
-#1/1   4x10G          Completed     Eth1/1/1
-#                                   Eth1/1/2
-#                                   Eth1/1/3
-#                                   Eth1/1/4
-#1/11  1x100G         Completed     Eth1/11
+# sonic# show interface breakout
+# -----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/1   4x10G          Completed     Eth1/1/1
+#                                    Eth1/1/2
+#                                    Eth1/1/3
+#                                    Eth1/1/4
+# 1/11  1x100G         Completed     Eth1/11/1
 #
 
-- name: Merge users configurations
+- name: Delete interface port breakout configuration
   dellemc.enterprise_sonic.sonic_port_breakout:
     config:
       - name: 1/11
@@ -113,15 +115,16 @@ EXAMPLES = """
 # After state:
 # ------------
 #
-#do show interface breakout
-#-----------------------------------------------
-#Port  Breakout Mode  Status        Interfaces
-#-----------------------------------------------
-#1/1   4x10G          Completed     Eth1/1/1
-#                                   Eth1/1/2
-#                                   Eth1/1/3
-#                                   Eth1/1/4
-#1/11  Default        Completed     Ethernet40
+# sonic# show interface breakout
+# -----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/1   4x10G          Completed     Eth1/1/1
+#                                    Eth1/1/2
+#                                    Eth1/1/3
+#                                    Eth1/1/4
+# 1/11  Default        Completed     Eth1/11
+#
 
 
 # Using deleted
@@ -129,31 +132,31 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-#do show interface breakout
-#-----------------------------------------------
-#Port  Breakout Mode  Status        Interfaces
-#-----------------------------------------------
-#1/1   4x10G          Completed     Eth1/1/1
-#                                   Eth1/1/2
-#                                   Eth1/1/3
-#                                   Eth1/1/4
-#1/11  1x100G         Completed     Eth1/11
+# sonic# show interface breakout
+# -----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/1   4x10G          Completed     Eth1/1/1
+#                                    Eth1/1/2
+#                                    Eth1/1/3
+#                                    Eth1/1/4
+# 1/11  1x100G         Completed     Eth1/11/1
 #
-- name: Merge users configurations
+
+- name: Delete all port breakout configurations
   dellemc.enterprise_sonic.sonic_port_breakout:
     config:
     state: deleted
 
-
 # After state:
 # ------------
 #
-#do show interface breakout
-#-----------------------------------------------
-#Port  Breakout Mode  Status        Interfaces
-#-----------------------------------------------
-#1/1   Default        Completed     Ethernet0
-#1/11  Default        Completed     Ethernet40
+# sonic# show interface breakout
+# -----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/1   Default        Completed     Eth1/1
+# 1/11  Default        Completed     Eth1/11
 
 
 # Using merged
@@ -161,35 +164,111 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-#do show interface breakout
-#-----------------------------------------------
-#Port  Breakout Mode  Status        Interfaces
-#-----------------------------------------------
-#1/1   4x10G          Completed     Eth1/1/1
-#                                   Eth1/1/2
-#                                   Eth1/1/3
-#                                   Eth1/1/4
+# sonic# show interface breakout
+# -----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/1   4x10G          Completed     Eth1/1/1
+#                                    Eth1/1/2
+#                                    Eth1/1/3
+#                                    Eth1/1/4
 #
-- name: Merge users configurations
+
+- name: Merge port breakout configurations
   dellemc.enterprise_sonic.sonic_port_breakout:
     config:
       - name: 1/11
         mode: 1x100G
     state: merged
 
+# After state:
+# ------------
+#
+# sonic# show interface breakout
+# -----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/1   4x10G          Completed     Eth1/1/1
+#                                    Eth1/1/2
+#                                    Eth1/1/3
+#                                    Eth1/1/4
+# 1/11  1x100G         Completed     Eth1/11/1
+
+
+# Using replaced
+#
+# Before state:
+# -------------
+#
+# sonic# show interface breakout
+# -----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/49   4x25G         Completed     Eth1/49/1
+#                                    Eth1/49/2
+#                                    Eth1/49/3
+#                                    Eth1/49/4
+#
+
+- name: Replace port breakout configurations
+  dellemc.enterprise_sonic.sonic_port_breakout:
+    config:
+      - name: 1/49
+        mode: 4x10G
+    state: replaced
 
 # After state:
 # ------------
 #
-#do show interface breakout
-#-----------------------------------------------
-#Port  Breakout Mode  Status        Interfaces
-#-----------------------------------------------
-#1/1   4x10G          Completed     Eth1/1/1
-#                                   Eth1/1/2
-#                                   Eth1/1/3
-#                                   Eth1/1/4
-#1/11  1x100G         Completed     Eth1/11
+# sonic# show interface breakout
+# -----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/49   4x10G         Completed     Eth1/49/1
+#                                    Eth1/49/2
+#                                    Eth1/49/3
+#                                    Eth1/49/4
+
+
+# Using overridden
+#
+# Before state:
+# -------------
+#
+# sonic# show interface breakout
+# ----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/49  4x10G          Completed     Eth1/49/1
+#                                    Eth1/49/2
+#                                    Eth1/49/3
+#                                    Eth1/49/4
+# 1/50  2x50G          Completed     Eth1/50/1
+#                                    Eth1/50/2
+# 1/51  1x100G         Completed     Eth1/51/1
+#
+
+- name: Override port breakout configurations
+  dellemc.enterprise_sonic.sonic_port_breakout:
+    config:
+      - name: 1/52
+        mode: 4x10G
+    state: overridden
+
+# After state:
+# ------------
+#
+# sonic# show interface breakout
+# -----------------------------------------------
+# Port  Breakout Mode  Status        Interfaces
+# -----------------------------------------------
+# 1/49  Default        Completed     Eth1/49
+# 1/50  Default        Completed     Eth1/50
+# 1/51  Default        Completed     Eth1/51
+# 1/52  4x10G          Completed     Eth1/52/1
+#                                    Eth1/52/2
+#                                    Eth1/52/3
+#                                    Eth1/52/4
 
 
 """

--- a/tests/regression/roles/sonic_port_breakout/defaults/main.yml
+++ b/tests/regression/roles/sonic_port_breakout/defaults/main.yml
@@ -33,6 +33,22 @@ tests:
     input:
       - name: 1/98
   - name: test_case_04
+    description: Replace breakout mode for ports
+    state: replaced
+    input:
+      - name: 1/97
+        mode: 4x10G
+      - name: 1/98
+        mode: 4x10G
+  - name: test_case_05
+    description: Override breakout mode for ports
+    state: overridden
+    input:
+      - name: 1/100
+        mode: 4x10G
+      - name: 1/101
+        mode: 2x50G
+  - name: test_case_06
     description: deleting all the port breakout modes
     state: deleted
     input: []

--- a/tests/regression/roles/sonic_port_breakout/tasks/tasks_template.yaml
+++ b/tests/regression/roles/sonic_port_breakout/tasks/tasks_template.yaml
@@ -8,14 +8,14 @@
 - import_role:
     name: common
     tasks_from: action.facts.report.yaml
-  
+
 - name: "{{ item.name}} , {{ item.description}} Idempotent"
   sonic_port_breakout:
     config: "{{ item.input }}"
     state: "{{ item.state }}"
   register: idempotent_task_output
   ignore_errors: yes
-  
+
 - import_role:
     name: common
     tasks_from: idempotent.facts.report.yaml

--- a/tests/unit/modules/network/sonic/fixtures/sonic_port_breakout.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_port_breakout.yaml
@@ -2,7 +2,7 @@
 merged_01:
   module_args:
     config:
-      - name: BreakoutForEth1/10
+      - name: 1/10
         mode: 1x100G
   existing_port_breakout_config:
     - path: "data/sonic-port-breakout:sonic-port-breakout/BREAKOUT_CFG/BREAKOUT_CFG_LIST"
@@ -14,7 +14,7 @@ merged_01:
       data:
         openconfig-platform:components:
           component:
-            - name: BreakoutForEth1/10
+            - name: 1/10
               port:
                 openconfig-platform-port:breakout-mode:
                   groups:
@@ -35,20 +35,12 @@ deleted_01:
           sonic-port-breakout:BREAKOUT_CFG_LIST:
             - port: 1/10
               brkout_mode: 1x100G
-    - path: "openconfig-platform:components"
-      response:
-        code: 200
-        value:
-          component:
-            - name: Eth1/1
-            - name: Eth1/10
-            - name: Eth1/20
     - path: "data/openconfig-platform:components/component=1%2f10"
       response:
         code: 200
         value:
           openconfig-platform:component:
-            - name: Eth1/10
+            - name: 1/10
               port:
                 openconfig-platform-port:breakout-mode:
                   groups:
@@ -77,20 +69,12 @@ deleted_02:
           sonic-port-breakout:BREAKOUT_CFG_LIST:
             - port: 1/10
               brkout_mode: 1x100G
-    - path: "openconfig-platform:components"
-      response:
-        code: 200
-        value:
-          component:
-            - name: Eth1/1
-            - name: Eth1/10
-            - name: Eth1/20
     - path: "data/openconfig-platform:components/component=1%2f10"
       response:
         code: 200
         value:
           openconfig-platform:component:
-            - name: Eth1/10
+            - name: 1/10
               port:
                 openconfig-platform-port:breakout-mode:
                   groups:
@@ -104,3 +88,165 @@ deleted_02:
     - path: "data/openconfig-platform:components/component=1%2f10/port/openconfig-platform-port:breakout-mode"
       method: "delete"
       data:
+
+replaced_01:
+  module_args:
+    config:
+      - name: 1/10
+        mode: 1x100G
+      - name: 1/12
+        mode: 4x25G
+    state: replaced
+  existing_port_breakout_config:
+    - path: "data/sonic-port-breakout:sonic-port-breakout/BREAKOUT_CFG/BREAKOUT_CFG_LIST"
+      response:
+        code: 200
+        value:
+          sonic-port-breakout:BREAKOUT_CFG_LIST:
+            - port: 1/10
+              brkout_mode: 4x10G
+            - port: 1/11
+              brkout_mode: 1x100G
+    - path: "data/openconfig-platform:components/component=1%2f10"
+      response:
+        code: 200
+        value:
+          openconfig-platform:component:
+            - name: 1/10
+              port:
+                openconfig-platform-port:breakout-mode:
+                  groups:
+                    group:
+                      - index: 1
+                        config:
+                          index: 1
+                          breakout-speed: openconfig-if-ethernet:SPEED_10GB
+                          num-breakouts: 4
+    - path: "data/openconfig-platform:components/component=1%2f11"
+      response:
+        code: 200
+        value:
+          openconfig-platform:component:
+            - name: 1/11
+              port:
+                openconfig-platform-port:breakout-mode:
+                  groups:
+                    group:
+                      - index: 1
+                        config:
+                          index: 1
+                          breakout-speed: openconfig-if-ethernet:SPEED_100GB
+                          num-breakouts: 1
+  expected_config_requests:
+    - path: "data/openconfig-platform:components"
+      method: "patch"
+      data:
+        openconfig-platform:components:
+          component:
+            - name: 1/10
+              port:
+                openconfig-platform-port:breakout-mode:
+                  groups:
+                    group:
+                      - index: 1
+                        config:
+                          index: 1
+                          num-breakouts: 1
+                          breakout-speed: SPEED_100GB
+    - path: "data/openconfig-platform:components"
+      method: "patch"
+      data:
+        openconfig-platform:components:
+          component:
+            - name: 1/12
+              port:
+                openconfig-platform-port:breakout-mode:
+                  groups:
+                    group:
+                      - index: 1
+                        config:
+                          index: 1
+                          num-breakouts: 4
+                          breakout-speed: SPEED_25GB
+
+overridden_01:
+  module_args:
+    config:
+      - name: 1/10
+        mode: 1x100G
+      - name: 1/12
+        mode: 4x25G
+    state: overridden
+  existing_port_breakout_config:
+    - path: "data/sonic-port-breakout:sonic-port-breakout/BREAKOUT_CFG/BREAKOUT_CFG_LIST"
+      response:
+        code: 200
+        value:
+          sonic-port-breakout:BREAKOUT_CFG_LIST:
+            - port: 1/10
+              brkout_mode: 4x10G
+            - port: 1/11
+              brkout_mode: 1x100G
+    - path: "data/openconfig-platform:components/component=1%2f10"
+      response:
+        code: 200
+        value:
+          openconfig-platform:component:
+            - name: 1/10
+              port:
+                openconfig-platform-port:breakout-mode:
+                  groups:
+                    group:
+                      - index: 1
+                        config:
+                          index: 1
+                          breakout-speed: openconfig-if-ethernet:SPEED_10GB
+                          num-breakouts: 4
+    - path: "data/openconfig-platform:components/component=1%2f11"
+      response:
+        code: 200
+        value:
+          openconfig-platform:component:
+            - name: 1/11
+              port:
+                openconfig-platform-port:breakout-mode:
+                  groups:
+                    group:
+                      - index: 1
+                        config:
+                          index: 1
+                          breakout-speed: openconfig-if-ethernet:SPEED_100GB
+                          num-breakouts: 1
+  expected_config_requests:
+    - path: "data/openconfig-platform:components/component=1%2f11/port/openconfig-platform-port:breakout-mode"
+      method: "delete"
+    - path: "data/openconfig-platform:components"
+      method: "patch"
+      data:
+        openconfig-platform:components:
+          component:
+            - name: 1/10
+              port:
+                openconfig-platform-port:breakout-mode:
+                  groups:
+                    group:
+                      - index: 1
+                        config:
+                          index: 1
+                          num-breakouts: 1
+                          breakout-speed: SPEED_100GB
+    - path: "data/openconfig-platform:components"
+      method: "patch"
+      data:
+        openconfig-platform:components:
+          component:
+            - name: 1/12
+              port:
+                openconfig-platform-port:breakout-mode:
+                  groups:
+                    group:
+                      - index: 1
+                        config:
+                          index: 1
+                          num-breakouts: 4
+                          breakout-speed: SPEED_25GB

--- a/tests/unit/modules/network/sonic/test_sonic_port_breakout.py
+++ b/tests/unit/modules/network/sonic/test_sonic_port_breakout.py
@@ -14,7 +14,7 @@ from ansible_collections.dellemc.enterprise_sonic.tests.unit.modules.utils impor
 from .sonic_module import TestSonicModule
 
 
-class TestSonicInterfacesModule(TestSonicModule):
+class TestSonicPortBreakoutModule(TestSonicModule):
     module = sonic_port_breakout
 
     @classmethod
@@ -34,7 +34,7 @@ class TestSonicInterfacesModule(TestSonicModule):
         cls.fixture_data = cls.load_fixtures('sonic_port_breakout.yaml')
 
     def setUp(self):
-        super(TestSonicInterfacesModule, self).setUp()
+        super(TestSonicPortBreakoutModule, self).setUp()
         self.facts_edit_config = self.mock_facts_edit_config.start()
         self.utils_edit_config = self.mock_utils_edit_config.start()
         self.config_edit_config = self.mock_config_edit_config.start()
@@ -47,7 +47,7 @@ class TestSonicInterfacesModule(TestSonicModule):
         self.get_interface_naming_mode.return_value = 'standard'
 
     def tearDown(self):
-        super(TestSonicInterfacesModule, self).tearDown()
+        super(TestSonicPortBreakoutModule, self).tearDown()
         self.mock_facts_edit_config.stop()
         self.mock_utils_edit_config.stop()
         self.mock_config_edit_config.stop()
@@ -71,5 +71,19 @@ class TestSonicInterfacesModule(TestSonicModule):
         set_module_args(self.fixture_data['deleted_02']['module_args'])
         self.initialize_facts_get_requests(self.fixture_data['deleted_02']['existing_port_breakout_config'])
         self.initialize_config_requests(self.fixture_data['deleted_02']['expected_config_requests'])
+        result = self.execute_module(changed=True)
+        self.validate_config_requests()
+
+    def test_sonic_port_breakout_replaced_01(self):
+        set_module_args(self.fixture_data['replaced_01']['module_args'])
+        self.initialize_facts_get_requests(self.fixture_data['replaced_01']['existing_port_breakout_config'])
+        self.initialize_config_requests(self.fixture_data['replaced_01']['expected_config_requests'])
+        result = self.execute_module(changed=True)
+        self.validate_config_requests()
+
+    def test_sonic_port_breakout_overridden_01(self):
+        set_module_args(self.fixture_data['overridden_01']['module_args'])
+        self.initialize_facts_get_requests(self.fixture_data['overridden_01']['existing_port_breakout_config'])
+        self.initialize_config_requests(self.fixture_data['overridden_01']['expected_config_requests'])
         result = self.execute_module(changed=True)
         self.validate_config_requests()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

- Add support for replaced, overridden states in `port_breakout` module.
- Add regression test cases to cover replaced and overridden states.
- Updated documentation examples.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
|  N/A |

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- sonic_port_breakout

##### OUTPUT
<!--- Paste the functionality test result below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?

- Regression test HTML report: [port_breakout_regression_report.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12416186/port_breakout_regression_report.pdf)

- Regression test detailed log: [port_breakout_regression_terminal_output.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12416191/port_breakout_regression_terminal_output.txt)
