### PR TITLE
Fix l3_interfaces regression failures due to IPv6 default "dad" configuration

### DIFF
--- a/changelogs/fragments/428-l3-interfaces-default-dad-fix.yaml
+++ b/changelogs/fragments/428-l3-interfaces-default-dad-fix.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - sonic_l3_interfaces: - Fix IPv6 default "dad" configuration handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/428).
+  - sonic_l3_interfaces: - Fix IPv6 default dad configuration handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/428).

--- a/changelogs/fragments/428-l3-interfaces-default-dad-fix.yaml
+++ b/changelogs/fragments/428-l3-interfaces-default-dad-fix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sonic_l3_interfaces: - Fix IPv6 default "dad" configuration handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/428).

--- a/changelogs/fragments/428-l3-interfaces-default-dad-fix.yaml
+++ b/changelogs/fragments/428-l3-interfaces-default-dad-fix.yaml
@@ -1,2 +1,3 @@
+---
 minor_changes:
-  - sonic_l3_interfaces: - Fix IPv6 default dad configuration handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/428).
+  - sonic_l3_interfaces - Fix IPv6 default dad configuration handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/428).

--- a/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
@@ -114,21 +114,21 @@ class L3_interfaces(ConfigBase):
             existing_l3_intf_facts = remove_empties_from_list(existing_l3_interfaces_facts)
             cmmnds = remove_empties_from_list(commands)
 
-            old_config = self.remove_default_entries(existing_l3_intf_facts)
-            cmds = self.remove_default_entries(cmmnds)
+            old_config = self.remove_default_entries(existing_l3_intf_facts, False)
+            cmds = self.remove_default_entries(cmmnds, True)
 
             new_config = get_new_config(cmds, old_config,
                                         TEST_KEYS_formatted_diff)
             new_config = remove_empties_from_list(new_config)
-            new_config = self.remove_default_entries(new_config)
+            new_config = self.remove_default_entries(new_config, False)
             result['after(generated)'] = new_config
 
         if self._module._diff:
             old_conf = remove_empties_from_list(old_config)
-            old_conf = self.remove_default_entries(old_conf)
+            old_conf = self.remove_default_entries(old_conf, False)
 
             new_conf = remove_empties_from_list(new_config)
-            new_conf = self.remove_default_entries(new_conf)
+            new_conf = self.remove_default_entries(new_conf, False)
 
             self.sort_lists_in_config(old_conf)
             self.sort_lists_in_config(new_conf)
@@ -184,7 +184,7 @@ class L3_interfaces(ConfigBase):
         ret_requests = list()
         commands = list()
         new_want = self.update_object(want)
-        new_have = self.remove_default_entries(have)
+        new_have = self.remove_default_entries(have, False)
         get_replace_interfaces_list = self.get_interface_object_for_replaced(new_have, want)
 
         diff = get_diff(get_replace_interfaces_list, new_want, TEST_KEYS)
@@ -210,9 +210,9 @@ class L3_interfaces(ConfigBase):
         commands = list()
         new_want = self.update_object(want)
         new_want = remove_empties_from_list(new_want)
-        new_want = self.remove_default_entries(new_want)
+        new_want = self.remove_default_entries(new_want, True)
         new_have = remove_empties_from_list(have)
-        new_have = self.remove_default_entries(new_have)
+        new_have = self.remove_default_entries(new_have, False)
         get_override_interfaces = self.get_interface_object_for_overridden(new_have)
         diff = get_diff(get_override_interfaces, new_want, TEST_KEYS)
         diff2 = get_diff(new_want, get_override_interfaces, TEST_KEYS)
@@ -264,8 +264,9 @@ class L3_interfaces(ConfigBase):
             commands = update_states(commands, "deleted")
         return commands, requests
 
-    def remove_default_entries(self, config):
+    def remove_default_entries(self, config, input_cmds):
         new_config = list()
+        state = self._module.params['state']
         for obj in config:
             new_obj = dict()
             if obj.get('ipv4', None) and \
@@ -278,6 +279,34 @@ class L3_interfaces(ConfigBase):
                obj['ipv6'].get('autoconf', None) is not None or
                obj['ipv6'].get('enabled', None) is not None):
                 new_obj['ipv6'] = obj['ipv6']
+                if new_obj['ipv6'].get('dad', None) == "DISABLE":
+
+                    # Because 'dad' is shown in the device IPv6 config as "DISABLE" when
+                    # 'dad' configuration has been deleted, enable correct handling
+                    # for all states by filtering out 'dad' == "DISABLE" unless one of the
+                    # following conditions is true:
+                    #
+                    # (1) The 'config' parameter to this function represents input commands
+                    # (from the executing user playbook) and the specified target state is a
+                    # value other than 'deleted' ("positive" configuration). This is to
+                    # enable idempotent handling for 'deleted' state when 'deleting' a 'dad'
+                    # value of 'DISABLE' (a no-op that should not generate a request), while
+                    # preserving the ability to 'merge' a 'dad' value of 'DISABLE'
+                    # when that is requested by a playbook state of 'merged', 'overridden',
+                    # or 'replaced'.
+                    #
+                    # or
+                    #
+                    # (2) The 'config' parameter to this function does not represent input
+                    # commands (because it is from the current device configuration) and the
+                    # specified target state is 'merged'. (This exclusion is to enable
+                    # idempotent handling for 'merged' state when 'merging' a 'dad' value of
+                    # 'DISABLE'.)
+                    if ((input_cmds and state == "deleted") or
+                        ((not input_cmds) and state != "merged")):
+                        del new_obj['ipv6']['dad']
+                        if new_obj['ipv6'] == {}:
+                            del new_obj['ipv6']
 
             if new_obj:
                 key_set = set(obj.keys())
@@ -397,7 +426,8 @@ class L3_interfaces(ConfigBase):
                 have_ipv6_enabled = have_obj['ipv6']['enabled']
             if have_obj.get('ipv6') and 'autoconf' in have_obj['ipv6']:
                 have_ipv6_autoconf = have_obj['ipv6']['autoconf']
-            if have_obj.get('ipv6') and 'dad' in have_obj['ipv6']:
+            if (have_obj.get('ipv6') and 'dad' in have_obj['ipv6'] and
+                have_obj['ipv6']['dad'] is not None and have_obj['ipv6']['dad'] != "DISABLE"):
                 have_ipv6_dad = have_obj['ipv6']['dad']
 
             ipv4 = l3.get('ipv4', None)
@@ -548,7 +578,7 @@ class L3_interfaces(ConfigBase):
                     ipv6_enabled = l3['ipv6']['enabled']
                 if 'autoconf' in l3['ipv6']:
                     ipv6_autoconf = l3['ipv6']['autoconf']
-                if 'dad' in l3['ipv6']:
+                if 'dad' in l3['ipv6'] and l3['ipv6']['dad'] is not None and l3['ipv6']['dad'] != "DISABLE":
                     ipv6_dad = l3['ipv6']['dad']
 
             sub_intf = self.get_sub_interface_name(name)

--- a/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
@@ -303,7 +303,7 @@ class L3_interfaces(ConfigBase):
                     # idempotent handling for 'merged' state when 'merging' a 'dad' value of
                     # 'DISABLE'.)
                     if ((input_cmds and state == "deleted") or
-                        ((not input_cmds) and state != "merged")):
+                       ((not input_cmds) and state != "merged")):
                         del new_obj['ipv6']['dad']
                         if new_obj['ipv6'] == {}:
                             del new_obj['ipv6']
@@ -427,7 +427,7 @@ class L3_interfaces(ConfigBase):
             if have_obj.get('ipv6') and 'autoconf' in have_obj['ipv6']:
                 have_ipv6_autoconf = have_obj['ipv6']['autoconf']
             if (have_obj.get('ipv6') and 'dad' in have_obj['ipv6'] and
-                have_obj['ipv6']['dad'] is not None and have_obj['ipv6']['dad'] != "DISABLE"):
+               have_obj['ipv6']['dad'] is not None and have_obj['ipv6']['dad'] != "DISABLE"):
                 have_ipv6_dad = have_obj['ipv6']['dad']
 
             ipv4 = l3.get('ipv4', None)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes made in SONiC for handling of default l3_interfaces IPv6 "dad" (duplicate address detection) configuration
have caused breakage in the enterprise_sonic l3_interfaces resource module. This breakage is evident in recent
regression test runs. It is caused by the fact that SONiC now represents a "deleted" IPv6 "dad" configuration as
an "active" (present) configuration with a value of "DISABLE". The previous SONiC handling for this attribute,
which represented deleted IPv6 "dad" configuration as "null" was consistent with handling of almost all
configuration options in SONiC and was compatible with our Ansible handling.

The new behavior caused failures in idempotency handling, resulting in sending of requests for configuration that was already present in cases where the configuration contained deleted IPv6 "dad" configuration.

The change set proposed in this PR enables correct Ansible configuration behavior for the cases that were causing failures by selectively filtering out IPv6 "dad" configuration that is not actually present.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
l3_interfaces
##### OUTPUT
<!--- Paste the functionality test result below -->
[l3_interfaces_dad_default_cfg_PR_regression-2024-08-10-20-03-17.zip](https://github.com/user-attachments/files/16571254/l3_interfaces_dad_default_cfg_PR_regression-2024-08-10-20-03-17.zip)
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

I re-ran the failing regression test section for l3_interfaces to verify that it passes with the proposed changes.
