### PR TITLE
bfd, copp and dhcp relay and snooping check and diff modes

### DIFF
--- a/changelogs/fragments/346-playbook-check-diff-modes-for-bfd-copp-dhcps.yaml
+++ b/changelogs/fragments/346-playbook-check-diff-modes-for-bfd-copp-dhcps.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - sonic_bfd - Add playbook check and diff modes support for bfd module (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/346).
+  - sonic_copp - Add playbook check and diff modes support for copp module (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/346).
+  - sonic_dhcp_relay - Add playbook check and diff modes support for dhcp_relay module (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/346).
+  - sonic_dhcp_snooping - Add playbook check and diff modes support for dhcp_snooping module (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/346).

--- a/plugins/module_utils/network/sonic/config/bfd/bfd.py
+++ b/plugins/module_utils/network/sonic/config/bfd/bfd.py
@@ -32,8 +32,6 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     edit_config
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
-    __DELETE_CONFIG_IF_NO_NON_KEY_LEAF_OR_SUBCONFIG,
-    __DELETE_SAME_LEAFS_THEN_CONFIG_IF_NO_NON_KEY_LEAF,
     get_new_config,
     get_formatted_config_diff
 )
@@ -71,9 +69,7 @@ BFD_CONFIG_KEY_SET = {
     'vrf',
     'echo_interval',
     'echo_mode',
-    'min_ttl',
-    'interface',
-    'local_address'
+    'interface'
 }
 is_delete_all = False
 

--- a/plugins/module_utils/network/sonic/config/bfd/bfd.py
+++ b/plugins/module_utils/network/sonic/config/bfd/bfd.py
@@ -27,6 +27,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     update_states
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.facts import Facts
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.argspec.bfd.bfd import BfdArgs
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import (
     to_request,
     edit_config
@@ -56,21 +57,13 @@ BFD_CONFIG_DEFAULT = {
     'echo_interval': 300,
     'echo_mode': False
 }
-BFD_CONFIG_KEY_SET = {
-    'detect_multiplier',
-    'enabled',
-    'local_address',
-    'min_ttl',
-    'passive_mode',
-    'profile_name',
-    'receive_interval',
-    'remote_address',
-    'transmit_interval',
-    'vrf',
-    'echo_interval',
-    'echo_mode',
-    'interface'
-}
+
+bfd_arg_spec = BfdArgs.argument_spec
+bfd_mhops_key_set = set(bfd_arg_spec['config']['options']['multi_hops']['options'].keys())
+bfd_profile_key_set = set(bfd_arg_spec['config']['options']['profiles']['options'].keys())
+bfd_shops_key_set = set(bfd_arg_spec['config']['options']['single_hops']['options'].keys())
+BFD_CONFIG_KEY_SET = bfd_mhops_key_set.union(bfd_profile_key_set).union(bfd_shops_key_set)
+
 is_delete_all = False
 
 

--- a/plugins/module_utils/network/sonic/config/bfd/bfd.py
+++ b/plugins/module_utils/network/sonic/config/bfd/bfd.py
@@ -725,12 +725,9 @@ class Bfd(ConfigBase):
 
         return request
 
-    def get_profile_name(self, profile_name):
-        return profile_name.get('profile_name')
-
     def sort_lists_in_config(self, config):
         if 'profiles' in config and config['profiles'] is not None:
-            config['profiles'].sort(key=self.get_profile_name)
+            config['profiles'].sort(key=lambda x: x['profile_name'])
         if 'single_hops' in config and config['single_hops'] is not None:
             config['single_hops'].sort(key=lambda x: (x['remote_address'], x['interface'], x['vrf'], x['local_address']))
         if 'multi_hops' in config and config['multi_hops'] is not None:

--- a/plugins/module_utils/network/sonic/config/bfd/bfd.py
+++ b/plugins/module_utils/network/sonic/config/bfd/bfd.py
@@ -48,7 +48,7 @@ TEST_KEYS = [
 ]
 BFD_CONFIG_DEFAULT = {
     'enabled': True,
-    'transmit_interval' : 300,
+    'transmit_interval': 300,
     'receive_interval': 300,
     'detect_multiplier': 3,
     'passive_mode': False,

--- a/plugins/module_utils/network/sonic/config/dhcp_relay/dhcp_relay.py
+++ b/plugins/module_utils/network/sonic/config/dhcp_relay/dhcp_relay.py
@@ -748,5 +748,3 @@ class Dhcp_relay(ConfigBase):
                 ipv6 = cfg.get('ipv6', {})
                 if ipv6 and ipv6.get('server_addresses', []):
                     ipv6['server_addresses'].sort(key=lambda x: x['address'])
-                 
-

--- a/plugins/module_utils/network/sonic/config/dhcp_relay/dhcp_relay.py
+++ b/plugins/module_utils/network/sonic/config/dhcp_relay/dhcp_relay.py
@@ -32,6 +32,11 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
     to_request,
     edit_config
 )
+from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.formatted_diff_utils import (
+    __DELETE_CONFIG_IF_NO_SUBCONFIG,
+    get_new_config,
+    get_formatted_config_diff
+)
 from ansible.module_utils.connection import ConnectionError
 
 PATCH = 'patch'
@@ -45,6 +50,20 @@ BOOL_TO_SELECT_VALUE = {
     True: 'ENABLE',
     False: 'DISABLE'
 }
+
+
+def __derive_dhcp_relay_address_delete_op(key_set, command, exist_conf):
+    new_conf = exist_conf
+    if command and command.get('address', None):
+        return __DELETE_CONFIG_IF_NO_SUBCONFIG(key_set, command, exist_conf)
+    else:
+        return True, new_conf
+
+
+TEST_KEYS_generate_config = [
+    {'config': {'name': '', '__delete_op': __DELETE_CONFIG_IF_NO_SUBCONFIG}},
+    {'server_addresses': {'address': '', '__delete_op': __derive_dhcp_relay_address_delete_op}}
+]
 
 
 class Dhcp_relay(ConfigBase):
@@ -125,6 +144,22 @@ class Dhcp_relay(ConfigBase):
             result['after'] = changed_dhcp_relay_facts
 
         result['commands'] = commands
+
+        new_config = changed_dhcp_relay_facts
+        old_config = existing_dhcp_relay_facts
+        if self._module.check_mode:
+            result.pop('after', None)
+            new_config = get_new_config(commands, existing_dhcp_relay_facts,
+                                        TEST_KEYS_generate_config)
+            new_config = self.post_process_generated_config(new_config)
+            result['after(generated)'] = new_config
+
+        if self._module._diff:
+            self.sort_lists_in_config(new_config)
+            self.sort_lists_in_config(old_config)
+            result['diff'] = get_formatted_config_diff(old_config,
+                                                       new_config,
+                                                       self._module._verbosity)
         result['warnings'] = warnings
         return result
 
@@ -693,3 +728,25 @@ class Dhcp_relay(ConfigBase):
                 server_addresses.add(addr['address'])
 
         return server_addresses
+
+    def post_process_generated_config(self, configs):
+        confs = remove_empties_from_list(configs)
+        if confs:
+            for conf in confs[:]:
+                keys = conf.keys()
+                if len(keys) <= 1:
+                    confs.remove(conf)
+        return confs
+
+    def sort_lists_in_config(self, config):
+        if config:
+            config.sort(key=lambda x: x['name'])
+            for cfg in config:
+                ipv4 = cfg.get('ipv4', {})
+                if ipv4 and ipv4.get('server_addresses', []):
+                    ipv4['server_addresses'].sort(key=lambda x: x['address'])
+                ipv6 = cfg.get('ipv6', {})
+                if ipv6 and ipv6.get('server_addresses', []):
+                    ipv6['server_addresses'].sort(key=lambda x: x['address'])
+                 
+

--- a/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
+++ b/plugins/module_utils/network/sonic/utils/formatted_diff_utils.py
@@ -217,6 +217,72 @@ def __DELETE_LEAFS_OR_CONFIG_IF_NO_NON_KEY_LEAF(key_set, command, exist_conf):
 
 
 """
+Delete non-key leafs, if any. Then
+delete configuration if no non-key leaf.
+"""
+
+
+def __DELETE_LEAFS_THEN_CONFIG_IF_NO_NON_KEY_LEAF(key_set, command, exist_conf):
+    new_conf = exist_conf
+    trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
+
+    trival_cmd_key_not_key_set = trival_cmd_key_set.difference(key_set)
+    for key in trival_cmd_key_not_key_set:
+        new_conf.pop(key, None)
+
+    trival_exist_key_set, dict_list_exist_key_set = get_key_sets(new_conf)
+    trival_exist_key_not_key_set = trival_exist_key_set.difference(key_set)
+    if len(trival_exist_key_not_key_set) == 0:
+        new_conf = []
+        return True, new_conf
+
+    return False, new_conf
+
+
+"""
+Delete non-key leafs with same values, if any. Then
+delete configuration if no non-key leaf.
+"""
+
+
+def __DELETE_SAME_LEAFS_THEN_CONFIG_IF_NO_NON_KEY_LEAF(key_set, command, exist_conf):
+    new_conf = exist_conf
+    trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
+
+    trival_cmd_key_not_key_set = trival_cmd_key_set.difference(key_set)
+    for key in trival_cmd_key_not_key_set:
+        command_val = command.get(key, None)
+        new_conf_val = new_conf.get(key, None)
+        if command_val == new_conf_val:
+            new_conf.pop(key, None)
+
+    trival_exist_key_set, dict_list_exist_key_set = get_key_sets(new_conf)
+    trival_exist_key_not_key_set = trival_exist_key_set.difference(key_set)
+    if len(trival_exist_key_not_key_set) == 0:
+        new_conf = []
+        return True, new_conf
+
+    return False, new_conf
+
+
+"""
+Delete configuration if no non-key leaf or sub-configuration.
+"""
+
+
+def __DELETE_CONFIG_IF_NO_NON_KEY_LEAF_OR_SUBCONFIG(key_set, command, exist_conf):
+    new_conf = exist_conf
+    trival_cmd_key_set, dict_list_cmd_key_set = get_key_sets(command)
+
+    trival_cmd_key_not_key_set = trival_cmd_key_set.difference(key_set)
+    if len(trival_cmd_key_not_key_set) == 0 and len(dict_list_cmd_key_set) == 0:
+        new_conf = []
+        return True, new_conf
+
+    return False, new_conf
+
+
+"""
 This is default deletion operation.
 Delete configuration if there is no non-key leaf, and
 delete non-key leaf configuration, if any, if the values of non-key leaf are

--- a/plugins/modules/sonic_bfd.py
+++ b/plugins/modules/sonic_bfd.py
@@ -39,6 +39,9 @@ DOCUMENTATION = """
 ---
 module: sonic_bfd
 version_added: "2.1.0"
+notes:
+  - Tested against Enterprise SONiC Distribution by Dell Technologies.
+  - Supports C(check_mode).
 short_description: Manage BFD configuration on SONiC
 description:
   - This module provides configuration management of BFD for devices running SONiC
@@ -654,6 +657,13 @@ after:
   sample: >
     The configuration returned will always be in the same format
     of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
 commands:
   description: The set of commands pushed to the remote device.
   returned: always

--- a/plugins/modules/sonic_copp.py
+++ b/plugins/modules/sonic_copp.py
@@ -39,6 +39,9 @@ DOCUMENTATION = """
 ---
 module: sonic_copp
 version_added: "2.1.0"
+notes:
+  - Tested against Enterprise SONiC Distribution by Dell Technologies.
+  - Supports C(check_mode).
 short_description: Manage CoPP configuration on SONiC
 description:
   - This module provides configuration management of CoPP for devices running SONiC
@@ -265,6 +268,13 @@ after:
   sample: >
     The configuration returned will always be in the same format
     of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
 commands:
   description: The set of commands pushed to the remote device.
   returned: always

--- a/plugins/modules/sonic_dhcp_relay.py
+++ b/plugins/modules/sonic_dhcp_relay.py
@@ -33,6 +33,9 @@ DOCUMENTATION = """
 ---
 module: sonic_dhcp_relay
 version_added: '2.1.0'
+notes:
+  - Tested against Enterprise SONiC Distribution by Dell Technologies.
+  - Supports C(check_mode).
 short_description: Manage DHCP and DHCPv6 relay configurations on SONiC
 description:
   - This module provides configuration management of DHCP and DHCPv6 relay
@@ -747,6 +750,13 @@ before:
 after:
   description: The resulting configuration model invocation.
   returned: when changed
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
   type: list
   sample: >
     The configuration returned will always be in the same format

--- a/plugins/modules/sonic_dhcp_snooping.py
+++ b/plugins/modules/sonic_dhcp_snooping.py
@@ -34,7 +34,8 @@ DOCUMENTATION = """
 module: sonic_dhcp_snooping
 version_added: 2.3.0
 notes:
-  - "Tested against Enterprise SONiC Distribution by Dell Technologies."
+  - Tested against Enterprise SONiC Distribution by Dell Technologies.
+  - Supports C(check_mode).
 short_description: "Manage DHCP Snooping on SONiC"
 description: "This module provides configuration management of DHCP snooping for devices running SONiC."
 author: Simon Nathans (@simon-nathans), Xiao Han (@Xiao_Han2)
@@ -466,6 +467,13 @@ after:
   description: The resulting configuration model invocation.
   returned: when changed
   type: dict
+  sample: >
+    The configuration returned will always be in the same format
+     of the parameters above.
+after(generated):
+  description: The generated configuration model invocation.
+  returned: when C(check_mode)
+  type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.


### PR DESCRIPTION
##### SUMMARY
Th is to add diff and check modes support for copp, bfd, dhcp_relay and dhcp_snooping modules.

##### GitHub Issues
N/A

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sonic_bfd, sonic_copp, sonic_dhcp_relay, sonic_dhcp_snooping

##### OUTPUT
- bfd_regression result: 
[bfd_regression-2024-02-23-00-22-13.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409158/bfd_regression-2024-02-23-00-22-13.html.pdf)
- bfd regression log: 
[bfd_regression.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409160/bfd_regression.log)
- bfd unit test log: 
[bfd_unit_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409162/bfd_unit_test.log)
- bfd unit test script: 
[bfd_unit_test.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409167/bfd_unit_test.txt)

- copp regression result: 
[copp_regression-2024-02-21-18-21-23.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409172/copp_regression-2024-02-21-18-21-23.html.pdf)
- copp regression log: 
[copp_regression.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409174/copp_regression.log)
- copp unit test log: 
[copp_unit_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409176/copp_unit_test.log)
- copp unit test script: 
[copp_unit_test.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409177/copp_unit_test.txt)

- dhcp_relay regression result: 
[dhcp_relay_regression-2024-02-20-17-42-04.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409184/dhcp_relay_regression-2024-02-20-17-42-04.html.pdf)
- dhcp_relay regression log: 
[dhcp_relay_regression.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409186/dhcp_relay_regression.log)
- dhcp_relay unit test log: 
[dhcp_relay_unit_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409191/dhcp_relay_unit_test.log)
- dhcp__relay unit test script: 
[dhcp_relay_unit_test.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409195/dhcp_relay_unit_test.txt)

- dhcp_snooping regression result: 
[dhcp_snooping_regression-2024-02-21-17-55-18.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409198/dhcp_snooping_regression-2024-02-21-17-55-18.html.pdf)
- dhcp_snooping regression log: 
[dhcp_snooping_regression.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409202/dhcp_snooping_regression.log)
- dhcp_snooping unit test log: 
[dhcp_snooping_unit_test.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409205/dhcp_snooping_unit_test.log)
- dhcp_snooping unit test script: 
[dhcp_snooping_unit_test.txt](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14409210/dhcp_snooping_unit_test.txt)

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Run regression test and lots of unit tests.
