### PR TITLE
Add evpn ethernet-segment support for LAG interface

### DIFF
--- a/changelogs/fragments/403-lag-interface-evpn-ethernet-segment.yaml
+++ b/changelogs/fragments/403-lag-interface-evpn-ethernet-segment.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sonic_lag_interfaces - Add evpn ethernet-segment support for LAG interfaces (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/403).

--- a/plugins/module_utils/network/sonic/argspec/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/argspec/lag_interfaces/lag_interfaces.py
@@ -64,7 +64,7 @@ class Lag_interfacesArgs(object):  # pylint: disable=R0903
                                                  "ethernet_segment_id"],
                                      "type": "str"},
                         "esi": {"type": "str"},
-                        "df_preference": {"default": 32767, "type": "int"},
+                        "df_preference": {"type": "int"},
                     },
                     "type": "dict"
                 }

--- a/plugins/module_utils/network/sonic/argspec/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/argspec/lag_interfaces/lag_interfaces.py
@@ -61,7 +61,7 @@ class Lag_interfacesArgs(object):  # pylint: disable=R0903
                         "esi_type": {"required": True,
                                      "choices": ["auto_lacp",
                                                  "auto_system_mac",
-                                                 "ethernet_segement_id"],
+                                                 "ethernet_segment_id"],
                                      "type": "str"},
                         "esi": {"type": "str"},
                         "df_preference": {"default": 32767, "type": "int"},

--- a/plugins/module_utils/network/sonic/argspec/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/argspec/lag_interfaces/lag_interfaces.py
@@ -55,7 +55,19 @@ class Lag_interfacesArgs(object):  # pylint: disable=R0903
                     "type": "dict"
                 },
                 "name": {"required": True, "type": "str"},
-                "mode": {"type": "str", "choices": ["static", "lacp"]}
+                "mode": {"type": "str", "choices": ["static", "lacp"]},
+                "ethernet_segment": {
+                    "options": {
+                        "esi_type": {"required": True,
+                                     "choices": ["auto_lacp",
+                                                 "auto_system_mac",
+                                                 "ethernet_segement_id"],
+                                     "type": "str"},
+                        "esi": {"type": "str"},
+                        "df_preference": {"default": 32767, "type": "int"},
+                    },
+                    "type": "dict"
+                }
             },
             "type": "list"
         },

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -438,7 +438,6 @@ class Lag_interfaces(ConfigBase):
         es_commands = []
         es_requests = []
         es_path = 'data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments'
-        df_pref_path = es_path + '/ethernet-segment=%s/df-election/config/preference'
 
         for cmd in diff_members:
             po_name = cmd['name']
@@ -471,27 +470,29 @@ class Lag_interfaces(ConfigBase):
                 else:
                     df_pref = have_es['df_preference']
 
+                df_election = {'config': {'preference': df_pref}}
+                es_payload_item = {
+	                'name': po_name,
+	                'config': {
+	                    'name': po_name,
+	                    'esi-type' : esi_t,
+                        'esi' : esi,
+	                    'interface': po_name
+	                },
+                    'df-election': df_election
+	            }
+
+                es_payload_list = list()
+                es_payload_list.append(es_payload_item)
                 es_payload = {
                     'openconfig-network-instance:ethernet-segments': {
-                        'ethernet-segment': [{
-                            'name': po_name,
-                            'config': {
-                                'esi-type' : esi_t,
-                                'esi' : esi,
-                                'interface': po_name
-                            },
-                        }]
+                        'ethernet-segment': es_payload_list
                     }
                 }
 
                 es_request = {'path': es_path, 'method': PATCH, 'data': es_payload}
+
                 es_requests.append(es_request)
-
-                ed_df_pref_path = df_pref_path % quote(po_name, safe='')
-                df_pref_payload = {'openconfig-network-instance:preference': df_pref}
-                df_pref_request = {'path': ed_df_pref_path, 'method': PATCH, 'data': df_pref_payload}
-                es_requests.append(df_pref_request)
-
                 es_commands.append(cmd)
 
         return es_commands, es_requests

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -354,9 +354,9 @@ class Lag_interfaces(ConfigBase):
                 else:
                     requests = request
 
-            es_commands, es_requests = self.create_ethernet_segment_requests(diff_members, have)
-            if es_requests:
-                requests.extend(es_requests)
+            es_commands, es_request = self.create_ethernet_segment_requests(diff_members, have)
+            if es_request:
+                requests.append(es_request)
 
             commands.extend(update_states(diff_members, state_name))
         if diff_portchannels:
@@ -436,8 +436,8 @@ class Lag_interfaces(ConfigBase):
 
     def create_ethernet_segment_requests(self, diff_members, have):
         es_commands = []
-        es_requests = []
         es_path = 'data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments'
+        es_payload_list = list()
 
         for cmd in diff_members:
             po_name = cmd['name']
@@ -482,20 +482,20 @@ class Lag_interfaces(ConfigBase):
                     'df-election': df_election
 	            }
 
-                es_payload_list = list()
                 es_payload_list.append(es_payload_item)
-                es_payload = {
-                    'openconfig-network-instance:ethernet-segments': {
-                        'ethernet-segment': es_payload_list
-                    }
-                }
-
-                es_request = {'path': es_path, 'method': PATCH, 'data': es_payload}
-
-                es_requests.append(es_request)
                 es_commands.append(cmd)
 
-        return es_commands, es_requests
+        es_request = {}
+        if es_payload_list:
+            es_payload = {
+                'openconfig-network-instance:ethernet-segments': {
+                    'ethernet-segment': es_payload_list
+                }
+            }
+
+            es_request = {'path': es_path, 'method': PATCH, 'data': es_payload}
+
+        return es_commands, es_request
 
     def build_create_payload_member(self, name):
         payload_template = """{\n"openconfig-if-aggregate:aggregate-id": "{{name}}"\n}"""

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -189,8 +189,7 @@ class Lag_interfaces(ConfigBase):
         elif state == 'deleted':
             commands, requests = self._state_deleted(want, have, diff)
         elif state == 'merged':
-            commands, requests = self._state_merged(want, have, diff,
-                                                    diff_members, diff_portchannels)
+            commands, requests = self._state_merged(want, have, diff_members, diff_portchannels)
         elif state == 'replaced':
             commands, requests = self._state_replaced(want, have, diff_members, diff_portchannels)
 
@@ -219,7 +218,7 @@ class Lag_interfaces(ConfigBase):
             commands.extend(update_states(replaced_list, "deleted"))
 
         es_commands, es_requests = self.get_delete_ethernet_segment_requests(replaced_list,
-                                                                             have, False)
+                                                                             have, True)
         if es_requests:
             es_cmds = list()
             for cmd in es_commands:
@@ -260,7 +259,7 @@ class Lag_interfaces(ConfigBase):
 
         requests = self.get_delete_lag_interfaces_requests(replaced_list)
 
-        na, es_requests = self.get_delete_ethernet_segment_requests(replaced_list,
+        nu, es_requests = self.get_delete_ethernet_segment_requests(replaced_list,
                                                                     have, True)
         requests.extend(es_requests)
         commands.extend(update_states(replaced_list, "deleted"))
@@ -271,7 +270,7 @@ class Lag_interfaces(ConfigBase):
             if not list_obj:
                 deleted_po_list.append(i)
 
-        na, es_requests = self.get_delete_po_ethernet_segment_requests(deleted_po_list,
+        nu, es_requests = self.get_delete_po_ethernet_segment_requests(deleted_po_list,
                                                                        have)
         requests.extend(es_requests)
         requests_deleted_po = self.get_delete_portchannel_requests(deleted_po_list)
@@ -285,7 +284,7 @@ class Lag_interfaces(ConfigBase):
 
         return commands, requests
 
-    def _state_merged(self, want, have, diff, diff_members, diff_portchannels):
+    def _state_merged(self, want, have, diff_members, diff_portchannels):
         """ The command generator when state is merged
 
         :rtype: A list
@@ -406,7 +405,7 @@ class Lag_interfaces(ConfigBase):
                 requests.extend(es_requests)
 
         if delete_portchannels:
-            na, es_requests = self.get_delete_po_ethernet_segment_requests(delete_portchannels,
+            nu, es_requests = self.get_delete_po_ethernet_segment_requests(delete_portchannels,
                                                                            have)
             if es_requests:
                 requests.extend(es_requests)
@@ -456,16 +455,12 @@ class Lag_interfaces(ConfigBase):
 
                 esi = cmd_es.get('esi')
                 if esi_type == 'auto_lacp':
-                    if esi and esi != 'AUTO':
-                        self._module.fail_json(msg='{0}: value of esi must be "AUTO" for esi_type {1}'.format(po_name, esi_type))
                     esi_t = 'TYPE_1_LACP_BASED'
                     esi = 'AUTO'
                 elif esi_type == 'auto_system_mac':
-                    if esi and esi != 'AUTO':
-                        self._module.fail_json(msg='{0}: value of esi must be "AUTO" for esi_type {1}'.format(po_name, esi_type))
                     esi_t = 'TYPE_3_MAC_BASED'
                     esi = 'AUTO'
-                elif esi_type == 'ethernet_segement_id':
+                elif esi_type == 'ethernet_segment_id':
                     esi_t = 'TYPE_0_OPERATOR_CONFIGURED'
                     if not esi:
                         esi = have_es['esi']
@@ -687,7 +682,7 @@ class Lag_interfaces(ConfigBase):
                         self._module.fail_json(msg='value of esi must be provided for esi_type {0}'.format(es['esi_type']))
 
                 df_pref = es.get('df_preference')
-                if df_pref < 1 or df_pref > 65535:
+                if df_pref and (df_pref < 1 or df_pref > 65535):
                     self._module.fail_json(msg='value of df_preference must be in range 1..65535')
 
     def preprocess_want(self, want, state):

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -61,8 +61,6 @@ except Exception as e:
     ERR_MSG = to_native(e)
     LIB_IMP_ERR = traceback.format_exc()
 
-DEFAULT_ES_DF_PREF = 32767
-
 PUT = 'put'
 PATCH = 'patch'
 DELETE = 'delete'
@@ -468,19 +466,21 @@ class Lag_interfaces(ConfigBase):
                 if cmd_es.get('df_preference'):
                     df_pref = cmd_es['df_preference']
                 else:
-                    df_pref = have_es['df_preference']
+                    df_pref = None
 
-                df_election = {'config': {'preference': df_pref}}
                 es_payload_item = {
-	                'name': po_name,
-	                'config': {
-	                    'name': po_name,
-	                    'esi-type' : esi_t,
+                    'name': po_name,
+                    'config': {
+                        'name': po_name,
+                        'esi-type' : esi_t,
                         'esi' : esi,
-	                    'interface': po_name
-	                },
-                    'df-election': df_election
-	            }
+                        'interface': po_name
+                    }
+                }
+
+                if df_pref:
+                    df_election = {'config': {'preference': df_pref}}
+                    es_payload_item['df-election'] = df_election
 
                 es_payload_list.append(es_payload_item)
                 es_commands.append(cmd)
@@ -613,7 +613,7 @@ class Lag_interfaces(ConfigBase):
                 else:
                     if cmd_es.get('esi_type'):
                         if cmd_es.get('esi'):
-                            if have_es.get('df_preference') != DEFAULT_ES_DF_PREF:
+                            if have_es.get('df_preference'):
                                 del_df_pref = True
                         else:
                             del_es = True

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -61,6 +61,7 @@ except Exception as e:
     ERR_MSG = to_native(e)
     LIB_IMP_ERR = traceback.format_exc()
 
+DEFAULT_ES_DF_PREF = 32767
 
 PUT = 'put'
 PATCH = 'patch'
@@ -170,6 +171,11 @@ class Lag_interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
+        state = self._module.params['state']
+
+        self.validate_want(want, state)
+        self.preprocess_want(want, state)
+
         commands = []
         diff = get_diff(want, have, TEST_KEYS)
         if diff:
@@ -178,16 +184,13 @@ class Lag_interfaces(ConfigBase):
             diff_members = []
             diff_portchannels = []
 
-        state = self._module.params['state']
-        if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
-
         if state == 'overridden':
             commands, requests = self._state_overridden(want, have, diff_members, diff_portchannels)
         elif state == 'deleted':
             commands, requests = self._state_deleted(want, have, diff)
         elif state == 'merged':
-            commands, requests = self._state_merged(want, have, diff_members, diff_portchannels)
+            commands, requests = self._state_merged(want, have, diff,
+                                                    diff_members, diff_portchannels)
         elif state == 'replaced':
             commands, requests = self._state_replaced(want, have, diff_members, diff_portchannels)
 
@@ -214,6 +217,21 @@ class Lag_interfaces(ConfigBase):
         requests = self.get_delete_lag_interfaces_requests(replaced_list)
         if requests:
             commands.extend(update_states(replaced_list, "deleted"))
+
+        es_commands, es_requests = self.get_delete_ethernet_segment_requests(replaced_list,
+                                                                             have, False)
+        if es_requests:
+            es_cmds = list()
+            for cmd in es_commands:
+                po_name = cmd['name']
+                cmd_in_cmds = next((po for po in commands if po['name'] == po_name), {})
+                if not cmd_in_cmds:
+                    es_cmds.append(cmd)
+            if es_cmds:
+                commands.extend(update_states(es_cmds, "deleted"))
+
+            requests.extend(es_requests)
+
         replaced_commands, replaced_requests = self.template_for_lag_creation(have, diff_members, diff_portchannels, "replaced")
         if replaced_requests:
             commands.extend(replaced_commands)
@@ -241,6 +259,10 @@ class Lag_interfaces(ConfigBase):
                 replaced_list.append(list_obj)
 
         requests = self.get_delete_lag_interfaces_requests(replaced_list)
+
+        na, es_requests = self.get_delete_ethernet_segment_requests(replaced_list,
+                                                                    have, True)
+        requests.extend(es_requests)
         commands.extend(update_states(replaced_list, "deleted"))
 
         deleted_po_list = list()
@@ -249,6 +271,9 @@ class Lag_interfaces(ConfigBase):
             if not list_obj:
                 deleted_po_list.append(i)
 
+        na, es_requests = self.get_delete_po_ethernet_segment_requests(deleted_po_list,
+                                                                       have)
+        requests.extend(es_requests)
         requests_deleted_po = self.get_delete_portchannel_requests(deleted_po_list)
         requests.extend(requests_deleted_po)
         commands_del = self.prune_commands(deleted_po_list)
@@ -260,14 +285,16 @@ class Lag_interfaces(ConfigBase):
 
         return commands, requests
 
-    def _state_merged(self, want, have, diff_members, diff_portchannels):
+    def _state_merged(self, want, have, diff, diff_members, diff_portchannels):
         """ The command generator when state is merged
 
         :rtype: A list
         :returns: the commands necessary to merge the provided into
                   the current configuration
         """
-        return self.template_for_lag_creation(have, diff_members, diff_portchannels, "merged")
+        commands, requests = self.template_for_lag_creation(have, diff_members,
+                                                            diff_portchannels, "merged")
+        return commands, requests
 
     def _state_deleted(self, want, have, diff):
         """ The command generator when state is deleted
@@ -287,15 +314,26 @@ class Lag_interfaces(ConfigBase):
             commands_del = self.prune_commands(have)
             commands.extend(update_states(commands_del, "deleted"))
         else:  # delete specific lag interfaces and specific portchannels
-            commands = get_diff(want, diff, TEST_KEYS)
-            commands = remove_empties_from_list(commands)
-            want_members, want_portchannels = self.diff_list_for_member_creation(commands)
-            commands, requests = self.template_for_lag_deletion(have, want_members, want_portchannels, "deleted")
+            po_commands = get_diff(want, diff, TEST_KEYS)
+            po_commands = remove_empties_from_list(po_commands)
+            want_members, want_portchannels = self.diff_list_for_member_creation(po_commands)
+
+            del_commands, del_requests = self.template_for_lag_deletion(have, want_members,
+                                                                        want_portchannels, "deleted")
+            if del_commands:
+                commands.extend(del_commands)
+            if del_requests:
+                requests.extend(del_requests)
         return commands, requests
 
     def diff_list_for_member_creation(self, diff):
-        diff_members = [x for x in diff if "members" in x.keys()]
-        diff_portchannels = [x for x in diff if ("name" in x.keys() and "members" not in x.keys())]
+        diff_members = list()
+        diff_portchannels = list()
+        for x in diff:
+            if "members" in x.keys() or "ethernet_segment" in x.keys():
+                diff_members.append(x)
+            else:
+                diff_portchannels.append(x)
         return diff_members, diff_portchannels
 
     def template_for_lag_creation(self, have, diff_members, diff_portchannels, state_name):
@@ -309,17 +347,23 @@ class Lag_interfaces(ConfigBase):
                 po_list = []
             if po_list:
                 commands.extend(update_states(po_list, state_name))
-            diff_members_remove_none = [x for x in diff_members if x["members"]]
+            diff_members_remove_none = [x for x in diff_members if x.get("members")]
             if diff_members_remove_none:
                 request = self.create_lag_interfaces_requests(diff_members_remove_none)
                 if request:
                     requests.extend(request)
                 else:
                     requests = request
+
+            es_commands, es_requests = self.create_ethernet_segment_requests(diff_members, have)
+            if es_requests:
+                requests.extend(es_requests)
+
             commands.extend(update_states(diff_members, state_name))
         if diff_portchannels:
             portchannels, po_requests = self.call_create_port_channel(diff_portchannels, have)
             requests.extend(po_requests)
+
             commands.extend(update_states(portchannels, state_name))
         return commands, requests
 
@@ -328,7 +372,7 @@ class Lag_interfaces(ConfigBase):
         requests = list()
         portchannel_requests = list()
         if delete_members:
-            delete_members_remove_none = [x for x in delete_members if x["members"]]
+            delete_members_remove_none = [x for x in delete_members if "members" in x.keys() and x["members"]]
             requests = self.get_delete_lag_interfaces_requests(delete_members_remove_none)
             delete_all_members = [x for x in delete_members if "members" in x.keys() and not x["members"]]
             delete_all_list = list()
@@ -347,7 +391,26 @@ class Lag_interfaces(ConfigBase):
                 requests = deleteall_requests
             if requests:
                 commands.extend(update_states(delete_members, state_name))
+
+            es_commands, es_requests = self.get_delete_ethernet_segment_requests(delete_members,
+                                                                                 have, False)
+            if es_requests:
+                es_cmds = list()
+                for cmd in es_commands:
+                    po_name = cmd['name']
+                    cmd_in_cmds = next((po for po in commands if po['name'] == po_name), {})
+                    if not cmd_in_cmds:
+                        es_cmds.append(cmd)
+                if es_cmds:
+                    commands.extend(update_states(es_cmds, state_name))
+                requests.extend(es_requests)
+
         if delete_portchannels:
+            na, es_requests = self.get_delete_po_ethernet_segment_requests(delete_portchannels,
+                                                                           have)
+            if es_requests:
+                requests.extend(es_requests)
+
             portchannel_requests = self.get_delete_portchannel_requests(delete_portchannels)
             commands_del = self.prune_commands(delete_portchannels)
             commands.extend(update_states(commands_del, state_name))
@@ -371,6 +434,72 @@ class Lag_interfaces(ConfigBase):
                 request = {'path': edit_path, 'method': PATCH, 'data': edit_payload}
                 requests.append(request)
         return requests
+
+    def create_ethernet_segment_requests(self, diff_members, have):
+        es_commands = []
+        es_requests = []
+        es_path = 'data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments'
+        df_pref_path = es_path + '/ethernet-segment=%s/df-election/config/preference'
+
+        for cmd in diff_members:
+            po_name = cmd['name']
+            cmd_es = cmd.get('ethernet_segment', None)
+            if cmd_es:
+                es = dict()
+                have_po = next((po for po in have if po['name'] == po_name), {})
+                have_es = have_po.get('ethernet_segment', {})
+
+                if cmd_es.get('esi_type'):
+                    esi_type = cmd_es['esi_type']
+                else:
+                    esi_type = have_es['esi_type']
+
+                esi = cmd_es.get('esi')
+                if esi_type == 'auto_lacp':
+                    if esi and esi != 'AUTO':
+                        self._module.fail_json(msg='{0}: value of esi must be "AUTO" for esi_type {1}'.format(po_name, esi_type))
+                    esi_t = 'TYPE_1_LACP_BASED'
+                    esi = 'AUTO'
+                elif esi_type == 'auto_system_mac':
+                    if esi and esi != 'AUTO':
+                        self._module.fail_json(msg='{0}: value of esi must be "AUTO" for esi_type {1}'.format(po_name, esi_type))
+                    esi_t = 'TYPE_3_MAC_BASED'
+                    esi = 'AUTO'
+                elif esi_type == 'ethernet_segement_id':
+                    esi_t = 'TYPE_0_OPERATOR_CONFIGURED'
+                    if not esi:
+                        esi = have_es['esi']
+                    esi = ''.join(esi.split(':'))
+
+                if cmd_es.get('df_preference'):
+                    df_pref = cmd_es['df_preference']
+                else:
+                    df_pref = have_es['df_preference']
+
+                es_payload = {
+                    'openconfig-network-instance:ethernet-segments': {
+                        'ethernet-segment': [{
+                            'name': po_name,
+                            'config': {
+                                'esi-type' : esi_t,
+                                'esi' : esi,
+                                'interface': po_name
+                            },
+                        }]
+                    }
+                }
+
+                es_request = {'path': es_path, 'method': PATCH, 'data': es_payload}
+                es_requests.append(es_request)
+
+                ed_df_pref_path = df_pref_path % quote(po_name, safe='')
+                df_pref_payload = {'openconfig-network-instance:preference': df_pref}
+                df_pref_request = {'path': ed_df_pref_path, 'method': PATCH, 'data': df_pref_payload}
+                es_requests.append(df_pref_request)
+
+                es_commands.append(cmd)
+
+        return es_commands, es_requests
 
     def build_create_payload_member(self, name):
         payload_template = """{\n"openconfig-if-aggregate:aggregate-id": "{{name}}"\n}"""
@@ -409,6 +538,7 @@ class Lag_interfaces(ConfigBase):
             if not any(d['name'] == c['name'] for d in have):
                 commands_list.append(c)
         requests = self.create_port_channel(commands_list)
+
         return commands_list, requests
 
     def get_delete_all_lag_interfaces_requests(self):
@@ -445,6 +575,69 @@ class Lag_interfaces(ConfigBase):
 
         return requests
 
+    def get_delete_po_ethernet_segment_requests(self, delete_portchannels, have):
+        es_commands = []
+        es_requests = []
+        es_path = 'data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments'
+        ess_path = es_path + '/ethernet-segment=%s'
+
+        for cmd in delete_portchannels:
+            po_name = cmd['name']
+            have_po = next((po for po in have if po['name'] == po_name), {})
+            have_es = have_po.get('ethernet_segment', {})
+            if have_es:
+                ed_ess_path = ess_path % quote(po_name, safe='')
+                es_request = {'path': ed_ess_path, 'method': DELETE}
+                es_requests.append(es_request)
+
+                es_commands.append(cmd)
+
+        return es_commands, es_requests
+
+    def get_delete_ethernet_segment_requests(self, delete_members, have, delete_es=False):
+        es_commands = []
+        es_requests = []
+        es_path = 'data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments'
+        ess_path = es_path + '/ethernet-segment=%s'
+        df_pref_path = es_path + '/ethernet-segment=%s/df-election/config/preference'
+
+        for cmd in delete_members:
+            po_name = cmd['name']
+            cmd_es = cmd.get('ethernet_segment', None)
+            if cmd_es:
+                have_po = next((po for po in have if po['name'] == po_name), {})
+                have_es = have_po.get('ethernet_segment', {})
+                if not have_es:
+                    continue
+
+                del_es = False
+                del_df_pref = False
+                if delete_es:
+                    del_es = True
+                else:
+                    if cmd_es.get('esi_type'):
+                        if cmd_es.get('esi'):
+                            if have_es.get('df_preference') != DEFAULT_ES_DF_PREF:
+                                del_df_pref = True
+                        else:
+                            del_es = True
+                    else:
+                        del_es = True
+
+                if del_es:
+                    ed_ess_path = ess_path % quote(po_name, safe='')
+                    es_request = {'path': ed_ess_path, 'method': DELETE}
+                    es_requests.append(es_request)
+                elif del_df_pref:
+                    ed_df_pref_path = df_pref_path % quote(po_name, safe='')
+                    df_pref_payload = {'openconfig-network-instance:preference': DEFAULT_ES_DF_PREF}
+                    df_pref_request = {'path': ed_df_pref_path, 'method': PATCH, 'data': df_pref_payload}
+                    es_requests.append(df_pref_request)
+
+                es_commands.append(cmd)
+
+        return es_commands, es_requests
+
     def get_delete_portchannel_requests(self, commands):
         requests = []
         # Create URL and payload
@@ -473,4 +666,36 @@ class Lag_interfaces(ConfigBase):
         cmds = deepcopy(commands)
         for cmd in cmds:
             cmd.pop('members', None)
+            cmd.pop('ethernet_segment', None)
         return cmds
+
+    def validate_want(self, want, state):
+        if not want:
+            if state in ('overridden', 'merged', 'replaced'):
+                self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
+            return
+        for conf in want:
+            es = conf.get('ethernet_segment', None)
+            if es:
+                esi = es.get('esi', None)
+                if es['esi_type'] in ['auto_lacp', 'auto_system_mac']:
+                    if esi and esi != 'AUTO':
+                        self._module.fail_json(msg='value of esi must be "AUTO" for esi_type {0}'.format(es['esi_type']))
+                else:
+                    if not esi and state != 'deleted':
+                        self._module.fail_json(msg='value of esi must be provided for esi_type {0}'.format(es['esi_type']))
+
+                df_pref = es.get('df_preference')
+                if df_pref < 1 or df_pref > 65535:
+                    self._module.fail_json(msg='value of df_preference must be in range 1..65535')
+
+    def preprocess_want(self, want, state):
+        if not want:
+            return
+        for conf in want:
+            es = conf.get('ethernet_segment', None)
+            if es:
+                if es['esi_type'] in ['auto_lacp', 'auto_system_mac']:
+                    if state != 'deleted':
+                        es['esi'] = 'AUTO'

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -626,8 +626,7 @@ class Lag_interfaces(ConfigBase):
                     es_requests.append(es_request)
                 elif del_df_pref:
                     ed_df_pref_path = df_pref_path % quote(po_name, safe='')
-                    df_pref_payload = {'openconfig-network-instance:preference': DEFAULT_ES_DF_PREF}
-                    df_pref_request = {'path': ed_df_pref_path, 'method': PATCH, 'data': df_pref_payload}
+                    df_pref_request = {'path': ed_df_pref_path, 'method': DELETE}
                     es_requests.append(df_pref_request)
 
                 es_commands.append(cmd)

--- a/plugins/module_utils/network/sonic/config/lldp_global/lldp_global.py
+++ b/plugins/module_utils/network/sonic/config/lldp_global/lldp_global.py
@@ -308,11 +308,13 @@ class Lldp_global(ConfigBase):
 
         if 'enable' in command:
             url = self.lldp_global_config_path['enable']
+            payload = {}
             if command['enable'] is False:
                 payload = {'openconfig-lldp:enabled': True}
             elif command['enable'] is True:
                 payload = {'openconfig-lldp:enabled': False}
-            requests.append({'path': url, 'method': PATCH, 'data': payload})
+            if payload:
+                requests.append({'path': url, 'method': PATCH, 'data': payload})
         if 'mode' in command:
             url = self.lldp_global_config_path['mode']
             requests.append({'path': url, 'method': DELETE})

--- a/plugins/module_utils/network/sonic/facts/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/lag_interfaces/lag_interfaces.py
@@ -26,6 +26,7 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 from ansible.module_utils.connection import ConnectionError
 
 GET = "get"
+DEFAULT_ES_DF_PREF = 32767
 
 
 class Lag_interfacesFacts(object):
@@ -57,6 +58,10 @@ class Lag_interfacesFacts(object):
             data = response[0][1]['sonic-portchannel:sonic-portchannel']
         else:
             data = []
+
+        return data
+
+    def get_po_and_po_members(self, data):
         if data is not None:
             if "PORTCHANNEL_MEMBER" in data:
                 portchannel_members_list = data["PORTCHANNEL_MEMBER"]["PORTCHANNEL_MEMBER_LIST"]
@@ -75,6 +80,13 @@ class Lag_interfacesFacts(object):
         else:
             return []
 
+    def get_ethernet_segments(self, data):
+        es_list = []
+        if data:
+            if "EVPN_ETHERNET_SEGMENT" in data:
+                es_list = data["EVPN_ETHERNET_SEGMENT"]["EVPN_ETHERNET_SEGMENT_LIST"]
+        return es_list
+
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for lag_interfaces
         :param connection: the device connection
@@ -86,13 +98,39 @@ class Lag_interfacesFacts(object):
         objs = []
         if not data:
             data = self.get_all_portchannels()
-        # operate on a collection of resource x
-        for conf in data:
+
+        po_data = self.get_po_and_po_members(data)
+        for conf in po_data:
             if conf:
                 obj = self.render_config(self.generated_spec, conf)
                 obj = self.transform_config(obj)
                 if obj:
                     self.merge_portchannels(objs, obj)
+
+        es_data = self.get_ethernet_segments(data)
+        for es in es_data:
+            po_name = es['ifname']
+            esi_t = es['esi_type']
+            esi = es['esi']
+            if 'df_pref' in es:
+                df_pref = es['df_pref']
+            else:
+                df_pref = DEFAULT_ES_DF_PREF
+
+            if esi_t == 'TYPE_1_LACP_BASED':
+                esi_type = 'auto_lacp'
+            elif esi_t == 'TYPE_3_MAC_BASED':
+                esi_type = 'auto_system_mac'
+            elif esi_t == 'TYPE_0_OPERATOR_CONFIGURED':
+                esi_type = 'ethernet_segement_id'
+
+            es_dict = {'esi_type': esi_type, 'esi': esi, 'df_preference': df_pref}
+            have_po_conf = next((po_conf for po_conf in objs if po_conf['name'] == po_name), {})
+            if have_po_conf:
+                have_po_conf['ethernet_segment'] = es_dict
+            else:
+                self._module.fail_json(msg='{0} does not exist for ethernet segment'.format(po_name))
+
         facts = {}
         if objs:
             facts['lag_interfaces'] = []
@@ -100,6 +138,7 @@ class Lag_interfacesFacts(object):
             for cfg in params['config']:
                 facts['lag_interfaces'].append(cfg)
         ansible_facts['ansible_network_resources'].update(facts)
+
         return ansible_facts
 
     def render_config(self, spec, conf):

--- a/plugins/module_utils/network/sonic/facts/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/lag_interfaces/lag_interfaces.py
@@ -26,7 +26,6 @@ from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.s
 from ansible.module_utils.connection import ConnectionError
 
 GET = "get"
-DEFAULT_ES_DF_PREF = 32767
 
 
 class Lag_interfacesFacts(object):
@@ -115,7 +114,7 @@ class Lag_interfacesFacts(object):
             if 'df_pref' in es:
                 df_pref = es['df_pref']
             else:
-                df_pref = DEFAULT_ES_DF_PREF
+                df_pref = None
 
             if esi_t == 'TYPE_1_LACP_BASED':
                 esi_type = 'auto_lacp'
@@ -124,7 +123,11 @@ class Lag_interfacesFacts(object):
             elif esi_t == 'TYPE_0_OPERATOR_CONFIGURED':
                 esi_type = 'ethernet_segment_id'
 
-            es_dict = {'esi_type': esi_type, 'esi': esi, 'df_preference': df_pref}
+            if df_pref:
+                es_dict = {'esi_type': esi_type, 'esi': esi, 'df_preference': df_pref}
+            else:
+                es_dict = {'esi_type': esi_type, 'esi': esi}
+
             have_po_conf = next((po_conf for po_conf in objs if po_conf['name'] == po_name), {})
             if have_po_conf:
                 have_po_conf['ethernet_segment'] = es_dict

--- a/plugins/module_utils/network/sonic/facts/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/lag_interfaces/lag_interfaces.py
@@ -122,7 +122,7 @@ class Lag_interfacesFacts(object):
             elif esi_t == 'TYPE_3_MAC_BASED':
                 esi_type = 'auto_system_mac'
             elif esi_t == 'TYPE_0_OPERATOR_CONFIGURED':
-                esi_type = 'ethernet_segement_id'
+                esi_type = 'ethernet_segment_id'
 
             es_dict = {'esi_type': esi_type, 'esi': esi, 'df_preference': df_pref}
             have_po_conf = next((po_conf for po_conf in objs if po_conf['name'] == po_name), {})

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -74,6 +74,31 @@ options:
         choices:
           - static
           - lacp
+      ethernet_segment:
+        description:
+          - Specifies Ethernet segment.
+        version_added: 2.5.0
+        type: dict
+        suboptions:
+          esi_type:
+            description:
+              - Specifies type of Ethernet Segment Identifier.
+            required: True
+            choices:
+              - auto_lacp
+              - auto_system_mac
+              - ethernet_segement_id
+            type: str
+          esi:
+            description:
+              - Specifies value of Ethernet Segment Identifier.
+              - "AUTO" is supported for auto_lacp and auto_system_mac.
+            type: str
+          df_preference:
+            description:
+              - The preference for Designated Forwarder election method.
+            default: 32767
+            type: int
   state:
     description:
       - The state that the configuration should be left in.

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -84,6 +84,7 @@ options:
             description:
               - Specifies type of Ethernet Segment Identifier.
             type: str
+            required: True
             choices:
               - auto_lacp
               - auto_system_mac

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -84,12 +84,15 @@ options:
           esi_type:
             description:
               - Specifies type of Ethernet Segment Identifier.
+                esi_type and esi can not be deleted separately.
+                If both esi and df_preference are not present,
+                deleted state will delete whole ethernet segment.  
             required: True
             type: str
             choices:
               - auto_lacp
               - auto_system_mac
-              - ethernet_segement_id
+              - ethernet_segment_id
           esi:
             description:
               - Specifies value of Ethernet Segment Identifier.
@@ -98,6 +101,7 @@ options:
           df_preference:
             description:
               - The preference for Designated Forwarder election method.
+                The range of df_preference value is from 1 to 65535.
             type: int
             default: 32767
   state:

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -103,7 +103,6 @@ options:
               - The preference for Designated Forwarder election method.
                 The range of df_preference value is from 1 to 65535.
             type: int
-            default: 32767
   state:
     description:
       - The state that the configuration should be left in.

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -59,7 +59,8 @@ options:
         type: dict
         suboptions:
           interfaces:
-            description: The list of interfaces that are part of the group.
+            description:
+              - The list of interfaces that are part of the group.
             type: list
             elements: dict
             suboptions:
@@ -84,11 +85,11 @@ options:
             description:
               - Specifies type of Ethernet Segment Identifier.
             required: True
+            type: str
             choices:
               - auto_lacp
               - auto_system_mac
               - ethernet_segement_id
-            type: str
           esi:
             description:
               - Specifies value of Ethernet Segment Identifier.
@@ -97,8 +98,8 @@ options:
           df_preference:
             description:
               - The preference for Designated Forwarder election method.
-            default: 32767
             type: int
+            default: 32767
   state:
     description:
       - The state that the configuration should be left in.
@@ -126,6 +127,9 @@ EXAMPLES = """
 #  mtu 9100
 #  speed 100000
 #  no shutdown
+# !
+# interface PortChannel0
+#  no shutdown
 #
 - name: Merges provided configuration with device configuration
   dellemc.enterprise_sonic.sonic_lag_interfaces:
@@ -134,6 +138,9 @@ EXAMPLES = """
        members:
          interfaces:
            - member: Eth1/10
+       ethernet_segment:
+         esi_type: auto_lacp
+         df_preference: 2222
     state: merged
 #
 # After state:
@@ -150,6 +157,12 @@ EXAMPLES = """
 #  mtu 9100
 #  speed 100000
 #  no shutdown
+# !
+# interface PortChannel0
+#  no shutdown
+#  !
+#  evpn ethernet-segment auto-lacp
+#  df-preference 2222
 #
 # Using replaced
 #
@@ -181,6 +194,9 @@ EXAMPLES = """
         members:
           interfaces:
             - member: Eth1/7
+        ethernet_segment:
+          esi_type: auto_lacp
+          df_preference: 2222
     state: replaced
 #
 # After state:
@@ -203,6 +219,12 @@ EXAMPLES = """
 #   mtu 9100
 #   speed 100000
 #   no shutdown
+#
+# interface PortChannel0
+#  no shutdown
+#  !
+#  evpn ethernet-segment auto-lacp
+#  df-preference 2222
 #
 # Using overridden
 #
@@ -234,6 +256,9 @@ EXAMPLES = """
         members:
           interfaces:
             - member: Eth1/6
+        ethernet_segment:
+          esi_type: auto_lacp
+          df_preference: 2222
     state: overridden
 #
 # After state:
@@ -255,6 +280,12 @@ EXAMPLES = """
 #   mtu 9100
 #   speed 100000
 #   no shutdown
+#
+# interface PortChannel0
+#  no shutdown
+#  !
+#  evpn ethernet-segment auto-lacp
+#  df-preference 2222
 #
 # Using deleted
 #
@@ -290,6 +321,10 @@ EXAMPLES = """
 # Before state:
 # -------------
 # interface PortChannel 10
+#  no shutdown
+#  !
+#  evpn ethernet-segment auto-lacp
+#  df-preference 2222
 # !
 # interface PortChannel 12
 # !

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -216,7 +216,6 @@ EXAMPLES = """
 # ------------
 #
 # interface Eth1/5
-#   channel-group 10
 #   mtu 9100
 #   speed 100000
 #   no shutdown
@@ -282,6 +281,12 @@ EXAMPLES = """
 #
 # After state:
 # ------------
+#
+# interface Eth1/5
+#   mtu 9100
+#   speed 100000
+#   no shutdown
+#
 # interface Eth1/6
 #   channel-group 20
 #   mtu 9100
@@ -352,11 +357,7 @@ EXAMPLES = """
 #  evpn ethernet-segment auto-lacp
 #   df-preference 2222
 #
-# interface PortChannel 12
-#  no shutdown
-#  !
-#
-- name: Deletes all LAGs and LAG attributes of all interfaces.
+- name: Deletes some LAGs and LAG attributes.
   sonic_lag_interfaces:
     config:
       - name: PortChannel10
@@ -366,7 +367,7 @@ EXAMPLES = """
         ethernet_segment:
           esi_type: auto_lacp
     state: deleted
-
+#
 # After state:
 # -------------
 #

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -74,6 +74,30 @@ options:
         choices:
           - static
           - lacp
+      ethernet_segment:
+        description:
+          - Specifies Ethernet segment.
+        version_added: 2.5.0
+        type: dict
+        suboptions:
+          esi_type:
+            description:
+              - Specifies type of Ethernet Segment Identifier.
+            type: str
+            choices:
+              - auto_lacp
+              - auto_system_mac
+              - ethernet_segement_id
+          esi:
+            description:
+              - Specifies value of Ethernet Segment Identifier.
+              - "AUTO" is supported for auto_lacp and auto_system_mac.
+            type: str
+          df_preference:
+            description:
+              - The preference for Designated Forwarder election method.
+            type: int
+            default: 32767
   state:
     description:
       - The state that the configuration should be left in.
@@ -101,6 +125,9 @@ EXAMPLES = """
 #  mtu 9100
 #  speed 100000
 #  no shutdown
+# !
+# interface PortChannel0
+#  no shutdown
 #
 - name: Merges provided configuration with device configuration
   dellemc.enterprise_sonic.sonic_lag_interfaces:
@@ -109,6 +136,9 @@ EXAMPLES = """
        members:
          interfaces:
            - member: Eth1/10
+       ethernet_segment:
+         esi_type: auto_lacp
+         df_preference: 2222
     state: merged
 #
 # After state:
@@ -125,6 +155,12 @@ EXAMPLES = """
 #  mtu 9100
 #  speed 100000
 #  no shutdown
+# !
+# interface PortChannel0
+#  no shutdown
+#  !
+#  evpn ethernet-segment auto-lacp
+#  df-preference 2222
 #
 # Using replaced
 #
@@ -156,6 +192,9 @@ EXAMPLES = """
         members:
           interfaces:
             - member: Eth1/7
+        ethernet_segment:
+          esi_type: auto_lacp
+          df_preference: 2222
     state: replaced
 #
 # After state:
@@ -178,6 +217,12 @@ EXAMPLES = """
 #   mtu 9100
 #   speed 100000
 #   no shutdown
+#
+# interface PortChannel0
+#  no shutdown
+#  !
+#  evpn ethernet-segment auto-lacp
+#  df-preference 2222
 #
 # Using overridden
 #
@@ -209,6 +254,9 @@ EXAMPLES = """
         members:
           interfaces:
             - member: Eth1/6
+        ethernet_segment:
+          esi_type: auto_lacp
+          df_preference: 2222
     state: overridden
 #
 # After state:
@@ -230,6 +278,12 @@ EXAMPLES = """
 #   mtu 9100
 #   speed 100000
 #   no shutdown
+#
+# interface PortChannel0
+#  no shutdown
+#  !
+#  evpn ethernet-segment auto-lacp
+#  df-preference 2222
 #
 # Using deleted
 #
@@ -265,6 +319,10 @@ EXAMPLES = """
 # Before state:
 # -------------
 # interface PortChannel 10
+#  no shutdown
+#  !
+#  evpn ethernet-segment auto-lacp
+#  df-preference 2222
 # !
 # interface PortChannel 12
 # !

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -93,7 +93,7 @@ options:
           esi:
             description:
               - Specifies value of Ethernet Segment Identifier.
-              - "AUTO" is supported for auto_lacp and auto_system_mac.
+                Only "AUTO" is supported for auto_lacp and auto_system_mac.
             type: str
           df_preference:
             description:

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -59,8 +59,7 @@ options:
         type: dict
         suboptions:
           interfaces:
-            description:
-              - The list of interfaces that are part of the group.
+            description: The list of interfaces that are part of the group.
             type: list
             elements: dict
             suboptions:
@@ -75,31 +74,6 @@ options:
         choices:
           - static
           - lacp
-      ethernet_segment:
-        description:
-          - Specifies Ethernet segment.
-        version_added: 2.5.0
-        type: dict
-        suboptions:
-          esi_type:
-            description:
-              - Specifies type of Ethernet Segment Identifier.
-            type: str
-            required: True
-            choices:
-              - auto_lacp
-              - auto_system_mac
-              - ethernet_segement_id
-          esi:
-            description:
-              - Specifies value of Ethernet Segment Identifier.
-              - "AUTO" is supported for auto_lacp and auto_system_mac.
-            type: str
-          df_preference:
-            description:
-              - The preference for Designated Forwarder election method.
-            type: int
-            default: 32767
   state:
     description:
       - The state that the configuration should be left in.
@@ -127,9 +101,6 @@ EXAMPLES = """
 #  mtu 9100
 #  speed 100000
 #  no shutdown
-# !
-# interface PortChannel0
-#  no shutdown
 #
 - name: Merges provided configuration with device configuration
   dellemc.enterprise_sonic.sonic_lag_interfaces:
@@ -138,9 +109,6 @@ EXAMPLES = """
        members:
          interfaces:
            - member: Eth1/10
-       ethernet_segment:
-         esi_type: auto_lacp
-         df_preference: 2222
     state: merged
 #
 # After state:
@@ -157,12 +125,6 @@ EXAMPLES = """
 #  mtu 9100
 #  speed 100000
 #  no shutdown
-# !
-# interface PortChannel0
-#  no shutdown
-#  !
-#  evpn ethernet-segment auto-lacp
-#  df-preference 2222
 #
 # Using replaced
 #
@@ -194,9 +156,6 @@ EXAMPLES = """
         members:
           interfaces:
             - member: Eth1/7
-        ethernet_segment:
-          esi_type: auto_lacp
-          df_preference: 2222
     state: replaced
 #
 # After state:
@@ -219,12 +178,6 @@ EXAMPLES = """
 #   mtu 9100
 #   speed 100000
 #   no shutdown
-#
-# interface PortChannel0
-#  no shutdown
-#  !
-#  evpn ethernet-segment auto-lacp
-#  df-preference 2222
 #
 # Using overridden
 #
@@ -256,9 +209,6 @@ EXAMPLES = """
         members:
           interfaces:
             - member: Eth1/6
-        ethernet_segment:
-          esi_type: auto_lacp
-          df_preference: 2222
     state: overridden
 #
 # After state:
@@ -280,12 +230,6 @@ EXAMPLES = """
 #   mtu 9100
 #   speed 100000
 #   no shutdown
-#
-# interface PortChannel0
-#  no shutdown
-#  !
-#  evpn ethernet-segment auto-lacp
-#  df-preference 2222
 #
 # Using deleted
 #
@@ -321,10 +265,6 @@ EXAMPLES = """
 # Before state:
 # -------------
 # interface PortChannel 10
-#  no shutdown
-#  !
-#  evpn ethernet-segment auto-lacp
-#  df-preference 2222
 # !
 # interface PortChannel 12
 # !

--- a/plugins/modules/sonic_lag_interfaces.py
+++ b/plugins/modules/sonic_lag_interfaces.py
@@ -59,7 +59,8 @@ options:
         type: dict
         suboptions:
           interfaces:
-            description: The list of interfaces that are part of the group.
+            description:
+              - The list of interfaces that are part of the group.
             type: list
             elements: dict
             suboptions:

--- a/tests/regression/roles/sonic_lag_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_lag_interfaces/defaults/main.yml
@@ -30,6 +30,9 @@ tests:
           members:
             interfaces:
               - member: "{{ interface1 }}"
+          ethernet_segment:
+            esi_type: ethernet_segement_id
+            esi: 00:00:00:00:44:38:39:ff:00:01
         - name: PortChannel41
           mode: lacp
           members:
@@ -47,6 +50,9 @@ tests:
             interfaces:
               - member: "{{ interface1 }}"
               - member: "{{ interface2 }}"
+          ethernet_segment:
+            esi_type: auto_lacp
+            df_preference: 2222
         - name: PortChannel41
           mode: lacp
           members:
@@ -62,6 +68,9 @@ tests:
           members:
             interfaces:
               - member: "{{ interface1 }}"
+          ethernet_segment:
+            esi_type: auto_lacp
+            df_preference: 2222
         - name: PortChannel41
           members:
             interfaces:
@@ -74,6 +83,9 @@ tests:
           members:
             interfaces:
               - member: "{{ interface1 }}"
+          ethernet_segment:
+            esi_type: auto_lacp
+            df_preference: 2222
         - name: po41
           members:
             interfaces:
@@ -86,10 +98,16 @@ tests:
           members:
             interfaces:
               - member: "{{ interface5 }}"
+          ethernet_segment:
+            esi_type: auto_system_mac
+            df_preference: 3333
         - name: po41
           members:
             interfaces:
               - member: "{{ interface6 }}"
+          ethernet_segment:
+            esi_type: auto_lacp
+            df_preference: 2233
   - name: test_case_07
     description: Override portchannel configuration
     state: overridden
@@ -98,6 +116,9 @@ tests:
           members:
             interfaces:
               - member: "{{ interface1 }}"
+          ethernet_segment:
+            esi_type: auto_lacp
+            df_preference: 2222
         - name: po41
           members:
             interfaces:

--- a/tests/regression/roles/sonic_lag_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_lag_interfaces/defaults/main.yml
@@ -31,7 +31,7 @@ tests:
             interfaces:
               - member: "{{ interface1 }}"
           ethernet_segment:
-            esi_type: ethernet_segement_id
+            esi_type: ethernet_segment_id
             esi: 00:00:00:00:44:38:39:ff:00:01
         - name: PortChannel41
           mode: lacp

--- a/tests/regression/roles/sonic_lag_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_lag_interfaces/defaults/main.yml
@@ -100,7 +100,6 @@ tests:
               - member: "{{ interface5 }}"
           ethernet_segment:
             esi_type: auto_system_mac
-            df_preference: 3333
         - name: po41
           members:
             interfaces:
@@ -127,6 +126,13 @@ tests:
     description: Override all portchannel configuration
     state: overridden
     input:
+        - name: portchannel 40
+          members:
+            interfaces:
+              - member: "{{ interface1 }}"
+          ethernet_segment:
+            esi_type: auto_system_mac
+            df_preference: 3333
         - name: portchannel 42
           members:
             interfaces:

--- a/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
@@ -232,3 +232,149 @@ deleted_03:
     - path: "data/sonic-portchannel:sonic-portchannel/PORTCHANNEL_MEMBER/PORTCHANNEL_MEMBER_LIST"
       method: "delete"
       data:
+
+replaced_01:
+  module_args:
+    state: replaced
+    config:
+      - name: PortChannel10
+        members:
+          interfaces:
+            - member: Eth1/12
+            - member: Eth1/14
+        ethernet_segment:
+            esi_type: auto_system_mac
+      - name: PortChannel20
+        members:
+          interfaces:
+            - member: Eth1/23
+  existing_lag_interfaces_config:
+    - path: "data/sonic-portchannel:sonic-portchannel"
+      response:
+        code: 200
+        value:
+          sonic-portchannel:sonic-portchannel:
+            PORTCHANNEL:
+              PORTCHANNEL_LIST:
+                - name: PortChannel10
+                - name: PortChannel30
+            PORTCHANNEL_MEMBER:
+              PORTCHANNEL_MEMBER_LIST:
+                - ifname: Eth1/11
+                  name: PortChannel10
+                - ifname: Eth1/31
+                  name: PortChannel30
+  expected_config_requests:
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f11/openconfig-if-ethernet:ethernet/config/openconfig-if-aggregate:aggregate-id"
+      method: "delete"
+      data:
+    - path: "data/openconfig-interfaces:interfaces"
+      method: "patch"
+      data:
+        openconfig-interfaces:interfaces:
+          interface:
+            - name: PortChannel20
+              config:
+                name: PortChannel20
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2F12/openconfig-if-ethernet:ethernet/config/openconfig-if-aggregate:aggregate-id"
+      method: "patch"
+      data:
+        openconfig-if-aggregate:aggregate-id: PortChannel10
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2F14/openconfig-if-ethernet:ethernet/config/openconfig-if-aggregate:aggregate-id"
+      method: "patch"
+      data:
+        openconfig-if-aggregate:aggregate-id: PortChannel10
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2F23/openconfig-if-ethernet:ethernet/config/openconfig-if-aggregate:aggregate-id"
+      method: "patch"
+      data:
+        openconfig-if-aggregate:aggregate-id: PortChannel20
+    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments"
+      method: "patch"
+      data:
+        openconfig-network-instance:ethernet-segments:
+          ethernet-segment:
+            - name: PortChannel10
+              config:
+                esi-type: TYPE_3_MAC_BASED
+                esi: AUTO
+                interface: PortChannel10
+    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments/ethernet-segment=PortChannel10/df-election/config/preference"
+      method: "patch"
+      data:
+        openconfig-network-instance:preference: 32767
+
+overridden_01:
+  module_args:
+    state: overridden
+    config:
+      - name: PortChannel10
+        members:
+          interfaces:
+            - member: Eth1/12
+            - member: Eth1/14
+        ethernet_segment:
+            esi_type: auto_system_mac
+      - name: PortChannel20
+        members:
+          interfaces:
+            - member: Eth1/23
+  existing_lag_interfaces_config:
+    - path: "data/sonic-portchannel:sonic-portchannel"
+      response:
+        code: 200
+        value:
+          sonic-portchannel:sonic-portchannel:
+            PORTCHANNEL:
+              PORTCHANNEL_LIST:
+                - name: PortChannel10
+                - name: PortChannel30
+            PORTCHANNEL_MEMBER:
+              PORTCHANNEL_MEMBER_LIST:
+                - ifname: Eth1/14
+                  name: PortChannel10
+                - ifname: Eth1/31
+                  name: PortChannel30
+            EVPN_ETHERNET_SEGMENT:
+              EVPN_ETHERNET_SEGMENT_LIST:
+                - name: PortChannel10
+                  ifname: PortChannel10
+                  esi_type: TYPE_3_MAC_BASED
+                  esi: AUTO
+                  df_pref: 3333
+  expected_config_requests:
+    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments/ethernet-segment=PortChannel10"
+      method: "delete"
+      data:
+    - path: "data/openconfig-interfaces:interfaces/interface=PortChannel30"
+      method: "delete"
+      data:
+    - path: "data/openconfig-interfaces:interfaces"
+      method: "patch"
+      data:
+        openconfig-interfaces:interfaces:
+          interface:
+            - name: PortChannel20
+              config:
+                name: PortChannel20
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2F12/openconfig-if-ethernet:ethernet/config/openconfig-if-aggregate:aggregate-id"
+      method: "patch"
+      data:
+        openconfig-if-aggregate:aggregate-id: PortChannel10
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2F23/openconfig-if-ethernet:ethernet/config/openconfig-if-aggregate:aggregate-id"
+      method: "patch"
+      data:
+        openconfig-if-aggregate:aggregate-id: PortChannel20
+    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments"
+      method: "patch"
+      data:
+        openconfig-network-instance:ethernet-segments:
+          ethernet-segment:
+            - name: PortChannel10
+              config:
+                esi-type: TYPE_3_MAC_BASED
+                esi: AUTO
+                interface: PortChannel10
+    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments/ethernet-segment=PortChannel10/df-election/config/preference"
+      method: "patch"
+      data:
+        openconfig-network-instance:preference: 32767

--- a/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
@@ -7,6 +7,9 @@ merged_01:
           interfaces:
             - member: Eth1/11
             - member: Eth1/12
+        ethernet_segment:
+            esi_type: auto_lacp
+            df_preference: 2222
       - name: PortChannel20
         members:
           interfaces:
@@ -66,6 +69,21 @@ merged_01:
       method: "patch"
       data:
         openconfig-if-aggregate:aggregate-id: PortChannel20
+    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments"
+      method: "patch"
+      data:
+        openconfig-network-instance:ethernet-segments:
+          ethernet-segment:
+            - name: PortChannel10
+              config:
+                esi-type: TYPE_1_LACP_BASED
+                esi: AUTO
+                interface: PortChannel10
+    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments/ethernet-segment=PortChannel10/df-election/config/preference"
+      method: "patch"
+      data:
+        openconfig-network-instance:preference: 2222
+
 deleted_01:
   module_args:
     state: deleted
@@ -101,6 +119,8 @@ deleted_02:
           interfaces:
             - member: Eth1/12
             - member: Eth1/14
+        ethernet_segment:
+            esi_type: auto_system_mac
       - name: PortChannel20
         members:
           interfaces:
@@ -146,6 +166,13 @@ deleted_02:
                   name: PortChannel40
                 - ifname: Eth1/42
                   name: PortChannel40
+            EVPN_ETHERNET_SEGMENT:
+              EVPN_ETHERNET_SEGMENT_LIST:
+                - name: PortChannel10
+                  ifname: PortChannel10
+                  esi_type: TYPE_3_MAC_BASED
+                  esi: AUTO
+                  df_pref: 3333
   expected_config_requests:
     - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f12/openconfig-if-ethernet:ethernet/config/openconfig-if-aggregate:aggregate-id"
       method: "delete"
@@ -160,6 +187,9 @@ deleted_02:
       method: "delete"
       data:
     - path: "data/openconfig-interfaces:interfaces/interface=PortChannel40"
+      method: "delete"
+      data:
+    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments/ethernet-segment=PortChannel10"
       method: "delete"
       data:
 

--- a/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
@@ -79,10 +79,10 @@ merged_01:
                 esi-type: TYPE_1_LACP_BASED
                 esi: AUTO
                 interface: PortChannel10
-    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments/ethernet-segment=PortChannel10/df-election/config/preference"
-      method: "patch"
-      data:
-        openconfig-network-instance:preference: 2222
+                name: PortChannel10
+              df-election:
+                config:
+                  preference: 2222
 
 deleted_01:
   module_args:
@@ -298,10 +298,7 @@ replaced_01:
                 esi-type: TYPE_3_MAC_BASED
                 esi: AUTO
                 interface: PortChannel10
-    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments/ethernet-segment=PortChannel10/df-election/config/preference"
-      method: "patch"
-      data:
-        openconfig-network-instance:preference: 32767
+                name: PortChannel10
 
 overridden_01:
   module_args:
@@ -313,7 +310,7 @@ overridden_01:
             - member: Eth1/12
             - member: Eth1/14
         ethernet_segment:
-            esi_type: auto_system_mac
+            esi_type: auto_lacp
       - name: PortChannel20
         members:
           interfaces:
@@ -371,10 +368,8 @@ overridden_01:
           ethernet-segment:
             - name: PortChannel10
               config:
-                esi-type: TYPE_3_MAC_BASED
+                esi-type: TYPE_1_LACP_BASED
                 esi: AUTO
                 interface: PortChannel10
-    - path: "data/openconfig-network-instance:network-instances/network-instance=default/evpn/ethernet-segments/ethernet-segment=PortChannel10/df-election/config/preference"
-      method: "patch"
-      data:
-        openconfig-network-instance:preference: 32767
+                name: PortChannel10
+

--- a/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
@@ -372,4 +372,3 @@ overridden_01:
                 esi: AUTO
                 interface: PortChannel10
                 name: PortChannel10
-

--- a/tests/unit/modules/network/sonic/test_sonic_lag_interfaces.py
+++ b/tests/unit/modules/network/sonic/test_sonic_lag_interfaces.py
@@ -74,3 +74,17 @@ class TestSonicLagInterfacesModule(TestSonicModule):
         self.initialize_config_requests(self.fixture_data['deleted_03']['expected_config_requests'])
         result = self.execute_module(changed=True)
         self.validate_config_requests()
+
+    def test_sonic_lag_interfaces_replaced_01(self):
+        set_module_args(self.fixture_data['replaced_01']['module_args'])
+        self.initialize_facts_get_requests(self.fixture_data['replaced_01']['existing_lag_interfaces_config'])
+        self.initialize_config_requests(self.fixture_data['replaced_01']['expected_config_requests'])
+        result = self.execute_module(changed=True)
+        self.validate_config_requests()
+
+    def test_sonic_lag_interfaces_overridden_01(self):
+        set_module_args(self.fixture_data['overridden_01']['module_args'])
+        self.initialize_facts_get_requests(self.fixture_data['overridden_01']['existing_lag_interfaces_config'])
+        self.initialize_config_requests(self.fixture_data['overridden_01']['expected_config_requests'])
+        result = self.execute_module(changed=True)
+        self.validate_config_requests()


### PR DESCRIPTION
##### SUMMARY
This is to add evpn ethernet-segment support for LAG interface.

##### GitHub Issues
GitHub Issue #379 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sonic_lag_interfaces

##### OUTPUT
[regression.log](https://github.com/user-attachments/files/16531877/regression.log)

[regression-2024-08-07-11-45-15.html.pdf](https://github.com/user-attachments/files/16531880/regression-2024-08-07-11-45-15.html.pdf)

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Regression testing and lots of unit testing.