### PR TITLE
Fix bgp_communities facts handling for empty member lists.

### DIFF
--- a/changelogs/fragments/319-bgp-communities-no-member-facts-fix.yaml
+++ b/changelogs/fragments/319-bgp-communities-no-member-facts-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fix incorrect handling for parsing of a BGP community list with an empty "members" list (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/319).
+  - Fix incorrect "facts" handling for parsing of a BGP community list configured with an empty "members" list (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/319).

--- a/changelogs/fragments/319-bgp-communities-no-member-facts-fix.yaml
+++ b/changelogs/fragments/319-bgp-communities-no-member-facts-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixed incorrect handling for parsing of a BGP community list with an empty "members" list (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/319).

--- a/changelogs/fragments/319-bgp-communities-no-member-facts-fix.yaml
+++ b/changelogs/fragments/319-bgp-communities-no-member-facts-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fixed incorrect handling for parsing of a BGP community list with an empty "members" list (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/319).
+  - Fix incorrect handling for parsing of a BGP community list with an empty "members" list (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/319).

--- a/changelogs/fragments/319-bgp-communities-no-member-facts-fix.yaml
+++ b/changelogs/fragments/319-bgp-communities-no-member-facts-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fix incorrect "facts" handling for parsing of a BGP community list configured with an empty "members" list (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/319).
+  - sonic_bgp_communities - Fix incorrect "facts" handling for parsing of a BGP community list configured with an empty "members" list (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/319).

--- a/plugins/module_utils/network/sonic/facts/bgp_communities/bgp_communities.py
+++ b/plugins/module_utils/network/sonic/facts/bgp_communities/bgp_communities.py
@@ -74,11 +74,14 @@ class Bgp_communitiesFacts(object):
                 result['permit'] = True
             if members:
                 result['type'] = 'expanded' if 'REGEX' in members[0] else 'standard'
-            if result['type'] == 'expanded':
-                members = [':'.join(i.split(':')[1:]) for i in members]
-                members.sort()
-                result['members'] = {'regex': members}
+                if result['type'] == 'expanded':
+                    members = [':'.join(i.split(':')[1:]) for i in members]
+                    members.sort()
+                    result['members'] = {'regex': members}
             else:
+                result['type'] = 'standard'
+
+            if result['type'] == 'standard':
                 result['local_as'] = None
                 result['no_advertise'] = None
                 result['no_export'] = None

--- a/tests/regression/roles/sonic_bgp_communities/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_communities/defaults/main.yml
@@ -66,8 +66,10 @@ tests:
               - "13"
         - name: test2
           type: standard
+          permit: false
           match: ALL
           no_export: true
+          no_peer: true
   - name: test_case_05
     description: Delete1 BGP properties
     state: deleted

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_communities.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_communities.yaml
@@ -26,6 +26,14 @@ merged_01:
     - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/community-sets"
       response:
         code: 200
+        value:
+          openconfig-bgp-policy:community-sets:
+            community-set:
+              - community-set-name: 'test2'
+                config:
+                  community-set-name: 'test2'
+                  openconfig-bgp-policy-ext:action: 'PERMIT'
+                  match-set-options: 'ALL'
   expected_config_requests:
     - path: "data/openconfig-routing-policy:routing-policy/defined-sets/openconfig-bgp-policy:bgp-defined-sets/community-sets"
       method: "patch"


### PR DESCRIPTION
##### SUMMARY
The change set merged for PR #251 (bgp_communities - Add support for replaced and overridden states: https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/251) introduced a crash exposure in the "facts" file for the case in which a configured BGP community list exists, but has no members. If this configuration case exists, any attempt to gather Ansible "facts" for the bgp_communities resource module fails with a crash during parsing of the configuration for the BGP community list with the empty member list. As a result, all playbook tasks fail for this resource module.

The crash occurs due to an attempt to access a non-existent "type" element of the "result" dict for the current BGP Community list to determine how to parse the "member" attributes. (No value was being set for the "type" element when the "member" list did not exist.)

The revised handling proposed in this PR handles the "problem" case by saving the parsed BGP community list result as a "standard" type list with default attribute values.

##### GitHub Issues
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
sonic_bgp_communities

##### OUTPUT
<!--- Paste the functionality test result below -->
Summary regression test result with the fix installed, plus  an added integration test case to generate the "problem" configuration case and verify that it is correctly handled during subsequent configuration requests:

[2.3.0_bgp_comm_fix_with_no-mem_cfg_integration test_regression-2024-01-02-22-58-14.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13817257/2.3.0_bgp_comm_fix_with_no-mem_cfg_integration.test_regression-2024-01-02-22-58-14.pdf)

Full regression test log for the test run for same test run (with the fix installed, plus  an added integration test case to generate the "problem" configuration case and verify that it is correctly handled during subsequent configuration requests):

[2.3.0_bgp_only_nomem_fix_pr_nomem_cfg_with_new_testcase_uninstrumented_permit_mismatch.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13817284/2.3.0_bgp_only_nomem_fix_pr_nomem_cfg_with_new_testcase_uninstrumented_permit_mismatch.log)



Summary regression test result with the fix installed and the "problem" case configured:

[2.3.0_bgp_comm_fix_with_no-mem_cfg_pr_regression-2023-12-29-17-21-05.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13797436/2.3.0_bgp_comm_fix_with_no-mem_cfg_pr_regression-2023-12-29-17-21-05.pdf)

Full regression test log with the fix installed and the "problem" case configured:

[2.3.0_bgp_comm_nomem_fix_pr_nomem_cfg.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13797438/2.3.0_bgp_comm_nomem_fix_pr_nomem_cfg.log)

Summary regression test result without the fix installed and the "problem" case configured:
[2.3.0_bgp_comm_nomem_nofix_regression-2023-12-29-16-36-29.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/13797486/2.3.0_bgp_comm_nomem_nofix_regression-2023-12-29-16-36-29.pdf)

Example traceback for the crash fixed by this PR:

 File "/home/kerry/.ansible/collections/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/facts/facts.py", line 135, in get_network_resources_facts
    inst.populate_facts(
  File "/home/kerry/.ansible/collections/ansible_collections/dellemc/enterprise_sonic/plugins/module_utils/network/sonic/facts/bgp_communities/bgp_communities.py", line 111, in populate_facts
    resources = self.get_bgp_communities()
  File "/home/kerry/.ansible/collections/ansible_collections/dellemc/enterprise_sonic/plugins/module_utils/network/sonic/facts/bgp_communities/bgp_communities.py", line 77, in get_bgp_communities
    if result['type'] == 'expanded':
fatal: [sonic1]: FAILED! => {

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?

Re-run the failing regression test suite with the fix installed.

- Verify that the crash occurs consistently with the "problem" configuration case present and without the fix installed.
- Verify that the crash does not occur with the "problem" configuration case present and with the fix installed.

- Problem configuration from a raw Openconfig "GET":

{
  "openconfig-bgp-policy:community-sets": {
    "community-set": [
      {
        "community-set-name": "bgp_no_mem",
        "config": {
          "openconfig-bgp-policy-ext:action": "PERMIT",
          "community-set-name": "bgp_no_mem",
          "match-set-options": "ANY"
        },
        "state": {
          "openconfig-bgp-policy-ext:action": "PERMIT",
          "community-set-name": "bgp_no_mem",
          "match-set-options": "ANY"
        }
      }
    ]
  }
}
