### PR TITLE
Fix dhcp_snooping regression failure

### DIFF
--- a/tests/regression/roles/sonic_dhcp_snooping/defaults/main.yml
+++ b/tests/regression/roles/sonic_dhcp_snooping/defaults/main.yml
@@ -31,12 +31,12 @@ tests:
           vlans:
             - '1'
           trusted:
-            - intf_name: 'Ethernet1'
+            - intf_name: '{{ interface1 }}'
           source_bindings:
             - mac_addr: "12:12:12:12:12:12"
               ip_addr: "2.2.2.2"
               vlan_id: 1
-              intf_name: "Ethernet3"
+              intf_name: "{{ interface3 }}"
         - afi: 'ipv6'
           enabled: true
           verify_mac: false
@@ -44,7 +44,7 @@ tests:
             - '2'
             - '3'
           trusted:
-            - intf_name: 'Ethernet2'
+            - intf_name: '{{ interface2 }}'
             - intf_name: 'PortChannel1'
   - name: test_case_02_merge_update
     description: Update DHCPv4 and DHCPv6 snooping configuration
@@ -53,16 +53,16 @@ tests:
       afis:
         - afi: 'ipv4'
           trusted:
-            - intf_name: 'Ethernet2'
+            - intf_name: '{{ interface2 }}'
           source_bindings:
             - mac_addr: "12:12:12:12:12:12"
               ip_addr: "2.2.2.2"
               vlan_id: 2
-              intf_name: 'Ethernet3'
+              intf_name: '{{ interface3 }}'
             - mac_addr: "14:14:14:14:14:14"
               ip_addr: "4.4.4.4"
               vlan_id: 4
-              intf_name: 'Ethernet4'
+              intf_name: '{{ interface4 }}'
         - afi: 'ipv6'
           vlans:
             - '2'
@@ -82,19 +82,19 @@ tests:
             - mac_addr: "12:12:12:12:12:12"
               ip_addr: "3.3.3.3"
               vlan_id: 2
-              intf_name: 'Ethernet3'
+              intf_name: '{{ interface3 }}'
           trusted:
-            - intf_name: 'Ethernet1'
-            - intf_name: 'Ethernet2'
+            - intf_name: '{{ interface1 }}'
+            - intf_name: '{{ interface2 }}'
         - afi: 'ipv6'
           verify_mac: true
           source_bindings:
             - mac_addr: "12:12:12:12:12:12"
               ip_addr: "2002::2"
               vlan_id: 3
-              intf_name: 'Ethernet3'
+              intf_name: '{{ interface3 }}'
           trusted:
-            - intf_name: 'Ethernet1'
+            - intf_name: '{{ interface1 }}'
   - name: test_case_04_replace
     description: Replace DHCPv4 and DHCPv6 snooping configuration
     state: replaced
@@ -104,8 +104,8 @@ tests:
           verify_mac: false
           vlans: ['3']
           trusted:
-            - intf_name: 'Ethernet1'
-            - intf_name: 'Ethernet2'
+            - intf_name: '{{ interface1 }}'
+            - intf_name: '{{ interface2 }}'
         - afi: 'ipv6'
           vlans: ['1', '4']
           trusted:


### PR DESCRIPTION
##### SUMMARY
Fix dhcp_snooping regression failure.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sonic_dhcp_snooping

##### OUTPUT
- regression result:
[regression-2024-02-26-17-39-33.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14408411/regression-2024-02-26-17-39-33.html.pdf)
- regression log: 
[regression.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14408412/regression.log)


##### Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [ ] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Run regression testing
