### PR TITLE
Add new 'message_type' choice to the logging resource module

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/logging/logging.py
+++ b/plugins/module_utils/network/sonic/argspec/logging/logging.py
@@ -45,7 +45,7 @@ class LoggingArgs(object):  # pylint: disable=R0903
                     'options': {
                         'host': {'required': True,
                                  'type': 'str'},
-                        'message_type': {'choices': ['log', 'event', 'audit'],
+                        'message_type': {'choices': ['log', 'event', 'audit', 'auditd-system'],
                                          'type': 'str'},
                         'remote_port': {'type': 'int'},
                         'source_interface': {'type': 'str'},

--- a/plugins/modules/sonic_logging.py
+++ b/plugins/modules/sonic_logging.py
@@ -76,6 +76,7 @@ options:
               - log
               - event
               - audit
+              - auditd-system
           protocol:
             type: str
             description:
@@ -198,7 +199,7 @@ EXAMPLES = """
           remote_port: 622
           protocol: TCP
           source_interface: Ethernet24
-          message_type: audit
+          message_type: auditd-system
     state: overridden
 #
 # After state:

--- a/tests/regression/roles/sonic_logging/defaults/main.yml
+++ b/tests/regression/roles/sonic_logging/defaults/main.yml
@@ -41,7 +41,7 @@ tests:
           source_interface: "{{ vlan1 }}"
           remote_port: 818
           protocol: TCP
-          message_type: event
+          message_type: auditd-system
           vrf: Vrf_logging_2
         - host: "{{ logging_ip_server_7 }}"
           source_interface: "{{ vlan1 }}"
@@ -90,7 +90,7 @@ tests:
           source_interface: "{{ interface5 }}"
           remote_port: 818
           protocol: TLS
-          message_type: event
+          message_type: auditd-system
 
   - name: test_case_05
     description: Overridden logging remote servers
@@ -120,7 +120,7 @@ tests:
           source_interface: "{{ vlan1 }}"
           remote_port: 818
           protocol: UDP
-          message_type: audit
+          message_type: auditd-system
           vrf: Vrf_logging_2
         - host: "{{ logging_host_server }}"
           source_interface: "{{ lo1 }}"


### PR DESCRIPTION
##### SUMMARY
Add new 'message_type' choice to the logging resource module.

##### GitHub Issues
"N/A".


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
sonic_logging

##### OUTPUT

##### Ansible Report:
[new_message_type.pdf](https://github.com/user-attachments/files/17214939/new_message_type.pdf)


##### Raw Regression Test Output:

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [ ] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] I ran different ansible playbooks to test that the new 'message_type' choice is being merged, replaced, deleted, and overriden the correct way.
- [x] Ran a regression test (attached above)

