### PR TITLE
Add mgmt VRF handling to VRFS module

### DIFF
--- a/changelogs/fragments/293-add-mgmt-vrf-handling-in-vrfs-module.yaml
+++ b/changelogs/fragments/293-add-mgmt-vrf-handling-in-vrfs-module.yaml
@@ -1,2 +1,2 @@
-major_changes:
+minor_changes:
         - sonic_vrfs - Add mgmt VRF support to sonic_vrfs module (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/293).

--- a/changelogs/fragments/293-add-mgmt-vrf-handling-in-vrfs-module.yaml
+++ b/changelogs/fragments/293-add-mgmt-vrf-handling-in-vrfs-module.yaml
@@ -1,0 +1,2 @@
+major_changes:
+        - sonic_vrfs - Add mgmt VRF support to sonic_vrfs module (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/293).

--- a/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
+++ b/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
@@ -425,6 +425,7 @@ class Vrfs(ConfigBase):
                 replaced_vrfs.append(have_vrf)
 
         return replaced_vrfs
+
     def validate_mgmt_vrf_in_want(self, want):
         conf = next((vrf for vrf in want if vrf['name'] == MGMT_VRF_NAME), None)
         if conf and conf.get('members', {}) and conf['members'].get('interfaces', []):

--- a/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
+++ b/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
@@ -438,12 +438,14 @@ class Vrfs(ConfigBase):
         if h_conf:
             conf = next((vrf for vrf in new_want if vrf['name'] == MGMT_VRF_NAME), None)
             if conf:
-                mv_intfs = (conf
-                            .get('members', {})
-                            .get('interfaces', []))
-                h_mv_intfs = (h_conf
-                              .get('members', {})
-                              .get('interfaces', []))
+                mv_intfs = []
+                if conf.get('members', None) and conf['members'].get('interfaces', None):
+                    mv_intfs = conf['members'].get('interfaces', [])
+
+                h_mv_intfs = []
+                if h_conf.get('members', None) and h_conf['members'].get('interfaces', None):
+                    h_mv_intfs = h_conf['members'].get('interfaces', [])
+
                 mv_intfs.sort(key=lambda x: x['name'])
                 h_mv_intfs.sort(key=lambda x: x['name'])
                 if mv_intfs == h_mv_intfs:

--- a/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
+++ b/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
@@ -305,7 +305,7 @@ class Vrfs(ConfigBase):
                 continue
 
             # if members are not mentioned delet the vrf name
-            if (name != MGMT_VRF_NAME) and (self.delete_all_flag or empty_flag):
+            if (name != MGMT_VRF_NAME and self.delete_all_flag) or empty_flag:
                 url = 'data/openconfig-network-instance:network-instances/network-instance={0}'.format(name)
                 request = {"path": url, "method": method}
                 requests.append(request)

--- a/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
+++ b/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
@@ -451,6 +451,8 @@ class Vrfs(ConfigBase):
                 if mv_intfs == h_mv_intfs:
                     new_want.remove(conf)
                     new_have.remove(h_conf)
+                elif not h_mv_intfs:
+                    new_have.remove(h_conf)
             else:
                 new_have.remove(h_conf)
 

--- a/tests/unit/modules/network/sonic/fixtures/sonic_vrfs.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_vrfs.yaml
@@ -79,15 +79,8 @@ deleted_01:
                     - id: Eth1/1
                     - id: Eth1/2
               - name: mgmt
-                interfaces:
-                  interface:
-                    - id: Eth1/3
-                    - id: Eth1/4
   expected_config_requests:
     - path: "data/openconfig-network-instance:network-instances/network-instance=VrfCheck1"
-      method: "delete"
-      data:
-    - path: "data/openconfig-network-instance:network-instances/network-instance=mgmt"
       method: "delete"
       data:
 
@@ -117,7 +110,7 @@ deleted_02:
     - path: "data/openconfig-network-instance:network-instances/network-instance=VrfCheck6/interfaces/interface=Eth1%2f1"
       method: "delete"
       data:
-    - path: "data/openconfig-network-instance:network-instances/network-instance=mgmt/interfaces/interface=Eth1%2f4"
+    - path: "data/openconfig-network-instance:network-instances/network-instance=mgmt"
       method: "delete"
       data:
 

--- a/tests/unit/modules/network/sonic/fixtures/sonic_vrfs.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_vrfs.yaml
@@ -100,9 +100,6 @@ deleted_02:
           interfaces:
             - name: Eth1/1
       - name: mgmt
-        members:
-          interfaces:
-            - name: Eth1/4
   existing_vrfs_config:
     - path: "data/openconfig-network-instance:network-instances"
       response:
@@ -116,10 +113,6 @@ deleted_02:
                     - id: Eth1/1
                     - id: Eth1/2
               - name: mgmt
-                interfaces:
-                  interface:
-                    - id: Eth1/3
-                    - id: Eth1/4
   expected_config_requests:
     - path: "data/openconfig-network-instance:network-instances/network-instance=VrfCheck6/interfaces/interface=Eth1%2f1"
       method: "delete"

--- a/tests/unit/modules/network/sonic/fixtures/sonic_vrfs.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_vrfs.yaml
@@ -78,7 +78,6 @@ deleted_01:
                   interface:
                     - id: Eth1/1
                     - id: Eth1/2
-              - name: mgmt
   expected_config_requests:
     - path: "data/openconfig-network-instance:network-instances/network-instance=VrfCheck1"
       method: "delete"
@@ -93,6 +92,9 @@ deleted_02:
           interfaces:
             - name: Eth1/1
       - name: mgmt
+        members:
+          interfaces:
+            - name: Eth1/4
   existing_vrfs_config:
     - path: "data/openconfig-network-instance:network-instances"
       response:
@@ -106,11 +108,15 @@ deleted_02:
                     - id: Eth1/1
                     - id: Eth1/2
               - name: mgmt
+                interfaces:
+                  interface:
+                    - id: Eth1/3
+                    - id: Eth1/4
   expected_config_requests:
     - path: "data/openconfig-network-instance:network-instances/network-instance=VrfCheck6/interfaces/interface=Eth1%2f1"
       method: "delete"
       data:
-    - path: "data/openconfig-network-instance:network-instances/network-instance=mgmt"
+    - path: "data/openconfig-network-instance:network-instances/network-instance=mgmt/interfaces/interface=Eth1%2f4"
       method: "delete"
       data:
 


### PR DESCRIPTION
SUMMARY
This is to add mgmt VRF handling to sonic_vrfs module

GitHub Issues
N/A

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
sonic_vrfs

OUTPUT
- regression test result:
[regression-2023-09-08-09-42-24.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12562997/regression-2023-09-08-09-42-24.html.pdf)
- regression test log: 
[regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12563000/regression_test.log)
- unit test script: 
[unit_test_script.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12479993/unit_test_script.txt)
- unit test log: 
[unit_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12479994/unit_test.log)


ADDITIONAL INFORMATION
mgmt VRF handling in sonic_vrfs module:

- when delete all, do not delete mgmt VRF if it is in "have", if any.
- when override, do not override mgmt VRF in "have", if any.

Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

How Has This Been Tested?
Tested with real SONIC system. Due to create/delete mgmt VRF causes disconnection, no test case is added to regression test suite. The function is tested with unit test.
