### PR TITLE
Add a sanity "ignore" file for the new Ansible core version 2.19.

### DIFF
--- a/changelogs/fragments/456-tests-sanity-ignore-action-plugin-for-ansible-2.19.yaml
+++ b/changelogs/fragments/456-tests-sanity-ignore-action-plugin-for-ansible-2.19.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - tests - Skip Ansible 2.19 checking for a module correspnding to the sonic.py action plugin to avoid invalid sanity failures (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/456).

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,1 @@
+plugins/action/sonic.py action-plugin-docs #action plugin for base class


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When Ansible deploys a new core release, the sanity matrix test for the new core release flags an error for the "sonic.py" action plugin because there is no corresponding resource module containing documentation. To work around the flagging of these misleading sanity errors, we have placed an "ignore" file for each Ansible core version in our "tests/sanity" folder. The new Ansible core 2.19 release has just been deployed, so this PR provides the corresponding "ignore" file for that release.
##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests
##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [ ] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Re-run the previously failing sanity tests to verify that they now pass:

```
All checks have passed
15 successful checks
```
