### PR TITLE
Add import of the Ansible ConnectionError exception class for all files where it is used.

### DIFF
--- a/plugins/module_utils/network/sonic/config/bfd/bfd.py
+++ b/plugins/module_utils/network/sonic/config/bfd/bfd.py
@@ -14,6 +14,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from copy import deepcopy
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase
 )

--- a/plugins/module_utils/network/sonic/config/copp/copp.py
+++ b/plugins/module_utils/network/sonic/config/copp/copp.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from copy import deepcopy
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/dhcp_snooping/dhcp_snooping.py
+++ b/plugins/module_utils/network/sonic/config/dhcp_snooping/dhcp_snooping.py
@@ -16,6 +16,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/mac/mac.py
+++ b/plugins/module_utils/network/sonic/config/mac/mac.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from copy import deepcopy
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/ospf_area/ospf_area.py
+++ b/plugins/module_utils/network/sonic/config/ospf_area/ospf_area.py
@@ -14,6 +14,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from copy import deepcopy
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/pki/pki.py
+++ b/plugins/module_utils/network/sonic/config/pki/pki.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/poe/poe.py
+++ b/plugins/module_utils/network/sonic/config/poe/poe.py
@@ -16,6 +16,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/sonic/config/prefix_lists/prefix_lists.py
@@ -14,6 +14,7 @@ created
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/qos_buffer/qos_buffer.py
+++ b/plugins/module_utils/network/sonic/config/qos_buffer/qos_buffer.py
@@ -13,6 +13,7 @@ created
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/qos_interfaces/qos_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/qos_interfaces/qos_interfaces.py
@@ -14,6 +14,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from copy import deepcopy
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/qos_maps/qos_maps.py
+++ b/plugins/module_utils/network/sonic/config/qos_maps/qos_maps.py
@@ -14,6 +14,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from copy import deepcopy
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/qos_pfc/qos_pfc.py
+++ b/plugins/module_utils/network/sonic/config/qos_pfc/qos_pfc.py
@@ -14,6 +14,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from copy import deepcopy
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/qos_scheduler/qos_scheduler.py
+++ b/plugins/module_utils/network/sonic/config/qos_scheduler/qos_scheduler.py
@@ -14,6 +14,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from copy import deepcopy
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/qos_wred/qos_wred.py
+++ b/plugins/module_utils/network/sonic/config/qos_wred/qos_wred.py
@@ -20,6 +20,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.c
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
 )
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     get_diff,
     remove_empties_from_list,

--- a/plugins/module_utils/network/sonic/config/roce/roce.py
+++ b/plugins/module_utils/network/sonic/config/roce/roce.py
@@ -13,6 +13,7 @@ created
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/route_maps/route_maps.py
+++ b/plugins/module_utils/network/sonic/config/route_maps/route_maps.py
@@ -18,6 +18,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/sflow/sflow.py
+++ b/plugins/module_utils/network/sonic/config/sflow/sflow.py
@@ -15,6 +15,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/config/static_routes/static_routes.py
+++ b/plugins/module_utils/network/sonic/config/static_routes/static_routes.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from copy import deepcopy
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )

--- a/plugins/module_utils/network/sonic/facts/bfd/bfd.py
+++ b/plugins/module_utils/network/sonic/facts/bfd/bfd.py
@@ -14,6 +14,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )

--- a/plugins/module_utils/network/sonic/facts/copp/copp.py
+++ b/plugins/module_utils/network/sonic/facts/copp/copp.py
@@ -18,6 +18,7 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     remove_empties
 )

--- a/plugins/module_utils/network/sonic/facts/mac/mac.py
+++ b/plugins/module_utils/network/sonic/facts/mac/mac.py
@@ -14,6 +14,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )

--- a/plugins/module_utils/network/sonic/facts/mgmt_servers/mgmt_servers.py
+++ b/plugins/module_utils/network/sonic/facts/mgmt_servers/mgmt_servers.py
@@ -14,6 +14,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )

--- a/plugins/module_utils/network/sonic/facts/ospf_area/ospf_area.py
+++ b/plugins/module_utils/network/sonic/facts/ospf_area/ospf_area.py
@@ -14,6 +14,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_empties,
     validate_config,

--- a/plugins/module_utils/network/sonic/facts/pki/pki.py
+++ b/plugins/module_utils/network/sonic/facts/pki/pki.py
@@ -16,6 +16,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )

--- a/plugins/module_utils/network/sonic/facts/poe/poe.py
+++ b/plugins/module_utils/network/sonic/facts/poe/poe.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.argspec.poe.poe import PoeArgs
 
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic \

--- a/plugins/module_utils/network/sonic/facts/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/sonic/facts/prefix_lists/prefix_lists.py
@@ -19,6 +19,7 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible.module_utils.connection import ConnectionError
 
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils \
     import (

--- a/plugins/module_utils/network/sonic/facts/qos_interfaces/qos_interfaces.py
+++ b/plugins/module_utils/network/sonic/facts/qos_interfaces/qos_interfaces.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     remove_empties_from_list
 )

--- a/plugins/module_utils/network/sonic/facts/qos_maps/qos_maps.py
+++ b/plugins/module_utils/network/sonic/facts/qos_maps/qos_maps.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     remove_empties
 )

--- a/plugins/module_utils/network/sonic/facts/qos_pfc/qos_pfc.py
+++ b/plugins/module_utils/network/sonic/facts/qos_pfc/qos_pfc.py
@@ -14,6 +14,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )

--- a/plugins/module_utils/network/sonic/facts/qos_scheduler/qos_scheduler.py
+++ b/plugins/module_utils/network/sonic/facts/qos_scheduler/qos_scheduler.py
@@ -14,6 +14,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )

--- a/plugins/module_utils/network/sonic/facts/qos_wred/qos_wred.py
+++ b/plugins/module_utils/network/sonic/facts/qos_wred/qos_wred.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     remove_empties_from_list
 )

--- a/plugins/module_utils/network/sonic/facts/roce/roce.py
+++ b/plugins/module_utils/network/sonic/facts/roce/roce.py
@@ -14,6 +14,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )

--- a/plugins/module_utils/network/sonic/facts/route_maps/route_maps.py
+++ b/plugins/module_utils/network/sonic/facts/route_maps/route_maps.py
@@ -18,6 +18,7 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.argspec.route_maps.route_maps import Route_mapsArgs
 
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import remove_empties_from_list

--- a/plugins/module_utils/network/sonic/facts/sflow/sflow.py
+++ b/plugins/module_utils/network/sonic/facts/sflow/sflow.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.argspec.sflow.sflow import SflowArgs
 
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.sonic \

--- a/plugins/module_utils/network/sonic/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/sonic/facts/static_routes/static_routes.py
@@ -15,6 +15,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )

--- a/plugins/module_utils/network/sonic/facts/stp/stp.py
+++ b/plugins/module_utils/network/sonic/facts/stp/stp.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.dellemc.enterprise_sonic.plugins.module_utils.network.sonic.utils.utils import (
     remove_empties
 )

--- a/plugins/module_utils/network/sonic/utils/interfaces_util.py
+++ b/plugins/module_utils/network/sonic/utils/interfaces_util.py
@@ -30,6 +30,7 @@ import json
 import re
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.connection import ConnectionError
 
 try:
     from urllib import quote


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Many of the files in the enterprise_sonic resource module had references to "ConnectionError" in try/except blocks without the needed import for the intended Ansible definition for this exception. As a result, the intended catching of this exception was not functional for these references.

This PR adds the needed import for all files where it was previously missing.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ConnectionError

##### OUTPUT
<!--- Paste the functionality test result below -->

To verify that all required files have been fixed, the following command was executed in the workspace where the fix was coded:

```
kerry@opensuse155:~/import_ConnectionError/dellemc.enterprise_sonic> grep -R 'ConnectionError' > ~/garb_all_ConnectionError_references.txt
```
It is easy to verify the fix by checking that the needed "import" is the first instance of ConnectionError for all code files appearing the the search result file.


[garb_all_ConnectionError_references.txt](https://github.com/user-attachments/files/16822891/garb_all_ConnectionError_references.txt)


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

See the "Output" section above.