### PR TITLE
Check and diff modes support for l2- and lag-interfaces modules

### DIFF
--- a/changelogs/fragments/303-playbook-check-diff-modes-for-l2-lag-interfaces.yaml
+++ b/changelogs/fragments/303-playbook-check-diff-modes-for-l2-lag-interfaces.yaml
@@ -1,0 +1,2 @@
+major_changes:
+        - l2_lag_interfaces - Playbook check and diff modes supports for sonic_l2_interfaces and sonic_lag_interfaces modules (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/303).

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -21,6 +21,9 @@ except ImportError:
 
 import json
 
+from copy import (
+    deepcopy
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )
@@ -38,6 +41,12 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import (
     to_request,
     edit_config
+)
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
+    __DELETE_CONFIG,
+    __DELETE_CONFIG_IF_NO_SUBCONFIG,
+    get_new_config,
+    get_formatted_config_diff
 )
 from ansible.module_utils._text import to_native
 from ansible.module_utils.connection import ConnectionError
@@ -59,6 +68,10 @@ PATCH = 'patch'
 DELETE = 'delete'
 TEST_KEYS = [
     {'interfaces': {'member': ''}},
+]
+TEST_KEYS_formatted_diff = [
+    {'config': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
+    {'interfaces': {'member': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
 ]
 
 
@@ -119,6 +132,18 @@ class Lag_interfaces(ConfigBase):
         if result['changed']:
             result['after'] = changed_lag_interfaces_facts
 
+        new_config = changed_lag_interfaces_facts
+        old_config = existing_lag_interfaces_facts
+        if self._module.check_mode:
+            result.pop('after', None)
+            new_config = get_new_config(commands, existing_lag_interfaces_facts,
+                                        TEST_KEYS_formatted_diff)
+            result['after(generated)'] = new_config
+        if self._module._diff:
+            self.sort_config(new_config)
+            self.sort_config(old_config)
+            result['config_diff'] = get_formatted_config_diff(old_config,
+                                                              new_config)
         result['warnings'] = warnings
         return result
 
@@ -188,7 +213,7 @@ class Lag_interfaces(ConfigBase):
                 replaced_list.append(list_obj)
         requests = self.get_delete_lag_interfaces_requests(replaced_list)
         if requests:
-            commands.extend(update_states(replaced_list, "replaced"))
+            commands.extend(update_states(replaced_list, "deleted"))
         replaced_commands, replaced_requests = self.template_for_lag_creation(have, diff_members, diff_portchannels, "replaced")
         if replaced_requests:
             commands.extend(replaced_commands)
@@ -226,7 +251,8 @@ class Lag_interfaces(ConfigBase):
 
         requests_deleted_po = self.get_delete_portchannel_requests(deleted_po_list)
         requests.extend(requests_deleted_po)
-        commands.extend(update_states(deleted_po_list, "deleted"))
+        commands_del = self.prune_commands(deleted_po_list)
+        commands.extend(update_states(commands_del, "deleted"))
 
         override_commands, override_requests = self.template_for_lag_creation(have, diff_members, diff_portchannels, "overridden")
         commands.extend(override_commands)
@@ -258,7 +284,8 @@ class Lag_interfaces(ConfigBase):
             requests = self.get_delete_all_lag_interfaces_requests()
             portchannel_requests = self.get_delete_all_portchannel_requests()
             requests.extend(portchannel_requests)
-            commands.extend(update_states(have, "Deleted"))
+            commands_del = self.prune_commands(have)
+            commands.extend(update_states(commands_del, "deleted"))
         else:  # delete specific lag interfaces and specific portchannels
             commands = get_diff(want, diff, TEST_KEYS)
             commands = remove_empties_from_list(commands)
@@ -322,7 +349,8 @@ class Lag_interfaces(ConfigBase):
                 commands.extend(update_states(delete_members, state_name))
         if delete_portchannels:
             portchannel_requests = self.get_delete_portchannel_requests(delete_portchannels)
-            commands.extend(update_states(delete_portchannels, state_name))
+            commands_del = self.prune_commands(delete_portchannels)
+            commands.extend(update_states(commands_del, state_name))
         if requests:
             requests.extend(portchannel_requests)
         else:
@@ -428,3 +456,21 @@ class Lag_interfaces(ConfigBase):
             requests.append(request)
 
         return requests
+
+    def sort_config(self, configs):
+        # natsort provides better result.
+        # The use of natsort causes sanity error due to it is not available in
+        # python version currently used.
+        # new_config = natsorted(new_config, key=lambda x: x['name'])
+        # For time-being, use simple "sort"
+        configs.sort(key=lambda x: x['name'])
+
+        for conf in configs:
+            if conf.get('members', {}) and conf['members'].get('interfaces', []):
+                conf['members']['interfaces'].sort(key=lambda x: x['member'])
+
+    def prune_commands(self, commands):
+        cmds = deepcopy(commands)
+        for cmd in cmds:
+            cmd.pop('members', None)
+        return cmds

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -43,7 +43,6 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     edit_config
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
-    __DELETE_CONFIG,
     __DELETE_CONFIG_IF_NO_SUBCONFIG,
     get_new_config,
     get_formatted_config_diff

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,1 @@
+plugins/action/sonic.py action-plugin-docs #action plugin for base class


### PR DESCRIPTION
SUMMARY
This is to add check and diff modes support for l2-interfaces and lag-interfaces modules.

GitHub Issues
N/A

ISSUE TYPE
- Feature Pull Request
- 
COMPONENT NAME
sonic_l2_interfaces, sonic_lag_interfaces

OUTPUT
- l2_interfaces regression result: 
[l2_interfaces_regression-2023-10-13-11-55-14.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12898850/l2_interfaces_regression-2023-10-13-11-55-14.html.pdf)
- l2_interfaces regression log: 
[l2_interfaces_regression.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12898853/l2_interfaces_regression.log)
- l2_interfaces unit test script: 
[l2_interfaces.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12898862/l2_interfaces.txt)
- l2_interfaces unit test log: 
[l2_interfaces_ut.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12898865/l2_interfaces_ut.log)

- lag_interfaces regression result: 
[lag_interfaces_regression-2023-10-13-12-01-33.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12898899/lag_interfaces_regression-2023-10-13-12-01-33.html.pdf)
- lag_interfaces regression log: 
[lag_interfaces_regression.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12898942/lag_interfaces_regression.log)
- lag_interfaces unit test script: 
[lag_interfaces.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12898993/lag_interfaces.txt)
- lag_interfaces unit test log: 
[lag_interfaces_ut.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/12899012/lag_interfaces_ut.log)


Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

How Has This Been Tested?
regression test and unit test.

