### PR TITLE
users and aaa module diff and check modes

### DIFF
--- a/changelogs/fragments/304-playbook-check-diff-modes-for-users-aaa.yaml
+++ b/changelogs/fragments/304-playbook-check-diff-modes-for-users-aaa.yaml
@@ -1,2 +1,3 @@
-major_changes:
-  - user_aaa - Playbook check and diff modes supports for sonic_users and sonic_aaa modules (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/304).
+minor_changes:
+  - sonic_users - Add support for playbook check and diff modes (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/304).
+  - sonic_aaa - Add support for playbook check and diff modes (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/304).

--- a/changelogs/fragments/304-playbook-check-diff-modes-for-users-aaa.yaml
+++ b/changelogs/fragments/304-playbook-check-diff-modes-for-users-aaa.yaml
@@ -1,0 +1,2 @@
+major_changes:
+  - user_aaa - Playbook check and diff modes supports for sonic_users and sonic_aaa modules (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/304).

--- a/plugins/module_utils/network/sonic/config/aaa/aaa.py
+++ b/plugins/module_utils/network/sonic/config/aaa/aaa.py
@@ -31,6 +31,10 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     to_request,
     edit_config
 )
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
+    get_new_config,
+    get_formatted_config_diff
+)
 
 PATCH = 'patch'
 DELETE = 'delete'
@@ -89,6 +93,15 @@ class Aaa(ConfigBase):
         if result['changed']:
             result['after'] = changed_aaa_facts
 
+        new_config = changed_aaa_facts
+        old_config = existing_aaa_facts
+        if self._module.check_mode:
+            result.pop('after', None)
+            new_config = get_new_config(commands, existing_aaa_facts)
+            result['after(generated)'] = new_config
+        if self._module._diff:
+            result['config_diff'] = get_formatted_config_diff(old_config,
+                                                              new_config)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/users/users.py
+++ b/plugins/module_utils/network/sonic/config/users/users.py
@@ -29,10 +29,18 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     update_states,
     get_diff,
 )
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
+    __DELETE_CONFIG_IF_NO_SUBCONFIG,
+    get_new_config,
+    get_formatted_config_diff
+)
 from ansible.module_utils.connection import ConnectionError
 
 PATCH = 'patch'
 DELETE = 'delete'
+TEST_KEYS_formatted_diff = [
+    {'config': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
+]
 
 
 class Users(ConfigBase):
@@ -100,6 +108,18 @@ class Users(ConfigBase):
         if result['changed']:
             result['after'] = changed_users_facts
 
+        new_config = changed_users_facts
+        old_config = existing_users_facts
+        if self._module.check_mode:
+            result.pop('after', None)
+            new_config = get_new_config(commands, existing_users_facts,
+                                        TEST_KEYS_formatted_diff)
+            result['after(generated)'] = new_config
+        if self._module._diff:
+            self.sort_lists_in_config(new_config)
+            self.sort_lists_in_config(old_config)
+            result['config_diff'] = get_formatted_config_diff(old_config,
+                                                              new_config)
         result['warnings'] = warnings
         return result
 
@@ -355,9 +375,6 @@ class Users(ConfigBase):
             commands.remove(admin_usr)
         return requests
 
-    def get_name(self, name):
-        return name.get('name')
-
     def sort_lists_in_config(self, config):
         if config:
-            config.sort(key=self.get_name)
+            config.sort(key=lambda x: x['name'])

--- a/plugins/modules/sonic_aaa.py
+++ b/plugins/modules/sonic_aaa.py
@@ -246,6 +246,13 @@ after:
   sample: >
     The configuration returned will always be in the same format
     of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
 commands:
   description: The set of commands pushed to the remote device.
   returned: always

--- a/plugins/modules/sonic_users.py
+++ b/plugins/modules/sonic_users.py
@@ -262,6 +262,13 @@ after:
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
 commands:
   description: The set of commands pushed to the remote device.
   returned: always


### PR DESCRIPTION
SUMMARY
This is to add diff and check modes supports for users and aaa resource modules.

GitHub Issues
N/A

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
sonic_users, sonic_aaa

OUTPUT
- users regression test result: 
[users_regression-2023-10-19-09-42-50.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13073915/users_regression-2023-10-19-09-42-50.html.pdf)
- users regression test log: 
[users_regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13073917/users_regression_test.log)
- users unit test script: 
[users.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13073919/users.txt)
- users unit test log: 
[users_unit_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13073923/users_unit_test.log)

- aaa regression test result: 
[aaaregression-2023-10-20-11-17-48.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13073940/aaaregression-2023-10-20-11-17-48.html.pdf)
- aaa regression test log: 
[aaa_regression_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13073942/aaa_regression_test.log)
- aaa unit test script: 
[aaa.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13073947/aaa.txt)
- aaa unit test log: 
[aaa_unit_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13073951/aaa_unit_test.log)


Checklist:
- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

How Has This Been Tested?
Tested by running regression and unit tests.
