### PR TITLE
Fix port_group regression failure

### DIFF
--- a/tests/regression/roles/sonic_port_group/defaults/main.yml
+++ b/tests/regression/roles/sonic_port_group/defaults/main.yml
@@ -34,7 +34,7 @@ tests:
       - id: "{{ pg1 }}"
       - id: "{{ pg2 }}"
   - name: test_case_03
-    description: Set all port group to default speeds
+    description: Set a port group to the default speed
     state: deleted
     input:
       - id: "{{ pg16 }}"

--- a/tests/regression/roles/sonic_port_group/defaults/main.yml
+++ b/tests/regression/roles/sonic_port_group/defaults/main.yml
@@ -37,7 +37,7 @@ tests:
     description: Set all port group to default speeds
     state: deleted
     input:
-      - id:
+      - id: "{{ pg16 }}"
   - name: test_case_04
     description: Set some port group speeds
     state: merged


### PR DESCRIPTION
##### SUMMARY
Fix port_group regression failure.
It is due to a restriction in the latest Ansible version from tighter enforcement of the argspec.

##### GitHub Issues
N/A

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sonic_port_group

##### OUTPUT
- [regression-2024-03-15-16-25-30.html.pdf](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14618302/regression-2024-03-15-16-25-30.html.pdf)
- [regression.log](https://github.com/ansible-collections/dellemc.enterprise_sonic/files/14618305/regression.log)


##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Run regression test.
