### PR TITLE
Vxlan external ip feature

### DIFF
--- a/changelogs/fragments/330-add-external-ip-attribute-for-vxlan.yaml
+++ b/changelogs/fragments/330-add-external-ip-attribute-for-vxlan.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sonic_vxlans - Add support for the "external_ip" vxlan option (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/330).

--- a/plugins/module_utils/network/sonic/argspec/vxlans/vxlans.py
+++ b/plugins/module_utils/network/sonic/argspec/vxlans/vxlans.py
@@ -45,6 +45,7 @@ class VxlansArgs(object):  # pylint: disable=R0903
                 'name': {'required': True, 'type': 'str'},
                 'source_ip': {'type': 'str'},
                 'primary_ip': {'type': 'str'},
+                'external_ip': {'type': 'str'},
                 'vlan_map': {
                     'elements': 'dict',
                     'options': {

--- a/plugins/module_utils/network/sonic/config/vxlans/vxlans.py
+++ b/plugins/module_utils/network/sonic/config/vxlans/vxlans.py
@@ -366,7 +366,7 @@ class Vxlans(ConfigBase):
 
             is_delete_full = False
             if (name and vlan_map_list is None and vrf_map_list is None and
-                    src_ip is None and evpn_nvo is None and primary_ip is None and 
+                    src_ip is None and evpn_nvo is None and primary_ip is None and
                     external_ip is None):
                 is_delete_full = True
                 vrf_map_list = matched.get("vrf_map", [])

--- a/plugins/module_utils/network/sonic/config/vxlans/vxlans.py
+++ b/plugins/module_utils/network/sonic/config/vxlans/vxlans.py
@@ -366,7 +366,8 @@ class Vxlans(ConfigBase):
 
             is_delete_full = False
             if (name and vlan_map_list is None and vrf_map_list is None and
-                    src_ip is None and evpn_nvo is None and primary_ip is None):
+                    src_ip is None and evpn_nvo is None and primary_ip is None and 
+                    external_ip is None):
                 is_delete_full = True
                 vrf_map_list = matched.get("vrf_map", [])
                 vlan_map_list = matched.get("vlan_map", [])

--- a/plugins/module_utils/network/sonic/config/vxlans/vxlans.py
+++ b/plugins/module_utils/network/sonic/config/vxlans/vxlans.py
@@ -279,6 +279,7 @@ class Vxlans(ConfigBase):
         vlan_map_requests = []
         src_ip_requests = []
         primary_ip_requests = []
+        external_ip_requests = []
         evpn_nvo_requests = []
         tunnel_requests = []
 
@@ -291,6 +292,7 @@ class Vxlans(ConfigBase):
             vrf_map_list = conf.get('vrf_map', [])
             src_ip = conf.get('source_ip', None)
             primary_ip = conf.get('primary_ip', None)
+            external_ip = conf.get('external_ip', None)
             evpn_nvo = conf.get('evpn_nvo', None)
 
             if vrf_map_list:
@@ -301,6 +303,8 @@ class Vxlans(ConfigBase):
                 src_ip_requests.extend(self.get_delete_src_ip_request(conf, conf, name, src_ip))
             if primary_ip:
                 primary_ip_requests.extend(self.get_delete_primary_ip_request(conf, conf, name, primary_ip))
+            if external_ip:
+                external_ip_requests.extend(self.get_delete_external_ip_request(conf, conf, name, external_ip))
             if evpn_nvo:
                 evpn_nvo_requests.extend(self.get_delete_evpn_request(conf, conf, evpn_nvo))
             tunnel_requests.extend(self.get_delete_tunnel_request(conf, conf, name))
@@ -315,6 +319,8 @@ class Vxlans(ConfigBase):
             requests.extend(primary_ip_requests)
         if evpn_nvo_requests:
             requests.extend(evpn_nvo_requests)
+        if external_ip_requests:
+            requests.extend(external_ip_requests)
         if tunnel_requests:
             requests.extend(tunnel_requests)
 
@@ -331,6 +337,7 @@ class Vxlans(ConfigBase):
         src_ip_requests = []
         evpn_nvo_requests = []
         primary_ip_requests = []
+        external_ip_requests = []
         tunnel_requests = []
 
         # Need to delete in the reverse order of creation.
@@ -342,6 +349,7 @@ class Vxlans(ConfigBase):
             src_ip = conf.get('source_ip', None)
             evpn_nvo = conf.get('evpn_nvo', None)
             primary_ip = conf.get('primary_ip', None)
+            external_ip = conf.get('external_ip', None)
             vlan_map_list = conf.get('vlan_map', None)
             vrf_map_list = conf.get('vrf_map', None)
 
@@ -384,6 +392,8 @@ class Vxlans(ConfigBase):
                 evpn_nvo_requests.extend(self.get_delete_evpn_request(conf, matched, evpn_nvo))
             if primary_ip:
                 primary_ip_requests.extend(self.get_delete_primary_ip_request(conf, matched, name, primary_ip))
+            if external_ip:
+                external_ip_requests.extend(self.get_delete_external_ip_request(conf, matched, name, external_ip))
             if is_delete_full:
                 tunnel_requests.extend(self.get_delete_tunnel_request(conf, matched, name))
 
@@ -397,6 +407,8 @@ class Vxlans(ConfigBase):
             requests.extend(evpn_nvo_requests)
         if primary_ip_requests:
             requests.extend(primary_ip_requests)
+        if external_ip_requests:
+            requests.extend(external_ip_requests)
         if tunnel_requests:
             requests.extend(tunnel_requests)
 
@@ -439,6 +451,8 @@ class Vxlans(ConfigBase):
             vtep_ip_dict['src_ip'] = conf['source_ip']
         if conf.get('primary_ip', None):
             vtep_ip_dict['primary_ip'] = conf['primary_ip']
+        if conf.get('external_ip', None):
+            vtep_ip_dict['external_ip'] = conf['external_ip']
 
         payload_url['sonic-vxlan:VXLAN_TUNNEL'] = {'VXLAN_TUNNEL_LIST': [vtep_ip_dict]}
 
@@ -581,6 +595,18 @@ class Vxlans(ConfigBase):
         if is_change_needed:
             request = {"path": url.format(name=name), "method": DELETE}
             requests.append(request)
+
+        return requests
+
+    def get_delete_external_ip_request(self, conf, matched, name, external_ip):
+        requests = []
+        url = "data/sonic-vxlan:sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST={name}/external_ip"
+
+        if matched:
+            matched_external_ip = matched.get('external_ip', None)
+            if matched_external_ip and matched_external_ip == external_ip:
+                request = {"path": url.format(name=name), "method": DELETE}
+                requests.append(request)
 
         return requests
 

--- a/plugins/module_utils/network/sonic/facts/vxlans/vxlans.py
+++ b/plugins/module_utils/network/sonic/facts/vxlans/vxlans.py
@@ -164,6 +164,7 @@ class VxlansFacts(object):
             vxlan['name'] = each_tunnel['name']
             vxlan['source_ip'] = each_tunnel.get('src_ip', None)
             vxlan['primary_ip'] = each_tunnel.get('primary_ip', None)
+            vxlan["external_ip"] = each_tunnel.get('external_ip', None)
             vxlan['evpn_nvo'] = None
             evpn_nvo = next((nvo_map['name'] for nvo_map in vxlans_evpn_nvo_list if nvo_map['source_vtep'] == vxlan['name']), None)
             if evpn_nvo:

--- a/plugins/modules/sonic_vxlans.py
+++ b/plugins/modules/sonic_vxlans.py
@@ -59,6 +59,9 @@ options:
       primary_ip:
         description: 'The vtep mclag primary ip address for this node'
         type: str
+      external_ip:
+        description: 'The vtep mclag external ip address for this node'
+        type: str
       vlan_map:
         description: 'The list of VNI map of VLAN.'
         type: list

--- a/tests/regression/roles/sonic_vxlan/defaults/main.yml
+++ b/tests/regression/roles/sonic_vxlan/defaults/main.yml
@@ -31,6 +31,7 @@ tests_cli:
       - name: vtep1
         source_ip: 1.1.1.1
         primary_ip: 2.2.2.2
+        external_ip: 3.3.3.3
         evpn_nvo: nvo5
         vlan_map:
           - vni: 101
@@ -56,6 +57,7 @@ tests:
       - name: vtep1
         source_ip: 1.1.1.1
         primary_ip: 2.2.2.2
+        external_ip: 3.3.3.3
   - name: test_case_03
     description: Update VRF properties
     state: merged
@@ -94,6 +96,7 @@ tests:
       - name: vtep2
         source_ip: 3.3.3.3
         primary_ip: 4.4.4.4
+        external_ip: 5.5.5.5
         evpn_nvo: nvo5
         vlan_map:
           - vni: 101
@@ -108,6 +111,7 @@ tests:
       - name: vtep2
         source_ip: 5.5.5.5
         primary_ip: 6.6.6.6
+        external_ip: 7.7.7.7
         evpn_nvo: nvo6
         vlan_map:
           - vni: 101
@@ -126,6 +130,7 @@ tests:
       - name: vtep2
         source_ip: 5.5.5.5
         primary_ip: 6.6.6.6
+        external_ip: 7.7.7.7
         evpn_nvo: nvo6
         vlan_map:
           - vni: 101

--- a/tests/unit/modules/network/sonic/fixtures/sonic_vxlans.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_vxlans.yaml
@@ -5,6 +5,7 @@ merged_01:
       - name: vteptest1
         source_ip: 1.1.1.1
         primary_ip: 2.2.2.2
+        external_ip: 3.3.3.3
         evpn_nvo: nvo1
         vlan_map:
           - vni: 101
@@ -52,6 +53,7 @@ merged_01:
             - name: vteptest1
               src_ip: 1.1.1.1
               primary_ip: 2.2.2.2
+              external_ip: 3.3.3.3
     - path: "data/sonic-vxlan:sonic-vxlan/VXLAN_TUNNEL_MAP"
       method: "patch"
       data:
@@ -102,6 +104,7 @@ deleted_01:
                 - name: vteptest1
                   src_ip: 1.1.1.1
                   primary_ip: 2.2.2.2
+                  external_ip: 3.3.3.3
             VXLAN_TUNNEL_MAP:
               VXLAN_TUNNEL_MAP_LIST:
                 - name: vteptest1
@@ -128,6 +131,9 @@ deleted_01:
     - path: "data/sonic-vxlan:sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST=vteptest1/src_ip"
       method: "delete"
       data:
+    - path: "data/sonic-vxlan:sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST=vteptest1/external_ip"
+      method: "delete"
+      data:
     - path: "data/sonic-vxlan:sonic-vxlan/EVPN_NVO/EVPN_NVO_LIST=nvo1"
       method: "delete"
       data:
@@ -145,6 +151,7 @@ deleted_02:
       - name: vteptest1
         source_ip: 1.1.1.1
         primary_ip: 2.2.2.2
+        external_ip: 3.3.3.3
         evpn_nvo: nvo1
         vlan_map:
           - vni: 101
@@ -184,6 +191,7 @@ deleted_02:
                 - name: vteptest1
                   src_ip: 1.1.1.1
                   primary_ip: 2.2.2.2
+                  external_ip: 3.3.3.3
             VXLAN_TUNNEL_MAP:
               VXLAN_TUNNEL_MAP_LIST:
                 - name: vteptest1
@@ -210,6 +218,9 @@ deleted_02:
     - path: "data/sonic-vxlan:sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST=vteptest1/src_ip"
       method: "delete"
       data:
+    - path: "data/sonic-vxlan:sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST=vteptest1/external_ip"
+      method: "delete"
+      data:
     - path: "data/sonic-vxlan:sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST=vteptest1,map_101_Vlan11"
       method: "delete"
       data:
@@ -224,6 +235,7 @@ replaced_02:
       - name: vteptest1
         source_ip: 1.1.1.9
         primary_ip: 2.2.2.9
+        external_ip: 3.3.3.9
         evpn_nvo: nvo1
         vlan_map:
           - vni: 101
@@ -265,6 +277,7 @@ replaced_02:
                 - name: vteptest1
                   src_ip: 1.1.1.1
                   primary_ip: 2.2.2.2
+                  external_ip: 3.3.3.3
             VXLAN_TUNNEL_MAP:
               VXLAN_TUNNEL_MAP_LIST:
                 - name: vteptest1
@@ -298,6 +311,7 @@ replaced_02:
             - name: vteptest1
               src_ip: 1.1.1.9
               primary_ip: 2.2.2.9
+              external_ip: 3.3.3.9
     - path: "data/sonic-vxlan:sonic-vxlan/VXLAN_TUNNEL_MAP"
       method: "patch"
       data:
@@ -324,6 +338,7 @@ overridden_02:
       - name: vteptest1
         source_ip: 1.1.1.9
         primary_ip: 2.2.2.9
+        external_ip: 3.3.3.9
         evpn_nvo: nvo1
         vlan_map:
           - vni: 101
@@ -365,6 +380,7 @@ overridden_02:
                 - name: vteptest1
                   src_ip: 1.1.1.1
                   primary_ip: 2.2.2.2
+                  external_ip: 3.3.3.3
             VXLAN_TUNNEL_MAP:
               VXLAN_TUNNEL_MAP_LIST:
                 - name: vteptest1
@@ -398,6 +414,7 @@ overridden_02:
             - name: vteptest1
               src_ip: 1.1.1.9
               primary_ip: 2.2.2.9
+              external_ip: 3.3.3.9
     - path: "data/sonic-vxlan:sonic-vxlan/VXLAN_TUNNEL_MAP"
       method: "patch"
       data:


### PR DESCRIPTION
##### SUMMARY
 adding support to retrieve and configure external ip attribute in vxlan resource module to match the CLI.

##### GitHub Issues

| GitHub Issue # |
| -------------- |
|#327 |


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sonic_vxlan

##### OUTPUT
[vxlan_regression_output1-24-24.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14057553/vxlan_regression_output1-24-24.txt)
[vxlan_regression_results_pdf1-24-24.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14057554/vxlan_regression_results_pdf1-24-24.pdf)


##### ADDITIONAL INFORMATION
none

##### Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [X] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
added attribute to existing tests
