### PR TITLE
Configure the selected interface naming test mode at the start of a regression run.

### DIFF
--- a/changelogs/fragments/329-regression-test-automated-intf-naming-config.yaml
+++ b/changelogs/fragments/329-regression-test-automated-intf-naming-config.yaml
@@ -1,0 +1,2 @@
+trivial:
+  - tests - Enable automated regression testing of both "native" and "standard" interface naming modes (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/329).

--- a/tests/regression/roles/sonic_route_maps/defaults/main.yml
+++ b/tests/regression/roles/sonic_route_maps/defaults/main.yml
@@ -65,7 +65,7 @@ tests:
             default_route: true
             vni: 735
           ext_comm: bgp_ext_comm1
-          interface: Ethernet8
+          interface: "{{interface2}}"
           ip:
             address: ip_pfx_list1
           ipv6:
@@ -126,7 +126,7 @@ tests:
             route_type: multicast
           origin: incomplete
           peer:
-            interface: Ethernet16
+            interface: "{{interface4}}"
           source_protocol: ospf
         set:
           community:
@@ -219,7 +219,7 @@ tests:
         action: permit
         sequence_num: 100
         match:
-          interface: Ethernet16
+          interface: "{{interface4}}"
           source_protocol: ospf
           origin: incomplete
           peer:
@@ -409,7 +409,7 @@ tests:
           ext_comm: bgp_ext_comm2
           origin: igp
           peer:
-            interface: Ethernet16
+            interface: "{{interface4}}"
           source_protocol: connected
         set:
           community:
@@ -423,7 +423,7 @@ tests:
         action: permit
         sequence_num: 100
         match:
-          interface: Ethernet16
+          interface: "{{interface4}}"
           origin: incomplete
           peer:
             ip: 5.6.7.8
@@ -597,7 +597,7 @@ tests:
         action: deny
         sequence_num: 3047
         match:
-          interface: Ethernet8
+          interface: "{{interface2}}"
           ipv6:
             address: ipv6_pfx_list1
           origin: egp
@@ -635,7 +635,7 @@ tests:
           ext_comm: bgp_ext_comm2
           origin: igp
           peer:
-            interface: Ethernet16
+            interface: "{{interface4}}"
           source_protocol: connected
         set:
           community:
@@ -649,7 +649,7 @@ tests:
         action: permit
         sequence_num: 100
         match:
-          interface: Ethernet16
+          interface: "{{interface4}}"
           origin: incomplete
           peer:
             ip: 5.6.7.8
@@ -746,7 +746,7 @@ tests:
           ext_comm: bgp_ext_comm2
           origin: igp
           peer:
-            interface: Ethernet16
+            interface: "{{interface4}}"
           source_protocol: connected
         set:
           community:
@@ -864,7 +864,7 @@ tests:
           ext_comm: bgp_ext_comm2
           origin: igp
           peer:
-            interface: Ethernet16
+            interface: "{{interface4}}"
           source_protocol: connected
         set:
           community:
@@ -917,7 +917,7 @@ tests:
           ext_comm: bgp_ext_comm2
           origin: igp
           peer:
-            interface: Ethernet16
+            interface: "{{interface4}}"
           source_protocol: connected
         set:
           community:
@@ -931,7 +931,7 @@ tests:
         action: permit
         sequence_num: 100
         match:
-          interface: Ethernet16
+          interface: "{{interface4}}"
           origin: incomplete
           peer:
             ip: 5.6.7.8
@@ -980,7 +980,7 @@ tests:
         action: permit
         sequence_num: 250
         match:
-          interface: Ethernet24
+          interface: "{{interface6}}"
         set:
           as_path_prepend: 150,275
           metric:
@@ -999,7 +999,7 @@ tests:
           ext_comm: bgp_ext_comm2
           origin: igp
           peer:
-            interface: Ethernet16
+            interface: "{{interface4}}"
           source_protocol: connected
         set:
           community:
@@ -1013,7 +1013,7 @@ tests:
         action: permit
         sequence_num: 100
         match:
-          interface: Ethernet16
+          interface: "{{interface4}}"
           origin: incomplete
           peer:
             ip: 5.6.7.8

--- a/tests/regression/test.yaml
+++ b/tests/regression/test.yaml
@@ -12,6 +12,7 @@
     #- sonic_command
     #- sonic_config
 
+    - sonic_system
     - sonic_interfaces
     - sonic_l2_interfaces
     - sonic_lag_interfaces
@@ -34,7 +35,6 @@
     - sonic_aaa
     - sonic_tacacs_server
     - sonic_radius_server
-    - sonic_system
     - sonic_prefix_lists
     - sonic_static_routes
     - sonic_ntp


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change set is proposed to facilitate automated testing runs for both interface-naming modes: "native" and "standard". It contains the following fixes:

1) It provides a simple change to automatically cause the configuration of the target switch interface-naming mode to match the interface-naming mode selected for the test run. This is accomplished by moving the "system" resource module integration test to the beginning of the module test list. Because the "system" resource module integration test does a cleanup task that configures the switch with the selected interface-naming mode specified in the test "defaults" file (tests/regression/roles/common/defaults/main.yaml), placing this test first in the list of tests to be run causes the matching interface-naming mode to be present for all of the remaining tests.

2) It fixes a bug in the "route map" integration test. That test was using hard coded "native" interface-naming mode for Ethernet interfaces referenced in the test. The changes proposed in this change set replace the hard coded Ethernet interface names with parameterized interface names that are set at the initial invocation of the test to use the interface-naming mode selected for the test. Although these changes modify the choices for which interfaces are used for the route map integration test, this doesn't matter as long as there is a 1:1 mapping from the previously used interfaces to the new interfaces and the new interfaces exist on the testbed device.

The posted regression test results show that the configured switch mode gets set as needed at the start of a regression test suite run and that module tests with references to Ethernet interfaces now pass even when the selected test interface-naming mode does not match the initially configured switch interface-naming mode.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below
```
Automated transition from configured "native" mode to configured "standard" mode:
  - Summary results:
[automation_intf_naming_fix_PR_rmap_std_regression-2024-01-24-01-25-01.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14043692/automation_intf_naming_fix_PR_rmap_std_regression-2024-01-24-01-25-01.pdf)

  - Detailed logs:
[if_naming_auto_rmap_to_standard.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14043695/if_naming_auto_rmap_to_standard.log)

Automated transition from configured "standard" mode to configured "native" mode:
  - Summary results:
[automation_intf_naming_fix_PR_rmap_native_regression-2024-01-24-02-57-48.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14043687/automation_intf_naming_fix_PR_rmap_native_regression-2024-01-24-02-57-48.pdf)

  - Detailed logs:
[if_naming_auto_rmap_to_native.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14043691/if_naming_auto_rmap_to_native.log)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

1) Automated transition from configured "native" mode to configured "standard" mode
2) Automated transition from configured "standard" mode to configured "native" mode:
