### PR TITLE
stp regression failures fix

### DIFF
--- a/tests/regression/roles/sonic_stp/defaults/main.yml
+++ b/tests/regression/roles/sonic_stp/defaults/main.yml
@@ -11,8 +11,6 @@ tests:
         enabled_protocol: mst
         loop_guard: true
         bpdu_filter: true 
-        disabled_vlans:
-          - 4-6
         hello_time: 5
         max_age: 10
         fwd_delay: 15
@@ -356,8 +354,6 @@ tests:
     input:
       global:
         enabled_protocol: mst
-        disabled_vlans:
-          - 4
         bpdu_filter: true
         hello_time: 5
         max_age: 10
@@ -402,8 +398,6 @@ tests:
     state: merged
     input:
       global:
-        disabled_vlans:
-          - 4-6
         bpdu_filter: false
         hello_time: 7
         max_age: 20
@@ -464,8 +458,6 @@ tests:
         enabled_protocol: mst
         loop_guard: true
         bpdu_filter: true
-        disabled_vlans:
-          - 4-6
         hello_time: 5
         max_age: 10
         fwd_delay: 15


### PR DESCRIPTION
##### SUMMARY
This is to fix stp module regression failures. SONIC changes causes the failures: in mst mode, no vlan disable allowed.

##### GitHub Issues
N/A

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sonic_stp

##### OUTPUT
[regression-2024-06-06-18-37-39.html.pdf](https://github.com/user-attachments/files/15686524/regression-2024-06-06-18-37-39.html.pdf)

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Run regression testing.