### PR TITLE
Update AAA regression test cases for 2.5.0

### DIFF
--- a/tests/regression/roles/sonic_aaa/defaults/main.yml
+++ b/tests/regression/roles/sonic_aaa/defaults/main.yml
@@ -12,13 +12,14 @@ tests:
           group: tacacs+
           local: true
 
-  - name: test_case_02
-    description: Update created aaa properties
-    state: merged
-    input:
-      authentication:
-        data:
-          fail_through: false
+            # This configuration will lock out admin user
+            #  - name: test_case_02
+            #    description: Update created aaa properties
+            #    state: merged
+            #    input:
+            #      authentication:
+            #        data:
+            #          fail_through: false
 
   - name: test_case_03
     description: Update aaa properties - change group


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I commented out AAA regression test case 2 because such configuration will cause a lockout on the switch during regression execution.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_aaa

##### OUTPUT
<!--- Paste the functionality test result below -->
[regression-2024-06-26-12-39-57.html.pdf](https://github.com/user-attachments/files/15994551/regression-2024-06-26-12-39-57.html.pdf)