### PR TITLE
Enable system auditd and ip loadshare hash downward compatibility

### DIFF
--- a/changelogs/fragments/441-system-downward-compatibility-fix.yaml
+++ b/changelogs/fragments/441-system-downward-compatibility-fix.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - system - Catch the ConnectionError exception caused by unconditional fetching of auditd and ip loadshare hash algorithm configuration fetches and return empty configuration instead of allowing the uncaught exception to abort all "system" operations on SONiC images older than version 4.4.0 (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/434).
+  - sonic_system - Catch the ConnectionError exception caused by unconditional fetching of auditd and ip loadshare hash algorithm configuration, and return empty configuration instead of allowing the uncaught exception to abort all "system" operations on SONiC images older than version 4.4.0 (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/441).

--- a/changelogs/fragments/441-system-downward-compatibility-fix.yaml
+++ b/changelogs/fragments/441-system-downward-compatibility-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - system - Catch the ConnectionError exception caused by unconditional fetching of auditd and ip loadshare hash algorithm configuration fetches and return empty configuration instead of allowing the uncaught exception to abort all "system" operations on SONiC images older than version 4.4.0 (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/434).

--- a/plugins/httpapi/sonic.py
+++ b/plugins/httpapi/sonic.py
@@ -39,6 +39,7 @@ options:
 
 import json
 import time
+import re
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import ConnectionError
@@ -78,7 +79,11 @@ class HttpApi(HttpApiBase):
             try:
                 response = self.send_request(**req)
             except ConnectionError as exc:
-                raise ConnectionError(to_text(exc, errors='surrogate_then_replace'))
+                if req.get('method') == 'get' and re.search("code.*404", str(exc)):
+                    # 'code': 404, 'error-message': 'Resource not found'
+                    response = [{}, {}]
+                else:
+                    raise ConnectionError(to_text(exc, errors='surrogate_then_replace'))
             responses.append(response)
         return responses
 

--- a/plugins/httpapi/sonic.py
+++ b/plugins/httpapi/sonic.py
@@ -68,7 +68,7 @@ class HttpApi(HttpApiBase):
     def get(self, command):
         return self.send_request(path=command, data=None, method='get')
 
-    def edit_config(self, requests):
+    def edit_config(self, requests, suppr_ntf_excp=True):
         """Send a list of http requests to remote device and return results
         """
         if requests is None:
@@ -79,7 +79,7 @@ class HttpApi(HttpApiBase):
             try:
                 response = self.send_request(**req)
             except ConnectionError as exc:
-                if req.get('method') == 'get' and re.search("code.*404", str(exc)):
+                if suppr_ntf_excp and req.get('method') == 'get' and re.search("Not Found.*code': 404", str(exc)):
                     # 'code': 404, 'error-message': 'Resource not found'
                     response = [{}, {}]
                 else:

--- a/plugins/module_utils/network/sonic/facts/poe/poe.py
+++ b/plugins/module_utils/network/sonic/facts/poe/poe.py
@@ -157,12 +157,7 @@ class PoeFacts(object):
             self._module.fail_json(msg=str(exc))
 
         poe_config = {}
-        try:
-            poe_config = response[0][1]
-            if len(poe_config) > 0:
-                poe_config = poe_config["openconfig-poe:poe"]
-        except Exception:
-            raise Exception("response from getting poe facts not formed as expected")
+        poe_config = response[0][1].get("openconfig-poe:poe", {})
 
         # get poe interface settings
         try:
@@ -175,8 +170,8 @@ class PoeFacts(object):
         poe_interfaces = response[0][1].get("openconfig-interfaces:interfaces", {}).get("interface", [])
         for interface in poe_interfaces:
             interface_settings = interface.get("openconfig-if-ethernet:ethernet", {}).get("openconfig-if-poe:poe", {})
-                if len(interface_settings) > 0:
-                    interface_settings.update({"name": interface["name"]})
-                    interface_poe_settings.append(interface_settings)
+            if len(interface_settings) > 0:
+                interface_settings.update({"name": interface["name"]})
+                interface_poe_settings.append(interface_settings)
         formatted_specs = self.format_to_argspec(poe_config, interface_poe_settings)
         return formatted_specs

--- a/plugins/module_utils/network/sonic/facts/poe/poe.py
+++ b/plugins/module_utils/network/sonic/facts/poe/poe.py
@@ -172,14 +172,11 @@ class PoeFacts(object):
             self._module.fail_json(msg=str(exc))
 
         interface_poe_settings = []
-        try:
-            interface_poe_settings = []
-            for interface in response[0][1]["openconfig-interfaces:interfaces"]["interface"]:
-                interface_settings = interface.get("openconfig-if-ethernet:ethernet", {}).get("openconfig-if-poe:poe", {})
+        poe_interfaces = response[0][1].get("openconfig-interfaces:interfaces", {}).get("interface", [])
+        for interface in poe_interfaces:
+            interface_settings = interface.get("openconfig-if-ethernet:ethernet", {}).get("openconfig-if-poe:poe", {})
                 if len(interface_settings) > 0:
                     interface_settings.update({"name": interface["name"]})
                     interface_poe_settings.append(interface_settings)
-        except Exception:
-            raise Exception("response from getting poe facts not formed as expected")
         formatted_specs = self.format_to_argspec(poe_config, interface_poe_settings)
         return formatted_specs

--- a/plugins/module_utils/network/sonic/facts/sflow/sflow.py
+++ b/plugins/module_utils/network/sonic/facts/sflow/sflow.py
@@ -53,17 +53,21 @@ class SflowFacts(object):
         if not data:
             data = self.get_sflow_info()
 
-        data = self.format_to_argspec(data)
+        # convert to argspec for ansible_facts
+        facts = {}
+        if data:
+            data = self.format_to_argspec(data)
 
-        # validate can add null values for things missing from device config,
-        #   so doing that before remove empties
-        cleaned_data = utils.remove_empties(
-            utils.validate_config(self.argument_spec, data)
-        )
+            # validate can add null values for things missing from device config,
+            #   so doing that before remove empties
+            cleaned_data = utils.remove_empties(
+                utils.validate_config(self.argument_spec, data)
+            )
+            if cleaned_data:
+                facts["sflow"] = cleaned_data["config"]
 
         ansible_facts['ansible_network_resources'].pop('sflow', None)
-        if cleaned_data:
-            ansible_facts['ansible_network_resources'].update({"sflow": cleaned_data["config"]})
+        ansible_facts['ansible_network_resources'].update(facts)
 
         return ansible_facts
 
@@ -121,7 +125,7 @@ class SflowFacts(object):
 
         response_body = {}
         try:
-            response_body = response[0][1][response_key]
+            response_body = response[0][1].get(response_key)
         except Exception:
             raise Exception("response from getting sflow facts not formed as expected")
 

--- a/plugins/module_utils/network/sonic/facts/system/system.py
+++ b/plugins/module_utils/network/sonic/facts/system/system.py
@@ -16,10 +16,12 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+
+from ansible.module_utils.connection import ConnectionError
+
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import (
     to_request,
-    edit_config,
-    edit_config_catch
+    edit_config
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.argspec.system.system import SystemArgs
 
@@ -91,7 +93,10 @@ class SystemFacts(object):
     def get_load_share_hash_algo(self):
         """Get load share hash algorithm"""
         request = [{"path": "data/openconfig-loadshare-mode-ext:loadshare/hash-algorithm/config", "method": GET}]
-        response = edit_config_catch(self._module, to_request(self._module, request))
+        try:
+            response = edit_config(self._module, to_request(self._module, request))
+        except ConnectionError as exc:
+            self._module.fail_json(msg=str(exc), code=exc.code)
         if ('openconfig-loadshare-mode-ext:config' in response[0][1]):
             data = response[0][1]['openconfig-loadshare-mode-ext:config']
         else:
@@ -101,7 +106,10 @@ class SystemFacts(object):
     def get_auditd_rules(self):
         """Get auditd rules configuration available in chassis"""
         request = [{"path": "data/openconfig-system:system/openconfig-system-ext:auditd-system", "method": GET}]
-        response = edit_config_catch(self._module, to_request(self._module, request))
+        try:
+            response = edit_config(self._module, to_request(self._module, request))
+        except ConnectionError as exc:
+            self._module.fail_json(msg=str(exc), code=exc.code)
         data = {}
         if response and response[0]:
             if len(response[0]) > 1:

--- a/plugins/module_utils/network/sonic/facts/system/system.py
+++ b/plugins/module_utils/network/sonic/facts/system/system.py
@@ -18,7 +18,8 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common i
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic import (
     to_request,
-    edit_config
+    edit_config,
+    edit_config_catch
 )
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.argspec.system.system import SystemArgs
 
@@ -90,10 +91,7 @@ class SystemFacts(object):
     def get_load_share_hash_algo(self):
         """Get load share hash algorithm"""
         request = [{"path": "data/openconfig-loadshare-mode-ext:loadshare/hash-algorithm/config", "method": GET}]
-        try:
-            response = edit_config(self._module, to_request(self._module, request))
-        except ConnectionError as exc:
-            self._module.fail_json(msg=str(exc), code=exc.code)
+        response = edit_config_catch(self._module, to_request(self._module, request))
         if ('openconfig-loadshare-mode-ext:config' in response[0][1]):
             data = response[0][1]['openconfig-loadshare-mode-ext:config']
         else:
@@ -103,10 +101,7 @@ class SystemFacts(object):
     def get_auditd_rules(self):
         """Get auditd rules configuration available in chassis"""
         request = [{"path": "data/openconfig-system:system/openconfig-system-ext:auditd-system", "method": GET}]
-        try:
-            response = edit_config(self._module, to_request(self._module, request))
-        except ConnectionError as exc:
-            self._module.fail_json(msg=str(exc), code=exc.code)
+        response = edit_config_catch(self._module, to_request(self._module, request))
         data = {}
         if response and response[0]:
             if len(response[0]) > 1:

--- a/plugins/module_utils/network/sonic/facts/vrfs/vrfs.py
+++ b/plugins/module_utils/network/sonic/facts/vrfs/vrfs.py
@@ -92,7 +92,7 @@ class VrfsFacts(object):
 
     def get_all_vrf_interfaces(self):
         """Get all the interfaces available in chassis"""
-        all_network_instatnces = {}
+        all_network_instances = {}
         request = [{"path": "data/openconfig-network-instance:network-instances", "method": GET}]
         try:
             response = edit_config(self._module, to_request(self._module, request))
@@ -100,8 +100,9 @@ class VrfsFacts(object):
             self._module.fail_json(msg=str(exc), code=exc.code)
 
         if "openconfig-network-instance:network-instances" in response[0][1]:
-            all_network_instatnces = response[0][1].get("openconfig-network-instance:network-instances", {})
-        return self.get_vrf_interfaces_from_network_instances(all_network_instatnces['network-instance'])
+            all_network_instances = response[0][1].get("openconfig-network-instance:network-instances", {})
+            network_instances = all_network_instances.get('network-instance', [])
+        return self.get_vrf_interfaces_from_network_instances(network_instances)
 
     def get_vrf_interfaces_from_network_instances(self, network_instances):
         vrf_interfaces = []

--- a/plugins/module_utils/network/sonic/facts/vxlans/vxlans.py
+++ b/plugins/module_utils/network/sonic/facts/vxlans/vxlans.py
@@ -125,6 +125,7 @@ class VxlansFacts(object):
         except ConnectionError as exc:
             self._module.fail_json(msg=str(exc), code=exc.code)
 
+        vxlan_vrf_list = {}
         if "sonic-vrf:VRF_LIST" in response[0][1]:
             vxlan_vrf_list = response[0][1].get("sonic-vrf:VRF_LIST", {})
 

--- a/plugins/module_utils/network/sonic/sonic.py
+++ b/plugins/module_utils/network/sonic/sonic.py
@@ -138,6 +138,7 @@ def edit_config(module, commands, skip_code=None):
     # End
     return connection.edit_config(commands)
 
+
 def edit_config_catch(module, commands, skip_code=None):
     connection = get_connection(module)
 
@@ -154,6 +155,7 @@ def edit_config_catch(module, commands, skip_code=None):
     except ConnectionError:
         response = [[{}, {}]]
     return response
+
 
 def edit_config_reboot(module, commands, skip_code=None):
     connection = get_connection(module)

--- a/plugins/module_utils/network/sonic/sonic.py
+++ b/plugins/module_utils/network/sonic/sonic.py
@@ -125,7 +125,7 @@ def run_commands(module, commands, check_rc=True):
         module.fail_json(msg=to_text(exc))
 
 
-def edit_config(module, commands, skip_code=None):
+def edit_config(module, commands, skip_code=None, suppr_ntf_excp=True):
     connection = get_connection(module)
 
     # Start: This is to convert interface name from Eth1/1 to Eth1%2f1
@@ -136,7 +136,11 @@ def edit_config(module, commands, skip_code=None):
             if url:
                 request["path"] = update_url(url)
     # End
-    return connection.edit_config(commands)
+    if suppr_ntf_excp:
+        # Default: not used for cliconf
+        return connection.edit_config(commands)
+    else:
+        return connection.edit_config(commands, suppr_ntf_excp)
 
 
 def edit_config_reboot(module, commands, skip_code=None):

--- a/plugins/module_utils/network/sonic/sonic.py
+++ b/plugins/module_utils/network/sonic/sonic.py
@@ -138,6 +138,22 @@ def edit_config(module, commands, skip_code=None):
     # End
     return connection.edit_config(commands)
 
+def edit_config_catch(module, commands, skip_code=None):
+    connection = get_connection(module)
+
+    # Start: This is to convert interface name from Eth1/1 to Eth1%2f1
+    for request in commands:
+        # This check is to differenciate between requests and commands
+        if isinstance(request, dict):
+            url = request.get("path", None)
+            if url:
+                request["path"] = update_url(url)
+    # End
+    try:
+        response = connection.edit_config(commands)
+    except ConnectionError:
+        response = [[{}, {}]]
+    return response
 
 def edit_config_reboot(module, commands, skip_code=None):
     connection = get_connection(module)

--- a/plugins/module_utils/network/sonic/sonic.py
+++ b/plugins/module_utils/network/sonic/sonic.py
@@ -130,31 +130,13 @@ def edit_config(module, commands, skip_code=None):
 
     # Start: This is to convert interface name from Eth1/1 to Eth1%2f1
     for request in commands:
-        # This check is to differenciate between requests and commands
+        # This check is to differentiate between requests and commands
         if isinstance(request, dict):
             url = request.get("path", None)
             if url:
                 request["path"] = update_url(url)
     # End
     return connection.edit_config(commands)
-
-
-def edit_config_catch(module, commands, skip_code=None):
-    connection = get_connection(module)
-
-    # Start: This is to convert interface name from Eth1/1 to Eth1%2f1
-    for request in commands:
-        # This check is to differenciate between requests and commands
-        if isinstance(request, dict):
-            url = request.get("path", None)
-            if url:
-                request["path"] = update_url(url)
-    # End
-    try:
-        response = connection.edit_config(commands)
-    except ConnectionError:
-        response = [[{}, {}]]
-    return response
 
 
 def edit_config_reboot(module, commands, skip_code=None):

--- a/plugins/modules/sonic_api.py
+++ b/plugins/modules/sonic_api.py
@@ -116,7 +116,7 @@ def initiate_request(module):
         request = to_request(module, [{"path": url, "method": method, "data": body}])
 
     try:
-        response = edit_config(module, request)
+        response = edit_config(module, request, suppr_ntf_excp=False)
     except ConnectionError as exc:
         module.fail_json(msg=to_text(exc))
     return response

--- a/tests/regression/roles/sonic_system/defaults/main.yml
+++ b/tests/regression/roles/sonic_system/defaults/main.yml
@@ -12,7 +12,8 @@ tests:
         ipv4: false
         ipv6: false
       auto_breakout: ENABLE
-      load_share_hash_algo: JENKINS_HASH_HI
+      # Use only on switch models that support this.
+      #load_share_hash_algo: JENKINS_HASH_HI
       audit_rules: BASIC
 
   - name: test_case_02
@@ -21,7 +22,8 @@ tests:
     input:
       hostname: SONIC-new
       interface_naming: standard_extended
-      load_share_hash_algo: JENKINS_HASH_LO 
+      # Use only on switch models that support this.
+      #load_share_hash_algo: JENKINS_HASH_LO 
       audit_rules: DETAIL
 
   - name: test_case_03
@@ -40,7 +42,8 @@ tests:
       anycast_address:
         ipv4: false
       auto_breakout: ENABLE
-      load_share_hash_algo: JENKINS_HASH_LO 
+      # Use only on switch models that support this.
+      #load_share_hash_algo: JENKINS_HASH_LO 
       audit_rules: BASIC
 
   - name: test_case_05
@@ -60,7 +63,8 @@ tests:
         ipv4: true
         mac_address: 00:09:5B:EC:EE:F2
       auto_breakout: ENABLE
-      load_share_hash_algo: CRC_XOR
+      # Use only on switch models that support this.
+      #load_share_hash_algo: CRC_XOR
       audit_rules: BASIC
 
   - name: test_case_07
@@ -83,7 +87,8 @@ tests:
       anycast_address:
         ipv4: true
       auto_breakout: ENABLE
-      load_share_hash_algo: CRC_32HI
+      # Use only on switch models that support this.
+      #load_share_hash_algo: CRC_32HI
       audit_rules: BASIC
   
   - name: test_case_09

--- a/tests/unit/modules/network/sonic/test_sonic_system.py
+++ b/tests/unit/modules/network/sonic/test_sonic_system.py
@@ -22,9 +22,6 @@ class TestSonicSystemModule(TestSonicModule):
         cls.mock_facts_edit_config = patch(
             "ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.system.system.edit_config"
         )
-        cls.mock_facts_edit_config_catch = patch(
-            "ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.system.system.edit_config_catch"
-        )
         cls.mock_config_edit_config = patch(
             "ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.config.system.system.edit_config"
         )
@@ -39,10 +36,8 @@ class TestSonicSystemModule(TestSonicModule):
     def setUp(self):
         super(TestSonicSystemModule, self).setUp()
         self.facts_edit_config = self.mock_facts_edit_config.start()
-        self.facts_edit_config_catch = self.mock_facts_edit_config_catch.start()
         self.config_edit_config = self.mock_config_edit_config.start()
         self.facts_edit_config.side_effect = self.facts_side_effect
-        self.facts_edit_config_catch.side_effect = self.facts_side_effect
         self.config_edit_config.side_effect = self.config_side_effect
         self.get_interface_naming_mode = self.mock_get_interface_naming_mode.start()
         self.get_interface_naming_mode.return_value = 'standard'
@@ -52,7 +47,6 @@ class TestSonicSystemModule(TestSonicModule):
     def tearDown(self):
         super(TestSonicSystemModule, self).tearDown()
         self.mock_facts_edit_config.stop()
-        self.mock_facts_edit_config_catch.stop()
         self.mock_config_edit_config.stop()
         self.mock_get_interface_naming_mode.stop()
         self.mock_utils_edit_config.stop()

--- a/tests/unit/modules/network/sonic/test_sonic_system.py
+++ b/tests/unit/modules/network/sonic/test_sonic_system.py
@@ -22,6 +22,9 @@ class TestSonicSystemModule(TestSonicModule):
         cls.mock_facts_edit_config = patch(
             "ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.system.system.edit_config"
         )
+        cls.mock_facts_edit_config_catch = patch(
+            "ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.facts.system.system.edit_config_catch"
+        )
         cls.mock_config_edit_config = patch(
             "ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.config.system.system.edit_config"
         )
@@ -36,8 +39,10 @@ class TestSonicSystemModule(TestSonicModule):
     def setUp(self):
         super(TestSonicSystemModule, self).setUp()
         self.facts_edit_config = self.mock_facts_edit_config.start()
+        self.facts_edit_config_catch = self.mock_facts_edit_config_catch.start()
         self.config_edit_config = self.mock_config_edit_config.start()
         self.facts_edit_config.side_effect = self.facts_side_effect
+        self.facts_edit_config_catch.side_effect = self.facts_side_effect
         self.config_edit_config.side_effect = self.config_side_effect
         self.get_interface_naming_mode = self.mock_get_interface_naming_mode.start()
         self.get_interface_naming_mode.return_value = 'standard'
@@ -47,6 +52,7 @@ class TestSonicSystemModule(TestSonicModule):
     def tearDown(self):
         super(TestSonicSystemModule, self).tearDown()
         self.mock_facts_edit_config.stop()
+        self.mock_facts_edit_config_catch.stop()
         self.mock_config_edit_config.stop()
         self.mock_get_interface_naming_mode.stop()
         self.mock_utils_edit_config.stop()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Modify the enterprise_sonic httapi plugin "edit_config" wrapper for invocation of the Ansible "send" utility to avoid playbook-aborting exceptions due to the unconditional "GET" REST API invocation done within the "system" resource module for the auditd and "ip loadshare hash" configuration. Modify this wrapper so that, when the new "suppress notification of exception" (suppr_ntf_excp) input flag is True, it returns a valid, but empty "response" for any GET request for which a "resource not found" (code '404') ConnectionError exception occurs instead of aborting the currently executing playbook with the ConnectionError exception. Because the auditd and "ip loadshare hash" configurations are only available in SONiC 4.4+, invoking these GETs on older versions of SONIC causes a ConnectionError exception to be raised in the Ansible "send" method of the HttpApi "connection"  object when a "resource not found" error is returned for the GET.

Because the "system" resource module facts collection function unconditionally performs the auditd and "ip loadshare hash algorithm" GET operations regardless of the SONiC version on the target device, this change is needed to enable downward compatibility of the "system" resource module for SONiC versions before 4.4.0. 

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_system
##### OUTPUT
<!--- Paste the functionality test result below -->
Regression test on a Z9664f switch (supporting ip loadshare hash algorithm configuration) with a recent 4.x_share image:

[system_downward_with_loadshare_latest_regression-2024-08-22-21-23-06.pdf](https://github.com/user-attachments/files/16724939/system_downward_with_loadshare_latest_regression-2024-08-22-21-23-06.pdf)


Regression test (conditional filter) with ip loadshare hash testing commented out on an s5296f switch, recent 4.x_share image:

[system_downward_conditional_httapi_filter_regression-2024-08-27-18-49-10.pdf](https://github.com/user-attachments/files/16776939/system_downward_conditional_httapi_filter_regression-2024-08-27-18-49-10.pdf)

Regression test on modules requiring fixes for empty GET response handling:

Note: The PoE test is not supported on the available test platforms, so only the PoE Unit Tests have been run.

[system_downward_empty_config_GET_fixes_regression-2024-08-29-04-49-32.zip](https://github.com/user-attachments/files/16796408/system_downward_empty_config_GET_fixes_regression-2024-08-29-04-49-32.zip)


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
System "gather facts" on a SONiC 4.2.1 image without the fix:

[gather_system_SONiC_4_2_1_failure.log](https://github.com/user-attachments/files/16724764/gather_system_SONiC_4_2_1_failure.log)

System "gather facts" on a SONiC 4.2.1 image with the conditionally enabled GET exception filter:

[sonic_api_get_httpapi_filter_SONiC_4_2_1_PR_mod.log](https://github.com/user-attachments/files/16776781/sonic_api_get_httpapi_filter_SONiC_4_2_1_PR_mod.log)

sonic_api "get" on a SONiC 4.x_share image with the conditionally enabled GET exception filter:

[sonic_api_get_httpapi_filter_SONiC_4_2_1_PR_mod.log](https://github.com/user-attachments/files/16776745/sonic_api_get_httpapi_filter_SONiC_4_2_1_PR_mod.log)

sonic_cli "show" on a SONiC 4.x_share image with the conditionally enabled GET exception filter:

[sonic_cli_show_httpapi_filter_SONiC_4_2_1_PR_mod.log](https://github.com/user-attachments/files/16776798/sonic_cli_show_httpapi_filter_SONiC_4_2_1_PR_mod.log)

PoE "gather facts" on a platform that doesn't support PoE (causing the empty config case that needs to be verified to confirm that empty configuration is returned and no exception occurs):

[poe_gather_facts_handle_empty.log](https://github.com/user-attachments/files/16796335/poe_gather_facts_handle_empty.log)

<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

See output above: I ran a playbook to gather "system" facts against a SONiC 4.2.1 image without the fix to demonstrate the failure and with the fix to demonstrate the effectiveness of the fix. I also ran the full "system" regression test on a z9664 switch supporting loadshare, and also the proposed "stubbed" system regression test with ip loadshare hash testing disabled on an s5296f.