### PR TITLE
Add protocol option in syslog server

### DIFF
--- a/changelogs/fragments/317-added-protocol-option-for-syslog-module.yaml
+++ b/changelogs/fragments/317-added-protocol-option-for-syslog-module.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sonic_logging - Add support for protocol option in logging module (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/317).

--- a/plugins/module_utils/network/sonic/argspec/logging/logging.py
+++ b/plugins/module_utils/network/sonic/argspec/logging/logging.py
@@ -49,7 +49,9 @@ class LoggingArgs(object):  # pylint: disable=R0903
                                          'type': 'str'},
                         'remote_port': {'type': 'int'},
                         'source_interface': {'type': 'str'},
-                        'vrf': {'type': 'str'}
+                        'vrf': {'type': 'str'},
+                        'protocol':  {'choices': ['TCP', 'UDP'],
+                                      'type': 'str'},
                     },
                     'type': 'list'
                 }

--- a/plugins/module_utils/network/sonic/argspec/logging/logging.py
+++ b/plugins/module_utils/network/sonic/argspec/logging/logging.py
@@ -50,8 +50,8 @@ class LoggingArgs(object):  # pylint: disable=R0903
                         'remote_port': {'type': 'int'},
                         'source_interface': {'type': 'str'},
                         'vrf': {'type': 'str'},
-                        'protocol':  {'choices': ['TCP', 'UDP'],
-                                      'type': 'str'},
+                        'protocol': {'choices': ['TCP', 'UDP'],
+                                     'type': 'str'},
                     },
                     'type': 'list'
                 }

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -339,7 +339,7 @@ class Logging(ConfigBase):
                     message_type_config = server.get('message_type', None)
                     vrf_config = server.get('vrf', None)
                     if source_interface_config or remote_port_config or \
-                        message_type_config or vrf_config or protocol_config:
+                            message_type_config or vrf_config or protocol_config:
                         err_msg = "Logging remote_server parameter(s) can not be deleted."
                         self._module.fail_json(msg=err_msg, code=405)
 

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -42,6 +42,7 @@ DELETE = 'DELETE'
 
 DEFAULT_REMOTE_PORT = 514
 DEFAULT_LOG_TYPE = 'log'
+DEFAULT_PROTOCOL = 'UDP'
 
 TEST_KEYS = [
     {
@@ -334,10 +335,11 @@ class Logging(ConfigBase):
                 for server in want['remote_servers']:
                     source_interface_config = server.get('source_interface', None)
                     remote_port_config = server.get('remote_port', None)
+                    protocol_config = server.get('protocol', None)
                     message_type_config = server.get('message_type', None)
                     vrf_config = server.get('vrf', None)
                     if source_interface_config or remote_port_config or \
-                       message_type_config or vrf_config:
+                        message_type_config or vrf_config or protocol_config:
                         err_msg = "Logging remote_server parameter(s) can not be deleted."
                         self._module.fail_json(msg=err_msg, code=405)
 
@@ -353,6 +355,8 @@ class Logging(ConfigBase):
                             get_normalize_interface_name(server['source_interface'], self._module)
                     if 'remote_port' in server and not server['remote_port']:
                         server.pop('remote_port', None)
+                    if 'protocol' in server and not server['protocol']:
+                        server.pop('protocol', None)
                     if 'message_type' in server and not server['message_type']:
                         server.pop('message_type', None)
                     if 'vrf' in server and not server['vrf']:
@@ -370,6 +374,8 @@ class Logging(ConfigBase):
                         server['remote_port'] = DEFAULT_REMOTE_PORT
                     if 'message_type' in server and not server['message_type']:
                         server['message_type'] = DEFAULT_LOG_TYPE
+                    if 'protocol' in server and not server['protocol']:
+                        server['protocol'] = DEFAULT_PROTOCOL
 
     def get_merge_requests(self, configs, have):
 
@@ -417,6 +423,8 @@ class Logging(ConfigBase):
                 req_config['message-type'] = config['message_type']
             if 'remote_port' in config:
                 req_config['remote-port'] = config['remote_port']
+            if 'protocol' in config:
+                req_config['protocol'] = config['protocol']
             if 'vrf' in config:
                 req_config['vrf-name'] = config['vrf']
 

--- a/plugins/module_utils/network/sonic/facts/logging/logging.py
+++ b/plugins/module_utils/network/sonic/facts/logging/logging.py
@@ -118,6 +118,8 @@ class LoggingFacts(object):
                     logging_server['source_interface'] = 'eth0'
             if 'openconfig-system-ext:vrf-name' in rs_config:
                 logging_server['vrf'] = rs_config['openconfig-system-ext:vrf-name']
+            if 'openconfig-system-ext:protocol' in rs_config:
+                logging_server['protocol'] = rs_config['openconfig-system-ext:protocol']
             if 'remote-port' in rs_config:
                 logging_server['remote_port'] = rs_config['remote-port']
 

--- a/plugins/modules/sonic_logging.py
+++ b/plugins/modules/sonic_logging.py
@@ -73,6 +73,13 @@ options:
             choices:
               - log
               - event
+          protocol:
+            type: str
+            description:
+              - Type of the protocol for sending the  messages.
+            choices:
+              - TCP
+              - UDP
           vrf:
             type: str
             description:
@@ -95,12 +102,12 @@ EXAMPLES = """
 # -------------
 #
 #sonic# show logging servers
-#--------------------------------------------------------------------------------
-#HOST            PORT      SOURCE-INTERFACE    VRF            MESSGE-TYPE
-#--------------------------------------------------------------------------------
-#10.11.0.2       5         Ethernet24          -              event
-#10.11.1.1       616       Ethernet8           -              log
-#log1.dell.com   6         Ethernet28          -              log
+#---------------------------------------------------------------------------------------
+#HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE     PROTOCOL
+#---------------------------------------------------------------------------------------
+#10.11.0.2       5         Ethernet24          -              event              udp
+#10.11.1.1       616       Ethernet8           -              log                tcp
+#log1.dell.com   6         Ethernet28          -              log                udp
 #
 - name: Delete logging server configuration
   sonic_logging:
@@ -114,10 +121,10 @@ EXAMPLES = """
 # ------------
 #
 #sonic# show logging servers
-#--------------------------------------------------------------------------------
-#HOST            PORT      SOURCE-INTERFACE    VRF            MESSGE-TYPE
-#--------------------------------------------------------------------------------
-#10.11.1.1       616       Ethernet8           -              log
+#---------------------------------------------------------------------------------------
+#HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE     PROTOCOL
+#---------------------------------------------------------------------------------------
+#10.11.1.1       616       Ethernet8           -              log               tcp
 #
 #
 # Using merged
@@ -126,10 +133,10 @@ EXAMPLES = """
 # -------------
 #
 #sonic# show logging servers
-#--------------------------------------------------------------------------------
-#HOST            PORT      SOURCE-INTERFACE    VRF            MESSGE-TYPE
-#--------------------------------------------------------------------------------
-#10.11.1.1       616       Ethernet8           -              log
+#--------------------------------------------------------------------------------------
+#HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE    PROTOCOL
+#--------------------------------------------------------------------------------------
+#10.11.1.1       616       Ethernet8           -              log              tcp
 #
 - name: Merge logging server configuration
   sonic_logging:
@@ -137,10 +144,12 @@ EXAMPLES = """
       remote_servers:
         - host: 10.11.0.2
           remote_port: 5
+          protocol: TCP
           source_interface: Ethernet24
           message_type: event
         - host: log1.dell.com
           remote_port: 6
+          protocol: udp
           source_interface: Ethernet28
     state: merged
 
@@ -148,12 +157,12 @@ EXAMPLES = """
 # ------------
 #
 #sonic# show logging servers
-#--------------------------------------------------------------------------------
-#HOST            PORT      SOURCE-INTERFACE    VRF            MESSGE-TYPE
-#--------------------------------------------------------------------------------
-#10.11.0.2       5         Ethernet24          -              event
-#10.11.1.1       616       Ethernet8           -              log
-#log1.dell.com   6         Ethernet28          -              log
+#-------------------------------------------------------------------------------------
+#HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE   PROTOCOL
+#-------------------------------------------------------------------------------------
+#10.11.0.2       5         Ethernet24          -              event           udp
+#10.11.1.1       616       Ethernet8           -              log             tcp
+#log1.dell.com   6         Ethernet28          -              log             udp
 #
 #
 # Using overridden
@@ -162,11 +171,11 @@ EXAMPLES = """
 # -------------
 #
 #sonic# show logging servers
-#--------------------------------------------------------------------------------
-#HOST            PORT      SOURCE-INTERFACE    VRF            MESSGE-TYPE
-#--------------------------------------------------------------------------------
-#10.11.1.1       616       Ethernet8           -              log
-#10.11.1.2       626       Ethernet16          -              event
+#--------------------------------------------------------------------------------------
+#HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE    PROTOCOL
+#--------------------------------------------------------------------------------------
+#10.11.1.1       616       Ethernet8           -              log              tcp
+#10.11.1.2       626       Ethernet16          -              event            udp
 #
 - name: Replace logging server configuration
   sonic_logging:
@@ -174,6 +183,7 @@ EXAMPLES = """
       remote_servers:
         - host: 10.11.1.2
           remote_port: 622
+          protocol: TCP
           source_interface: Ethernet24
           message_type: event
     state: overridden
@@ -182,10 +192,10 @@ EXAMPLES = """
 # ------------
 #
 #sonic# show logging servers
-#--------------------------------------------------------------------------------
-#HOST            PORT      SOURCE-INTERFACE    VRF            MESSGE-TYPE
-#--------------------------------------------------------------------------------
-#10.11.1.2       622       Ethernet24          -              event
+#--------------------------------------------------------------------------------------
+#HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE    PROTOCOL
+#--------------------------------------------------------------------------------------
+#10.11.1.2       622       Ethernet24          -              event            tcp
 #
 # Using replaced
 #
@@ -193,11 +203,11 @@ EXAMPLES = """
 # -------------
 #
 #sonic# show logging servers
-#--------------------------------------------------------------------------------
-#HOST            PORT      SOURCE-INTERFACE    VRF            MESSGE-TYPE
-#--------------------------------------------------------------------------------
-#10.11.1.1       616       Ethernet8           -              log
-#10.11.1.2       626       Ethernet16          -              event
+#--------------------------------------------------------------------------------------
+#HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE    PROTOCOL
+#--------------------------------------------------------------------------------------
+#10.11.1.1       616       Ethernet8           -              log              tcp
+#10.11.1.2       626       Ethernet16          -              event            udp
 #
 - name: Replace logging server configuration
   sonic_logging:
@@ -205,6 +215,7 @@ EXAMPLES = """
       remote_servers:
         - host: 10.11.1.2
           remote_port: 622
+          protocol: UDP
     state: replaced
 #
 # After state:
@@ -213,11 +224,11 @@ EXAMPLES = """
 # "MESSAGE-TYPE" has default value of "log"
 #
 #sonic# show logging servers
-#--------------------------------------------------------------------------------
-#HOST            PORT      SOURCE-INTERFACE    VRF            MESSGE-TYPE
-#--------------------------------------------------------------------------------
-#10.11.1.1       616       Ethernet8           -              log
-#10.11.1.2       622       -                   -              log
+#--------------------------------------------------------------------------------------
+#HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE    PROTOCOL
+#--------------------------------------------------------------------------------------
+#10.11.1.1       616       Ethernet8           -              log              tcp
+#10.11.1.2       622       -                   -              log              udp
 #
 """
 RETURN = """

--- a/tests/regression/roles/sonic_logging/defaults/main.yml
+++ b/tests/regression/roles/sonic_logging/defaults/main.yml
@@ -24,6 +24,7 @@ tests:
         - host: "{{ logging_ip_server_1 }}"
           source_interface: "{{ interface1 }}"
           remote_port: 616
+          protocol: UDP
           message_type: event
           vrf: Vrf_logging_1
 
@@ -37,15 +38,18 @@ tests:
         - host: "{{ logging_ip_server_3 }}"
           source_interface: "{{ vlan1 }}"
           remote_port: 818
+          protocol: TCP
           message_type: event
           vrf: Vrf_logging_2
         - host: "{{ logging_ip_server_4 }}"
           source_interface: "{{ mgmt }}"
           message_type: event
+          protocol: UDP
           vrf: Vrf_logging_1
         - host: "{{ logging_host_server }}"
           source_interface: "{{ lo1 }}"
           message_type: log
+          protocol: TCP
           vrf: Vrf_logging_1
 
   - name: test_case_03
@@ -56,6 +60,7 @@ tests:
         - host: "{{ logging_ip_server_3 }}"
           source_interface: "{{ interface2 }}"
           remote_port: 838
+          protocol: UDP
 
   - name: test_case_04
     description: Replace logging remote servers
@@ -65,12 +70,14 @@ tests:
         - host: "{{ logging_ip_server_3 }}"
           source_interface: "{{ interface3 }}"
           remote_port: 838
+          protocol: UDP
           message_type: event
         - host: "{{ logging_ip_server_4 }}"
           source_interface: "{{ interface4 }}"
         - host: "{{ logging_ip_server_6 }}"
           source_interface: "{{ interface4 }}"
           remote_port: 868
+          protocol: TCP
           message_type: event
 
   - name: test_case_05
@@ -83,6 +90,7 @@ tests:
         - host: "{{ logging_ip_server_5 }}"
           source_interface: "{{ interface4 }}"
           remote_port: 858
+          protocol: TCP
           message_type: event
 
   - name: test_case_06
@@ -93,11 +101,13 @@ tests:
         - host: "{{ logging_ip_server_1 }}"
           source_interface: "{{ interface1 }}"
           remote_port: 616
+          protocol: TCP
           message_type: event
           vrf: Vrf_logging_1
         - host: "{{ logging_ip_server_3 }}"
           source_interface: "{{ vlan1 }}"
           remote_port: 818
+          protocol: UDP
           message_type: event
           vrf: Vrf_logging_2
         - host: "{{ logging_host_server }}"

--- a/tests/unit/modules/network/sonic/fixtures/sonic_logging.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_logging.yaml
@@ -5,10 +5,12 @@ merged_01:
       remote_servers:
         - host: 10.11.0.2
           remote_port: 5
+          protocol: TCP
           source_interface: Eth1/24
           message_type: event
         - host: log1.dell.com
           remote_port: 6
+          protocol: UDP
           source_interface: Eth1/28
   existing_logging_config:
     - path: "data/openconfig-system:system/logging"
@@ -26,11 +28,13 @@ merged_01:
                 source-interface: Eth1/24
                 message-type: event
                 remote-port: 5
+                protocol: TCP
             - host: log1.dell.com
               config:
                 host: log1.dell.com
                 source-interface: Eth1/28
                 remote-port: 6
+                protocol: UDP
 
 deleted_01:
   module_args:
@@ -49,11 +53,13 @@ deleted_01:
                     source-interface: Eth1/24
                     message-type: event
                     remote-port: 5
+                    protocol: TCP
                 - host: log1.dell.com
                   config:
                     host: log1.dell.com
                     source-interface: Eth1/28
                     remote-port: 6
+                    protocol: UDP
   expected_config_requests:
     - path: "data/openconfig-system:system/logging/remote-servers"
       method: "delete"
@@ -79,11 +85,13 @@ deleted_02:
                     source-interface: Eth1/24
                     message-type: event
                     remote-port: 5
+                    protocol: TCP
                 - host: log1.dell.com
                   config:
                     host: log1.dell.com
                     source-interface: Eth1/28
                     remote-port: 6
+                    protocol: UDP
   expected_config_requests:
     - path: "data/openconfig-system:system/logging/remote-servers/remote-server=10.11.0.2"
       method: "delete"
@@ -98,6 +106,7 @@ replaced_01:
           remote_port: 9
           source_interface: Eth1/25
           message_type: log
+          protocol: TCP
   existing_logging_config:
     - path: "data/openconfig-system:system/logging"
       response:
@@ -112,11 +121,13 @@ replaced_01:
                     source-interface: Eth1/24
                     message-type: event
                     remote-port: 5
+                    protocol: TCP
                 - host: log1.dell.com
                   config:
                     host: log1.dell.com
                     source-interface: Eth1/28
                     remote-port: 6
+                    protocol: UDP
   expected_config_requests:
     - path: "data/openconfig-system:system/logging/remote-servers"
       method: "patch"
@@ -129,6 +140,7 @@ replaced_01:
                 source-interface: Eth1/25
                 message-type: log
                 remote-port: 9
+                protocol: TCP
                 vrf-name:
     - path: "data/openconfig-system:system/logging/remote-servers/remote-server=10.11.0.2"
       method: "delete"
@@ -143,6 +155,7 @@ overridden_01:
           remote_port: 10
           source_interface: Eth1/26
           message_type: log
+          protocol: TCP
   existing_logging_config:
     - path: "data/openconfig-system:system/logging"
       response:
@@ -157,11 +170,13 @@ overridden_01:
                     source-interface: Eth1/24
                     message-type: event
                     remote-port: 5
+                    protocol: TCP
                 - host: log1.dell.com
                   config:
                     host: log1.dell.com
                     source-interface: Eth1/28
                     remote-port: 6
+                    protocol: UDP
   expected_config_requests:
     - path: "data/openconfig-system:system/logging/remote-servers"
       method: "delete"
@@ -177,4 +192,5 @@ overridden_01:
                 source-interface: Eth1/26
                 message-type: log
                 remote-port: 10
+                protocol: TCP
                 vrf-name:


### PR DESCRIPTION
##### SUMMARY
Addition of protocol option in syslog server.

##### GitHub Issues

| GitHub Issue # |
| -------------- |
| | N/A

##### COMPONENT NAME
logging

##### ADDITIONAL INFORMATION
**Regression report:**
[regression_report_logging.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13672599/regression_report_logging.pdf)


**Sanity test:**
[sanity test.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13672048/sanity.test.txt)

**show logging server CLI and its related facts:**
[facts_UT.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13672197/facts_UT.txt)

**Checklist:**
 
- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x]  I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

**How Has This Been Tested?**
Run sanity, regression and unit tests.
 