### PR TITLE
Change config diff utility function

### DIFF
--- a/changelogs/fragments/318-playbook-diff-mode-enhancement.yaml
+++ b/changelogs/fragments/318-playbook-diff-mode-enhancement.yaml
@@ -1,0 +1,19 @@
+minor_changes:
+  - sonic_aaa - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_acl_interfaces - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_interfaces - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_ip_neighbor - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_l2_acls - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_l2_interfaces - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_l3_acls - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_lag_interfaces - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_logging - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_ntp - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_port_group - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_radius_server - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_static_routes - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_system - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_tacacs_server - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_users - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_vlans - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).
+  - sonic_vrfs - Enhance config diff generation function (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/318).

--- a/plugins/module_utils/network/sonic/config/aaa/aaa.py
+++ b/plugins/module_utils/network/sonic/config/aaa/aaa.py
@@ -100,8 +100,9 @@ class Aaa(ConfigBase):
             new_config = get_new_config(commands, existing_aaa_facts)
             result['after(generated)'] = new_config
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(old_config,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/acl_interfaces/acl_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/acl_interfaces/acl_interfaces.py
@@ -132,8 +132,9 @@ class Acl_interfaces(ConfigBase):
         if self._module._diff:
             self.sort_config(new_config)
             self.sort_config(old_config)
-            result['config_diff'] = get_formatted_config_diff(old_config,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/sonic/config/interfaces/interfaces.py
@@ -169,8 +169,9 @@ class Interfaces(ConfigBase):
             old_config.sort(key=lambda x: x['name'])
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(old_config,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/ip_neighbor/ip_neighbor.py
+++ b/plugins/module_utils/network/sonic/config/ip_neighbor/ip_neighbor.py
@@ -87,7 +87,7 @@ def __derive_ip_neighbor_config_delete_op(key_set, command, exist_conf):
 
 
 TEST_KEYS_formatted_diff = [
-    {'__delete_op_default': {'__delete_op': __derive_ip_neighbor_config_delete_op}},
+    {'__default_ops': {'__delete_op': __derive_ip_neighbor_config_delete_op}},
 ]
 
 
@@ -170,8 +170,9 @@ class Ip_neighbor(ConfigBase):
             result['after(generated)'] = new_config
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(existing_ip_neighbor_facts,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(existing_ip_neighbor_facts,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/l2_acls/l2_acls.py
+++ b/plugins/module_utils/network/sonic/config/l2_acls/l2_acls.py
@@ -162,8 +162,9 @@ class L2_acls(ConfigBase):
         if self._module._diff:
             self.sort_config(new_config)
             self.sort_config(old_config)
-            result['config_diff'] = get_formatted_config_diff(old_config,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l2_interfaces/l2_interfaces.py
@@ -134,8 +134,9 @@ class L2_interfaces(ConfigBase):
         if self._module._diff:
             self.sort_config(new_config)
             self.sort_config(old_config)
-            result['config_diff'] = get_formatted_config_diff(old_config,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/l3_acls/l3_acls.py
+++ b/plugins/module_utils/network/sonic/config/l3_acls/l3_acls.py
@@ -191,8 +191,9 @@ class L3_acls(ConfigBase):
         if self._module._diff:
             self.sort_config(new_config)
             self.sort_config(old_config)
-            result['config_diff'] = get_formatted_config_diff(old_config,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -141,8 +141,9 @@ class Lag_interfaces(ConfigBase):
         if self._module._diff:
             self.sort_config(new_config)
             self.sort_config(old_config)
-            result['config_diff'] = get_formatted_config_diff(old_config,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -121,8 +121,9 @@ class Logging(ConfigBase):
             result['after(generated)'] = new_config
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(existing_logging_facts,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(existing_logging_facts,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/ntp/ntp.py
+++ b/plugins/module_utils/network/sonic/config/ntp/ntp.py
@@ -48,7 +48,7 @@ TEST_KEYS = [
     {"ntp_keys": {"key_id": ""}}
 ]
 TEST_KEYS_formatted_diff = [
-    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF}},
+    {'__default_ops': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF}},
     {"servers": {"address": "", '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
     {"ntp_keys": {"key_id": "", '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}}
 ]
@@ -122,9 +122,9 @@ class Ntp(ConfigBase):
             result['after(generated)'] = new_config
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(existing_ntp_facts,
-                                                              new_config)
-
+            result['diff'] = get_formatted_config_diff(existing_ntp_facts,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/port_group/port_group.py
+++ b/plugins/module_utils/network/sonic/config/port_group/port_group.py
@@ -133,8 +133,9 @@ class Port_group(ConfigBase):
             result['after(generated)'] = new_config
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(existing_port_group_facts,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(existing_port_group_facts,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
+++ b/plugins/module_utils/network/sonic/config/radius_server/radius_server.py
@@ -43,7 +43,7 @@ TEST_KEYS = [
     {'host': {'name': ''}},
 ]
 TEST_KEYS_formatted_diff = [
-    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF}},
+    {'__default_ops': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF}},
     {'host': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
 ]
 
@@ -110,8 +110,9 @@ class Radius_server(ConfigBase):
             result['after(generated)'] = new_config
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(existing_radius_server_facts,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(existing_radius_server_facts,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/static_routes/static_routes.py
+++ b/plugins/module_utils/network/sonic/config/static_routes/static_routes.py
@@ -170,8 +170,9 @@ class Static_routes(ConfigBase):
         if self._module._diff:
             self.sort_lists_in_config(new_config)
             self.sort_lists_in_config(old_config)
-            result['config_diff'] = get_formatted_config_diff(old_config,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/system/system.py
+++ b/plugins/module_utils/network/sonic/config/system/system.py
@@ -61,7 +61,7 @@ def __derive_system_config_delete_op(key_set, command, exist_conf):
 
 
 TEST_KEYS_formatted_diff = [
-    {'__delete_op_default': {'__delete_op': __derive_system_config_delete_op}},
+    {'__default_ops': {'__delete_op': __derive_system_config_delete_op}},
 ]
 
 
@@ -126,8 +126,9 @@ class System(ConfigBase):
             result['after(generated)'] = new_config
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(existing_system_facts,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(existing_system_facts,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
@@ -43,7 +43,7 @@ TEST_KEYS = [
     {'host': {'name': ''}},
 ]
 TEST_KEYS_formatted_diff = [
-    {'__delete_op_default': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF}},
+    {'__default_ops': {'__delete_op': __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF}},
     {'host': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
 ]
 
@@ -110,8 +110,9 @@ class Tacacs_server(ConfigBase):
             result['after(generated)'] = new_config
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(existing_tacacs_server_facts,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(existing_tacacs_server_facts,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/users/users.py
+++ b/plugins/module_utils/network/sonic/config/users/users.py
@@ -119,8 +119,8 @@ class Users(ConfigBase):
             self.sort_lists_in_config(new_config)
             self.sort_lists_in_config(old_config)
             result['diff'] = get_formatted_config_diff(old_config,
-                                                      new_config,
-                                                      self._module._verbosity)
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/users/users.py
+++ b/plugins/module_utils/network/sonic/config/users/users.py
@@ -118,8 +118,9 @@ class Users(ConfigBase):
         if self._module._diff:
             self.sort_lists_in_config(new_config)
             self.sort_lists_in_config(old_config)
-            result['config_diff'] = get_formatted_config_diff(old_config,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                      new_config,
+                                                      self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/vlans/vlans.py
+++ b/plugins/module_utils/network/sonic/config/vlans/vlans.py
@@ -115,8 +115,9 @@ class Vlans(ConfigBase):
             result['after(generated)'] = new_config
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(existing_vlans_facts,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(existing_vlans_facts,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
+++ b/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
@@ -116,8 +116,9 @@ class Vrfs(ConfigBase):
             result['after(generated)'] = new_config
 
         if self._module._diff:
-            result['config_diff'] = get_formatted_config_diff(existing_vrf_interfaces_facts,
-                                                              new_config)
+            result['diff'] = get_formatted_config_diff(existing_vrf_interfaces_facts,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -104,8 +104,7 @@ def __MERGE_OP_DEFAULT(key_set, command, exist_conf):
     for key in trival_cmd_key_set:
         new_conf[key] = command[key]
 
-    common_dict_list_key_set = dict_list_cmd_key_set.intersection(dict_list_exist_key_set)
-    only_cmd_dict_list_key_set = dict_list_cmd_key_set.difference(common_dict_list_key_set)
+    only_cmd_dict_list_key_set = dict_list_cmd_key_set.difference(dict_list_exist_key_set)
     for key in only_cmd_dict_list_key_set:
         new_conf[key] = command[key]
 

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import json
 from copy import (
     deepcopy
 )
@@ -40,11 +41,22 @@ def get_test_key_set(key, test_keys):
 
     t_keys = next((t_key_item[key] for t_key_item in tst_keys if key in t_key_item), None)
     if t_keys:
+        t_keys.pop('__merge_op', None)
         t_keys.pop('__delete_op', None)
         t_keys.pop('__key_match_op', None)
         t_key_set = set(t_keys.keys())
 
     return t_key_set
+
+
+#
+# Pre-defined Key Match Operations
+#
+
+
+"""
+Default key match operation.
+"""
 
 
 def __KEY_MATCH_OP_DEFAULT(key_set, command, exist_conf):
@@ -75,6 +87,45 @@ def get_key_match_op(key, test_keys):
         k_match_op = t_keys.get('__key_match_op', __KEY_MATCH_OP_DEFAULT)
 
     return k_match_op
+
+
+#
+# Pre-defined Merge Operations
+#
+
+
+"""
+Default key match operation: simply merge command to existing config.
+"""
+
+
+def __MERGE_OP_DEFAULT(key_set, command, exist_conf):
+    new_conf = exist_conf
+    trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
+    nu, dict_list_exist_key_set = get_key_sets(new_conf)
+
+    for key in trival_cmd_key_set:
+        new_conf[key] = command[key]
+
+    common_dict_list_key_set = dict_list_cmd_key_set.intersection(dict_list_exist_key_set)
+    only_cmd_dict_list_key_set = dict_list_cmd_key_set.difference(common_dict_list_key_set)
+    for key in only_cmd_dict_list_key_set:
+        new_conf[key] = command[key]
+
+    return False, new_conf
+
+
+def get_merge_op(key, test_keys):
+    mrg_op = __MERGE_OP_DEFAULT
+    if not test_keys:
+        return mrg_op
+    if not key:
+        key = '__default_ops'
+    t_keys = next((t_key_item[key] for t_key_item in test_keys if key in t_key_item), None)
+    if t_keys:
+        mrg_op = t_keys.pop('__merge_op', __MERGE_OP_DEFAULT)
+
+    return mrg_op
 
 
 #
@@ -198,7 +249,7 @@ def get_delete_op(key, test_keys):
     if not test_keys:
         return del_op
     if not key:
-        key = '__delete_op_default'
+        key = '__default_ops'
     t_keys = next((t_key_item[key] for t_key_item in test_keys if key in t_key_item), None)
     if t_keys:
         del_op = t_keys.get('__delete_op', __DELETE_OP_DEFAULT)
@@ -247,9 +298,10 @@ def derive_config_from_merged_cmd(command, exist_conf, test_keys=None):
                                                                test_keys)
         new_conf = new_conf_dict.get("config", [])
     elif isinstance(command, dict) and isinstance(exist_conf, dict):
-        nu, new_conf = derive_config_from_merged_cmd_dict(command,
-                                                          exist_conf,
-                                                          test_keys)
+        merge_op_dft = get_merge_op('__default_ops', test_keys)
+        nu, new_conf = derive_config_from_merged_cmd_dict(command, exist_conf,
+                                                          test_keys, None,
+                                                          None, merge_op_dft)
     elif isinstance(command, dict) and isinstance(exist_conf, list):
         nu, new_conf_dict = derive_config_from_merged_cmd_dict({"config": [command]},
                                                                {"config": exist_conf},
@@ -262,7 +314,7 @@ def derive_config_from_merged_cmd(command, exist_conf, test_keys=None):
 
 
 def derive_config_from_merged_cmd_dict(command, exist_conf, test_keys=None, key_set=None,
-                                       key_match_op=None):
+                                       key_match_op=None, merge_op=None):
 
     if test_keys is None:
         test_keys = []
@@ -270,6 +322,8 @@ def derive_config_from_merged_cmd_dict(command, exist_conf, test_keys=None, key_
         key_set = set()
     if key_match_op is None:
         key_match_op = __KEY_MATCH_OP_DEFAULT
+    if merge_op is None:
+        merge_op = __MERGE_OP_DEFAULT
 
     new_conf = deepcopy(exist_conf)
     if not command:
@@ -283,12 +337,12 @@ def derive_config_from_merged_cmd_dict(command, exist_conf, test_keys=None, key_
 
     key_matched = key_match_op(key_set, command, new_conf)
     if key_matched:
-        for key in trival_cmd_key_set:
-            new_conf[key] = command[key]
-
-        only_cmd_dict_list_key_set = dict_list_cmd_key_set.difference(common_dict_list_key_set)
-        for key in only_cmd_dict_list_key_set:
-            new_conf[key] = command[key]
+        done, new_conf = merge_op(key_set, command, new_conf)
+        if done:
+            return key_matched, new_conf
+        else:
+            nu, dict_list_exist_key_set = get_key_sets(new_conf)
+            common_dict_list_key_set = dict_list_cmd_key_set.intersection(dict_list_exist_key_set)
     else:
         return key_matched, new_conf
 
@@ -300,11 +354,13 @@ def derive_config_from_merged_cmd_dict(command, exist_conf, test_keys=None, key_
         cmd_value = command[key]
         exist_value = new_conf[key]
 
+        t_key_set = get_test_key_set(key, test_keys)
+        t_key_match_op = get_key_match_op(key, test_keys)
+        t_merge_op = get_merge_op(key, test_keys)
+
         if (isinstance(cmd_value, list) and isinstance(exist_value, list)):
             c_list = cmd_value
             e_list = exist_value
-            t_key_set = get_test_key_set(key, test_keys)
-            t_key_match_op = get_key_match_op(key, test_keys)
 
             new_conf_list = list()
             not_dict_item = False
@@ -319,7 +375,8 @@ def derive_config_from_merged_cmd_dict(command, exist_conf, test_keys=None, key_
                                                                                         e_item,
                                                                                         remaining_keys,
                                                                                         t_key_set,
-                                                                                        t_key_match_op)
+                                                                                        t_key_match_op,
+                                                                                        t_merge_op)
                             if k_mtchd:
                                 new_conf[key].remove(e_item)
                                 if new_conf_dict:
@@ -355,7 +412,10 @@ def derive_config_from_merged_cmd_dict(command, exist_conf, test_keys=None, key_
         elif (isinstance(cmd_value, dict) and isinstance(exist_value, dict)):
             k_mtchd, new_conf_dict = derive_config_from_merged_cmd_dict(cmd_value,
                                                                         exist_value,
-                                                                        test_keys)
+                                                                        test_keys,
+                                                                        None,
+                                                                        t_key_match_op,
+                                                                        t_merge_op)
             if k_mtchd and new_conf_dict:
                 new_conf[key] = new_conf_dict
 
@@ -380,7 +440,7 @@ def derive_config_from_deleted_cmd(command, exist_conf, test_keys=None):
                                                                 test_keys)
         new_conf = new_conf_dict.get("config", [])
     elif isinstance(command, dict) and isinstance(exist_conf, dict):
-        delete_op_dft = get_delete_op('__delete_op_default', test_keys)
+        delete_op_dft = get_delete_op('__default_ops', test_keys)
         nu, new_conf = derive_config_from_deleted_cmd_dict(command, exist_conf,
                                                            test_keys, None,
                                                            None, delete_op_dft)
@@ -509,31 +569,27 @@ def derive_config_from_deleted_cmd_dict(command, exist_conf, test_keys=None, key
     return key_matched, new_conf
 
 
-def get_formatted_config_diff(exist_conf, new_conf):
+def get_formatted_config_diff(exist_conf, new_conf, verbosity=0):
 
-    diff_correction = [
-        {'python_str': ': None', 'ansible_str': ': null'},
-        {'python_str': ': True', 'ansible_str': ': true'},
-        {'python_str': ': False', 'ansible_str': ': false'},
-    ]
+    exist_conf = json.dumps(exist_conf, sort_keys=True, indent=4, separators=(u',', u': ')) + u'\n'
+    new_conf = json.dumps(new_conf, sort_keys=True, indent=4, separators=(u',', u': ')) + u'\n'
 
-    bfr = pformat(exist_conf)
-    for d_correct in diff_correction:
-        bfr = bfr.replace(d_correct['python_str'], d_correct['ansible_str'])
+    bfr = exist_conf.replace("\"", "\'")
+    aft = new_conf.replace("\"", "\'")
 
-    aft = pformat(new_conf)
-    for d_correct in diff_correction:
-        aft = aft.replace(d_correct['python_str'], d_correct['ansible_str'])
+    bfr_list = bfr.splitlines(True)
+    aft_list = aft.splitlines(True)
+    diffs = context_diff(bfr_list, aft_list, fromfile='before', tofile='after')
 
-    bfr_list = list(bfr.split(',\n'))
-    aft_list = list(aft.split(',\n'))
-    diffs = context_diff(bfr_list, aft_list,
-                         fromfile='before_config',
-                         tofile='after_config')
     formatted_diff = list()
     for diff in diffs:
-        if diff.endswith('\n'):
-            diff = diff.rstrip('\n')
+        if verbosity >= 3:
+            if diff.endswith('\n'):
+                diff = diff.rstrip('\n')
         formatted_diff.append(diff)
+
+    if verbosity < 3:
+        fmt_diff = u''.join(formatted_diff)
+        formatted_diff = {'prepared': fmt_diff}
 
     return formatted_diff

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -578,15 +578,12 @@ def get_formatted_config_diff(exist_conf, new_conf, verbosity=0):
     aft_list = aft.splitlines(True)
     diffs = context_diff(bfr_list, aft_list, fromfile='before', tofile='after')
 
-    formatted_diff = list()
-    for diff in diffs:
-        if verbosity >= 3:
-            if diff.endswith('\n'):
-                diff = diff.rstrip('\n')
-        formatted_diff.append(diff)
+    if verbosity >= 3:
+        formatted_diff = list()
+        for diff in diffs:
+            formatted_diff.append(diff.rstrip('\n'))
 
-    if verbosity < 3:
-        fmt_diff = u''.join(formatted_diff)
-        formatted_diff = {'prepared': fmt_diff}
+    else:
+        formatted_diff = {'prepared': u''.join(diffs)}
 
     return formatted_diff

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -120,7 +120,7 @@ def get_merge_op(key, test_keys):
         key = '__default_ops'
     t_keys = next((t_key_item[key] for t_key_item in test_keys if key in t_key_item), None)
     if t_keys:
-        mrg_op = t_keys.pop('__merge_op', __MERGE_OP_DEFAULT)
+        mrg_op = t_keys.get('__merge_op', __MERGE_OP_DEFAULT)
 
     return mrg_op
 

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -12,9 +12,6 @@ import json
 from copy import (
     deepcopy
 )
-from pprint import (
-    pformat
-)
 from difflib import (
     context_diff
 )

--- a/plugins/modules/sonic_ip_neighbor.py
+++ b/plugins/modules/sonic_ip_neighbor.py
@@ -34,6 +34,8 @@ DOCUMENTATION = """
 ---
 module: sonic_ip_neighbor
 version_added: 2.1.0
+notes:
+  - Supports C(check_mode).
 short_description: Manage IP neighbor global configuration on SONiC.
 description:
   - This module provides configuration management of IP neighbor global for devices running SONiC.
@@ -257,6 +259,13 @@ before:
 after:
   description: The resulting configuration model invocation.
   returned: when changed
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
   type: list
   sample: >
     The configuration returned will always be in the same format

--- a/plugins/modules/sonic_logging.py
+++ b/plugins/modules/sonic_logging.py
@@ -34,6 +34,8 @@ DOCUMENTATION = """
 ---
 module: sonic_logging
 version_added: 2.1.0
+notes:
+  - Supports C(check_mode).
 short_description: Manage logging configuration on SONiC.
 description:
   - This module provides configuration management of logging for devices running SONiC.
@@ -231,6 +233,13 @@ before:
 after:
   description: The resulting configuration model invocation.
   returned: when changed
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
   type: list
   sample: >
     The configuration returned will always be in the same format

--- a/plugins/modules/sonic_ntp.py
+++ b/plugins/modules/sonic_ntp.py
@@ -34,6 +34,8 @@ DOCUMENTATION = """
 ---
 module: sonic_ntp
 version_added: 2.0.0
+notes:
+  - Supports C(check_mode).
 short_description: Manage NTP configuration on SONiC.
 description:
   - This module provides configuration management of NTP for devices running SONiC.
@@ -416,6 +418,13 @@ before:
 after:
   description: The resulting configuration model invocation.
   returned: when changed
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
   type: list
   sample: >
     The configuration returned will always be in the same format

--- a/plugins/modules/sonic_port_group.py
+++ b/plugins/modules/sonic_port_group.py
@@ -34,6 +34,8 @@ DOCUMENTATION = """
 ---
 module: sonic_port_group
 version_added: 2.1.0
+notes:
+  - Supports C(check_mode).
 short_description: Manages port group configuration on SONiC.
 description:
   - This module provides configuration management of port group for devices running SONiC.
@@ -327,6 +329,13 @@ before:
 after:
   description: The resulting configuration model invocation.
   returned: when changed
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
   type: list
   sample: >
     The configuration returned will always be in the same format


### PR DESCRIPTION
##### SUMMARY
- Enhance config generation utility to allow plugin for "merged" state handling.
- Change config diff utility to use json_dump instead of pformat, and generate console output for diff strings.
- Change module result with "diff" attribute instead of "config_diff"

##### GitHub Issues
N/A

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
All modules which have invoked "get_formatted_config_diff" util function.

##### OUTPUT
Take sonic_radius_server as sample (All regression tests and all unit tests results and logs are too many to be attached.  If needed, please ask and will be provided):

- unit test script: 
[radius.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13729181/radius.txt)
- log for playbook with --diff: 
[radius_diff.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13729192/radius_diff.log)
- log for playbook with --diff and -vvv: 
[radius_diff_vvv.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13729196/radius_diff_vvv.log)
-  log for playbook with --diff and --check: 
[radius_diff_check.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13729203/radius_diff_check.log)
-  log for playbook with --diff, --check and -vvv: 
[radius_diff_check_vvv.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13729204/radius_diff_check_vvv.log)


##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
- executed all related regression tests. All regression status are passed
- executed unit tests for all involved modules.
