### PR TITLE
sonic_route_maps: Add 'set tag' functionality; sync argpec, module, and model files

### DIFF
--- a/changelogs/fragments/413-route-maps-set-tag-support-and-doc-updates.yaml
+++ b/changelogs/fragments/413-route-maps-set-tag-support-and-doc-updates.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sonic_route_maps - Add support for the 'set tag' option and synchronize module documentation with argspec and model(https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/413).

--- a/changelogs/fragments/413-route-maps-set-tag-support-and-doc-updates.yaml
+++ b/changelogs/fragments/413-route-maps-set-tag-support-and-doc-updates.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - sonic_route_maps - Add support for the 'set tag' option and synchronize module documentation with argspec and model(https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/413).
+  - sonic_route_maps - Add support for the 'set tag' option and synchronize module documentation with argspec and model (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/413).

--- a/plugins/module_utils/network/sonic/argspec/route_maps/route_maps.py
+++ b/plugins/module_utils/network/sonic/argspec/route_maps/route_maps.py
@@ -180,7 +180,8 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                             'choices': ['egp', 'igp', 'incomplete'],
                             'type': 'str'
                         },
-                        'weight': {'type': 'int'}
+                        'weight': {'type': 'int'},
+                        'tag': {'type': 'int'}
                     },
                     'type': 'dict'
                 },

--- a/plugins/module_utils/network/sonic/config/route_maps/route_maps.py
+++ b/plugins/module_utils/network/sonic/config/route_maps/route_maps.py
@@ -770,6 +770,10 @@ class Route_maps(ConfigBase):
         if cmd_set_top.get('weight'):
             route_map_bgp_actions_cfg['set-weight'] = cmd_set_top['weight']
 
+        # Handle set tag
+        if cmd_set_top.get('tag'):
+            route_map_bgp_actions_cfg['set-tag'] = cmd_set_top['tag']
+
     @staticmethod
     def get_route_map_modify_call_attr(command, route_map_statement):
         '''In the dict specified by the input route_map_statement paramenter,
@@ -1442,7 +1446,7 @@ class Route_maps(ConfigBase):
         # Note: Although 'metric' (REST API 'set-med') is in this REST API configuration
         # group, it is handled separately as part of deleting the top level, functionally
         # related 'metric-action' attribute.
-        bgp_cfg_keys = {'ip_next_hop', 'origin', 'local_preference', 'ipv6_next_hop', 'weight'}
+        bgp_cfg_keys = {'ip_next_hop', 'origin', 'local_preference', 'ipv6_next_hop', 'weight', 'tag'}
         delete_bgp_keys = bgp_cfg_keys.intersection(set_both_keys)
         if not delete_bgp_keys:
             for bgp_key in bgp_cfg_keys:
@@ -1479,7 +1483,8 @@ class Route_maps(ConfigBase):
             'ip_next_hop': 'set-next-hop',
             'local_preference': 'set-local-pref',
             'origin': 'set-route-origin',
-            'weight': 'set-weight'
+            'weight': 'set-weight',
+            'tag': 'set-tag',
         }
 
         for bgp_cfg_key in bgp_cfg_rest_names:
@@ -1926,6 +1931,7 @@ class Route_maps(ConfigBase):
             'metric',
             'origin',
             'weight',
+            'tag',
         ]
 
         set_uri_attr = {
@@ -1941,7 +1947,8 @@ class Route_maps(ConfigBase):
             'local_preference': bgp_set_delete_req_base + 'config/set-local-pref',
             'metric': metric_uri,
             'origin': bgp_set_delete_req_base + 'config/set-route-origin',
-            'weight': bgp_set_delete_req_base + 'config/set-weight'
+            'weight': bgp_set_delete_req_base + 'config/set-weight',
+            'tag': bgp_set_delete_req_base + 'config/set-tag'
         }
 
         # Remove all appropriate "set" configuration for this route map if any of the

--- a/plugins/module_utils/network/sonic/facts/route_maps/route_maps.py
+++ b/plugins/module_utils/network/sonic/facts/route_maps/route_maps.py
@@ -258,6 +258,10 @@ class Route_mapsFacts(object):
             if weight:
                 parsed_route_map_stmt_set['weight'] = weight
 
+            tag = set_bgp_policy_cfg.get('set-tag')
+            if tag:
+                parsed_route_map_stmt_set['tag'] = tag
+
     @staticmethod
     def get_rmap_set_community(set_bgp_policy, parsed_route_map_stmt_set):
         '''Parse the "community" sub-section of the BGP policy "set" attribute

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -66,7 +66,7 @@ options:
           - deny
       sequence_num:
         description:
-          - unique number in the range 1-66535 to specify priority of the map
+          - "unique number in the range 1-66535 to specify priority of the map"
           - This value is required for creation and modification of a route
           - map or route map attributes as well as for deletion of route map
           - attributes. It can be omitted only when requesting deletion of all
@@ -94,12 +94,12 @@ options:
             suboptions:
               default_route:
                 description:
-                  - Default EVPN type-5 route
+                  - "Default EVPN type-5 route"
                 type: bool
               route_type:
                 description:
                   - "Non-default route type: One of the following:"
-                  - mac-ip route, EVPN Type 3 Inclusive Multicast Ethernet
+                  - "mac-ip route, EVPN Type 3 Inclusive Multicast Ethernet"
                   - Tag (IMET) route, or prefix route
                 type: str
                 choices:
@@ -109,7 +109,7 @@ options:
               vni:
                 description:
                   - VNI ID to be checked for a match; specified by a value in the
-                  - range 1-16777215
+                  - "range 1-16777215"
                 type: int
           ext_comm:
             description:
@@ -120,7 +120,7 @@ options:
             description:
               - Next hop interface name (type and number) to be checked for a
               - match with the target route. The interface type can be any
-              - of the following; 'Ethernet/Eth' interface or sub-interface,
+              - "of the following; 'Ethernet/Eth' interface or sub-interface,"
               - "'Loopback' interface, 'PortChannel' interface or"
               - "sub-interface, 'Vlan' interface."
             type: str
@@ -137,7 +137,7 @@ options:
                 type: str
               next_hop:
                 description:
-                  - name of a prefix list containing a list of next-hop
+                  - "name of a prefix list containing a list of next-hop"
                   - prefixes to be checked for a match with the target route
                 type: str
           ipv6:
@@ -154,13 +154,13 @@ options:
                 required: true
           local_preference:
             description:
-              - local-preference value to be checked for a match with the
-              - target route. This is a value in the range 0-4294967295.
+              - "local-preference value to be checked for a match with the"
+              - "target route. This is a value in the range 0-4294967295."
             type: int
           metric:
             description:
               - metric value to be checked for a match with the target route.
-              - This is a value in the range 0-4294967295.
+              - "This is a value in the range 0-4294967295."
             type: int
           origin:
             description:
@@ -186,7 +186,7 @@ options:
                 description:
                   - Name (type and number) of a BGP peer interface
                   - Allowed interface types are Ethernet or Eth (depending
-                  - on the configured interface-naming mode),
+                  - "on the configured interface-naming mode),"
                   - Vlan, and Portchannel
                 type: str
           source_protocol:
@@ -203,17 +203,17 @@ options:
           tag:
             description:
               - Tag value required for a matching route
-              - The value must be in the range 1-4294967295
+              - "The value must be in the range 1-4294967295"
             type: int
       set:
-        description: Information to set into a matching route for re-distribution
+        description: "Information to set into a matching route for re-distribution"
         type: dict
         suboptions:
           as_path_prepend:
             description:
-              - String specifying a comma-separated list of AS-path numbers
+              - "String specifying a comma-separated list of AS-path numbers"
               - "to prepend to the BGP AS-path attribute in a matched route."
-              - AS-path values in the list must be in the range
+              - "AS-path values in the list must be in the range"
               - "1-4294967295; for example, 2000,3000"
             type: str
           comm_list_delete:
@@ -328,13 +328,13 @@ options:
                   - Set the corresponding attribute into a matching route
                   - if the value of this Ansible attribute is 'true'.
                   - The attribute indicates that the routing algorithm must
-                  - prefer the global next-hop address over the link-local
+                  - "prefer the global next-hop address over the link-local"
                   - address if both exist.
                 type: bool
           local_preference:
             description:
                 - "BGP local preference path attribute; integer value in"
-                - the range 0-4294967295
+                - "the range 0-4294967295"
             type: int
           metric:
             description:
@@ -345,7 +345,7 @@ options:
               value:
                 description:
                   - "metric value to be set into a matching route;"
-                  - value in the range 0-4294967295
+                  - "value in the range 0-4294967295"
                 type: int
               rtt_action:
                 description:

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -376,12 +376,12 @@ options:
           weight:
             description:
               - BGP weight to be set for a matching route: The weight must be
-              - an integer in the range 0-4294967295
+              - "an integer in the range 0-4294967295"
             type: int
           tag:
             description:
               - Tag value to be set for a matching route
-              - The value must be in the range 1-4294967295
+              - "The value must be in the range 1-4294967295"
       call:
         description:
           - Name of a route map to jump to after executing 'match' and 'set'

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -184,7 +184,7 @@ options:
                 type: str
               interface:
                 description:
-                  - Name (type and number) of a BGP peer interface.
+                  - Name (type and number) of a BGP peer interface
                   - Allowed interface types are Ethernet or Eth (depending
                   - on the configured interface-naming mode),
                   - Vlan, and Portchannel

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -279,13 +279,12 @@ options:
                   - and I(additive).
                 type: list
                 elements: str
-                'mutually_exclusive': [
-                    ['none', 'local_as'],
-                    ['none', 'no_advertise'],
-                    ['none', 'no_export'],
-                    ['none', 'no_peer'],
-                    ['none', 'additive']
-                ],
+                'mutually_exclusive': [[ /
+                    'none', 'local_as'], /
+                    ['none', 'no_advertise'], /
+                    ['none', 'no_export'], /
+                    ['none', 'no_peer'], /
+                    ['none', 'additive']],
                 choices:
                   - local_as
                   - no_advertise

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -279,7 +279,6 @@ options:
                   - and I(additive).
                 type: list
                 elements: str
-                'mutually_exclusive': [['none', 'local_as'], ['none', 'no_advertise'], ['none', 'no_export'], ['none', 'no_peer'], ['none', 'additive']],
                 choices:
                   - local_as
                   - no_advertise

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -172,9 +172,10 @@ options:
               - incomplete
           peer:
             description:
-              - BGP routing peer/neighbor required for a matching route.
+              - BGP routing peer/neighbor required for a matching route
               - I(ip), I(ipv6), and I(interface) are mutually exclusive.
             type: dict
+            mutually_exclusive: [['ip', 'ipv6', 'interface']]
             suboptions:
               ip:
                 description: IPv4 address of a BGP peer
@@ -278,6 +279,13 @@ options:
                   - and I(additive).
                 type: list
                 elements: str
+                'mutually_exclusive': [
+                    ['none', 'local_as'],
+                    ['none', 'no_advertise'],
+                    ['none', 'no_export'],
+                    ['none', 'no_peer'],
+                    ['none', 'additive']
+                ],
                 choices:
                   - local_as
                   - no_advertise
@@ -289,6 +297,7 @@ options:
             description:
               - BGP extended community attributes to set into a matching route.
             type: dict
+            required_one_of: [['rt', 'soo']]
             suboptions:
               rt:
                 description:
@@ -317,6 +326,7 @@ options:
             description:
               - IPv6 next hop address attributes to set into a matching route
             type: dict
+            required_one_of: [['global_addr', 'prefer_global']]
             suboptions:
               global_addr:
                 description:
@@ -341,7 +351,9 @@ options:
               - route metric value actions
               - I(value) and I(rtt_action) are mutually exclusive.
             type: dict
-            suboptions:
+            required_one_of: [['value', 'rtt_action']]
+            mutually_exclusive: [['value', 'rtt_action']]
+            options:
               value:
                 description:
                   - "metric value to be set into a matching route;"
@@ -375,9 +387,13 @@ options:
               - incomplete
           weight:
             description:
-              - BGP weight for the routing table. The weight must be an
-              - integer in the range 0-4294967295
+              - BGP weight to be set for a matching route: The weight must be
+              - an integer in the range 0-4294967295
             type: int
+          tag:
+            description:
+              - Tag value to be set for a matching route
+              - The value must be in the range 1-4294967295
       call:
         description:
           - Name of a route map to jump to after executing 'match' and 'set'
@@ -1447,13 +1463,12 @@ EXAMPLES = """
 #  match source-protocol static
 #  set metric -rtt
 # ------------
-- name: Delete a route map or route map subset
+- name: Delete a route map subset or a route map
   dellemc.enterprise_sonic.sonic_route_maps:
      config:
        - map_name: rm1
          sequence_num: 3047
        - map_name: rm2
-         sequence_num: 100
      state: deleted
 
 # After state:

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -279,12 +279,7 @@ options:
                   - and I(additive).
                 type: list
                 elements: str
-                'mutually_exclusive': [[ /
-                    'none', 'local_as'], /
-                    ['none', 'no_advertise'], /
-                    ['none', 'no_export'], /
-                    ['none', 'no_peer'], /
-                    ['none', 'additive']],
+                'mutually_exclusive': [['none', 'local_as'], ['none', 'no_advertise'], ['none', 'no_export'], ['none', 'no_peer'], ['none', 'additive']],
                 choices:
                   - local_as
                   - no_advertise

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -472,6 +472,7 @@ EXAMPLES = """
              metric_value: 870
            origin: egp
            weight: 93471
+           tag: 65
        - map_name: rm1
          action: deny
          sequence_num: 3047
@@ -549,6 +550,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm1 deny 3047
 #  match evpn route-type multicast
@@ -610,6 +612,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm1 deny 3047
 #  match evpn route-type multicast
@@ -729,6 +732,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm1 deny 3047
 #  match as-path bgp_as3
@@ -800,6 +804,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # ------------
 - name: Replace a list
   dellemc.enterprise_sonic.sonic_route_maps:
@@ -848,6 +853,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 
 
 # Using "replaced" state to replace the contents of dictionaries
@@ -885,6 +891,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm1 deny 3047
 #  match as-path bgp_as3
@@ -976,6 +983,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm1 deny 3047
 #  match as-path bgp_as3
@@ -1044,6 +1052,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm1 deny 3047
 #  match as-path bgp_as3
@@ -1169,6 +1178,7 @@ EXAMPLES = """
              rtt_action: add
            origin: egp
            weight: 93471
+           tag: 65
        - map_name: rm1
          action: deny
          sequence_num: 3047
@@ -1261,6 +1271,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm1 deny 3047
 #  match as-path bgp_as3
@@ -1332,6 +1343,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # ------------
 - name: Delete selected route map configuration
   dellemc.enterprise_sonic.sonic_route_maps:
@@ -1386,6 +1398,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 
 
 # Using "deleted" state to remove a route map or route map subset
@@ -1418,6 +1431,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm1 deny 3047
 #  match as-path bgp_as3
@@ -1488,6 +1502,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm3 deny 285
 #  match evpn route-type macip
@@ -1536,6 +1551,7 @@ EXAMPLES = """
 #  set local-preference 635
 #  set origin egp
 #  set weight 93471
+#  set tag 65
 # !
 # route-map rm3 deny 285
 #  match evpn route-type macip

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -175,7 +175,6 @@ options:
               - BGP routing peer/neighbor required for a matching route
               - I(ip), I(ipv6), and I(interface) are mutually exclusive.
             type: dict
-            mutually_exclusive: [['ip', 'ipv6', 'interface']]
             suboptions:
               ip:
                 description: IPv4 address of a BGP peer
@@ -290,7 +289,6 @@ options:
             description:
               - BGP extended community attributes to set into a matching route.
             type: dict
-            required_one_of: [['rt', 'soo']]
             suboptions:
               rt:
                 description:
@@ -319,7 +317,6 @@ options:
             description:
               - IPv6 next hop address attributes to set into a matching route
             type: dict
-            required_one_of: [['global_addr', 'prefer_global']]
             suboptions:
               global_addr:
                 description:
@@ -344,8 +341,6 @@ options:
               - route metric value actions
               - I(value) and I(rtt_action) are mutually exclusive.
             type: dict
-            required_one_of: [['value', 'rtt_action']]
-            mutually_exclusive: [['value', 'rtt_action']]
             options:
               value:
                 description:

--- a/plugins/modules/sonic_route_maps.py
+++ b/plugins/modules/sonic_route_maps.py
@@ -341,7 +341,7 @@ options:
               - route metric value actions
               - I(value) and I(rtt_action) are mutually exclusive.
             type: dict
-            options:
+            suboptions:
               value:
                 description:
                   - "metric value to be set into a matching route;"
@@ -375,13 +375,14 @@ options:
               - incomplete
           weight:
             description:
-              - BGP weight to be set for a matching route: The weight must be
+              - "BGP weight to be set for a matching route: The weight must be"
               - "an integer in the range 0-4294967295"
             type: int
           tag:
             description:
               - Tag value to be set for a matching route
               - "The value must be in the range 1-4294967295"
+            type: int
       call:
         description:
           - Name of a route map to jump to after executing 'match' and 'set'

--- a/tests/regression/roles/sonic_route_maps/defaults/main.yml
+++ b/tests/regression/roles/sonic_route_maps/defaults/main.yml
@@ -114,6 +114,7 @@ tests:
             value: 870
           origin: egp
           weight: 93471
+          tag: 65
   - name: test_case_03_merged_base_other_route_maps
     description: Add initial route map match configuration for other maps
     state: merged
@@ -287,6 +288,7 @@ tests:
             rtt_action: add
           origin: egp
           weight: 93471
+          tag: 83540
       - map_name: rm1
         action: deny
         sequence_num: 3047
@@ -395,6 +397,7 @@ tests:
               rtt_action: add
           origin: egp
           weight: 93471
+          tag: 83540
   - name: test_case_10_merged_restore_other_route_maps
     description: Restore route map configuration for other maps
     state: merged
@@ -560,6 +563,7 @@ tests:
               rtt_action: add
           origin: egp
           weight: 93471
+          tag: 83540
   - name: test_case_14_merged_restore_other_route_maps
     description: Restore route map configuration for other replaced maps (rm2 "set")
     state: merged
@@ -732,6 +736,7 @@ tests:
               rtt_action: add
           origin: egp
           weight: 93471
+          tag: 83540
   - name: test_case_22_merged_restore_deleted_rm1_3047_and_rm3_route_map
     description: Restore deleted route maps rm1 3047 and rm3
     state: merged
@@ -850,6 +855,7 @@ tests:
               rtt_action: add
           origin: egp
           weight: 93471
+          tag: 83540
   - name: test_case_26_merged_restore_deleted_rm1_3047_and_rm3_route_map
     description: Restore deleted route maps rm1 3047 and rm3
     state: merged

--- a/tests/unit/modules/network/sonic/fixtures/sonic_route_maps.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_route_maps.yaml
@@ -118,6 +118,7 @@ merged_02:
             value: 870
           origin: egp
           weight: 93471
+          tag: 65
   existing_route_maps_config:
     - path: "data/openconfig-routing-policy:routing-policy/policy-definitions"
       response:
@@ -229,6 +230,7 @@ merged_02:
                           set-med: 870
                           set-route-origin: EGP
                           set-weight: 93471
+                          set-tag: 65
                       metric-action:
                         config:
                           metric: 870
@@ -304,6 +306,7 @@ merged_03:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "200,315,7135"
@@ -527,6 +530,7 @@ merged_04:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "200,315,7135"
@@ -796,6 +800,7 @@ merged_05:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "200,315,7135"
@@ -1080,6 +1085,7 @@ merged_06:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "188,257"
@@ -1415,6 +1421,7 @@ replaced_01:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "188,257"
@@ -1792,6 +1799,7 @@ replaced_02:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "188,257"
@@ -2158,6 +2166,7 @@ replaced_03:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "188,257"
@@ -2479,6 +2488,9 @@ replaced_03:
     - path: "data/openconfig-routing-policy:routing-policy/policy-definitions/policy-definition=rm1/statements/statement=80/actions/openconfig-bgp-policy:bgp-actions/config/set-weight"
       method: "delete"
       data:
+    - path: "data/openconfig-routing-policy:routing-policy/policy-definitions/policy-definition=rm1/statements/statement=80/actions/openconfig-bgp-policy:bgp-actions/config/set-tag"
+      method: "delete"
+      data:
     - path: "data/openconfig-routing-policy:routing-policy/policy-definitions/policy-definition=rm1/statements/statement=80/actions/openconfig-bgp-policy:bgp-actions/set-as-path-prepend"
       method: "delete"
       data:
@@ -2586,6 +2598,7 @@ overridden_01:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "188,257"
@@ -2878,6 +2891,7 @@ overridden_02:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "188,257"
@@ -3351,6 +3365,7 @@ deleted_01:
             rtt_action: add
           origin: egp
           weight: 93471
+          tag: 65
       - map_name: rm1
         action: deny
         sequence_num: 3047
@@ -3417,6 +3432,7 @@ deleted_01:
                             set-next-hop: 10.48.16.18
                             set-route-origin: EGP
                             set-weight: 93471
+                            set-tag: 65
                           set-as-path-prepend:
                             config:
                               openconfig-routing-policy-ext:asn-list: "188,257"
@@ -3688,6 +3704,9 @@ deleted_01:
       method: "delete"
       data:
     - path: "data/openconfig-routing-policy:routing-policy/policy-definitions/policy-definition=rm1/statements/statement=80/actions/openconfig-bgp-policy:bgp-actions/config/set-weight"
+      method: "delete"
+      data:
+    - path: "data/openconfig-routing-policy:routing-policy/policy-definitions/policy-definition=rm1/statements/statement=80/actions/openconfig-bgp-policy:bgp-actions/config/set-tag"
       method: "delete"
       data:
     - path: "data/openconfig-routing-policy:routing-policy/policy-definitions/policy-definition=rm1/statements/statement=80/actions/openconfig-bgp-policy:bgp-actions/set-as-path-prepend"


### PR DESCRIPTION
sonic_route_maps: Add 'set tag' functionality and sync argpec/module/model files

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Update the argspec, module, config, and facts files to support the route map 'set tag' option.
- Expand regression and unit test cases to test the new functionality.
- Update the 'module' file to synchronize option descriptions, "EXAMPLES", and other documentation items with the corresponding content in the 'argspec' file and in the "model" repo.
##### GitHub Issues


| GitHub Issue # |
| -------------- |
|N/A |


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_route_maps
##### OUTPUT
<!--- Paste the functionality test result below -->

[route_map_2.5.0_regression_ summary_native_intf.zip](https://github.com/user-attachments/files/16114467/route_map_2.5.0_regression_.summary_native_intf.zip)
[route_map_2.5.0_regression_full_native_intf.zip](https://github.com/user-attachments/files/16114468/route_map_2.5.0_regression_full_native_intf.zip)
[route_map_2.5.0_regression_summary_std_intf.zip](https://github.com/user-attachments/files/16114470/route_map_2.5.0_regression_summary_std_intf.zip)
[route_map_2.5.0_regression_full_std_intf.zip](https://github.com/user-attachments/files/16114469/route_map_2.5.0_regression_full_std_intf.zip)


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- manual testing with custom playbooks for the new attribute in 'merged', 'deleted', 'replaced', and 'overridden' modes.
- automated regression test verification in 'standard' and 'native' interface-naming mode
- Verified UT and sanity test results before submitting this PR.
