### PR TITLE
Allow handling of vlan ID values containing more then one digit.

### DIFF
--- a/changelogs/fragments/460-stp-long-int-vlan-fix.yaml
+++ b/changelogs/fragments/460-stp-long-int-vlan-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_stp - Change the criteria for converting vlans and vlan ranges to handle vlan IDs with more than one digit (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/460).

--- a/plugins/module_utils/network/sonic/config/stp/stp.py
+++ b/plugins/module_utils/network/sonic/config/stp/stp.py
@@ -669,10 +669,10 @@ class Stp(ConfigBase):
         converted_vlans = []
 
         for vlan in vlans:
-            if len(vlan) == 1:
-                converted_vlans.append(int(vlan))
-            else:
+            if '-' in vlan:
                 converted_vlans.append(vlan.replace('-', '..'))
+            else:
+                converted_vlans.append(int(vlan))
 
         return converted_vlans
 

--- a/tests/regression/roles/sonic_stp/defaults/main.yml
+++ b/tests/regression/roles/sonic_stp/defaults/main.yml
@@ -60,7 +60,7 @@ tests:
           - mst_id: 1
             bridge_priority: 2048
             vlans:
-              - 1
+              - 301
             interfaces:
               - intf_name: '{{ interface1 }}'
                 cost: 60
@@ -68,7 +68,7 @@ tests:
           - mst_id: 2
             bridge_priority: 1024
             vlans:
-              - 2
+              - 302
             interfaces:
               - intf_name: '{{ interface2 }}'
                 cost: 50
@@ -82,7 +82,7 @@ tests:
           - mst_id: 1
             bridge_priority: 1024
             vlans:
-              - 2-3
+              - 302-303
           - mst_id: 2
             interfaces:
               - intf_name: '{{ interface2 }}'
@@ -118,7 +118,7 @@ tests:
         mst_instances:
           - mst_id: 1
             vlans:
-              - 1
+              - 301
             interfaces:
               - intf_name: '{{ interface1 }}'
                 cost: 70
@@ -126,7 +126,7 @@ tests:
           - mst_id: 2
             bridge_priority: 2048
             vlans:
-              - 1-3
+              - 301-303
             interfaces:
               - intf_name: '{{ interface2 }}'
                 cost: 52
@@ -150,7 +150,7 @@ tests:
           - mst_id: 2
             bridge_priority: 2048
             vlans:
-              - 2
+              - 302
             interfaces:
               - intf_name: '{{ interface2 }}'
                 cost: 52
@@ -176,7 +176,7 @@ tests:
         fwd_delay: 20
         bridge_priority: 4096
       pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 4
           max_age: 6
           fwd_delay: 8
@@ -185,7 +185,7 @@ tests:
             - intf_name: '{{ interface1 }}'
               cost: 10
               port_priority: 50
-        - vlan_id: 2
+        - vlan_id: 302
           hello_time: 5
           max_age: 7
           fwd_delay: 9
@@ -202,12 +202,12 @@ tests:
     state: replaced
     input:
       pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 7
           max_age: 8
           fwd_delay: 9
           bridge_priority: 8192
-        - vlan_id: 2
+        - vlan_id: 302
           interfaces:
             - intf_name: '{{ interface2 }}'
               cost: 2
@@ -220,12 +220,12 @@ tests:
     state: merged
     input:
       pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           interfaces:
             - intf_name: '{{ interface1 }}'
               cost: 11
               port_priority: 51
-        - vlan_id: 2
+        - vlan_id: 302
           hello_time: 3
           max_age: 9
           fwd_delay: 11
@@ -235,7 +235,7 @@ tests:
     state: deleted
     input:
       pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 7
           max_age: 8
           fwd_delay: 9
@@ -243,7 +243,7 @@ tests:
           interfaces:
             - intf_name: '{{ interface1 }}'
               cost: 11
-        - vlan_id: 2
+        - vlan_id: 302
           interfaces:
             - intf_name: '{{ interface2 }}'
             - intf_name: '{{ interface3 }}'
@@ -268,7 +268,7 @@ tests:
         fwd_delay: 20
         bridge_priority: 4096
       rapid_pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 4
           max_age: 6
           fwd_delay: 8
@@ -277,7 +277,7 @@ tests:
             - intf_name: '{{ interface1 }}'
               cost: 10
               port_priority: 50
-        - vlan_id: 2
+        - vlan_id: 302
           hello_time: 5
           max_age: 7
           fwd_delay: 9
@@ -294,12 +294,12 @@ tests:
     state: replaced
     input:
       rapid_pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 7
           max_age: 8
           fwd_delay: 9
           bridge_priority: 8192
-        - vlan_id: 2
+        - vlan_id: 302
           interfaces:
             - intf_name: '{{ interface2 }}'
               cost: 2
@@ -312,12 +312,12 @@ tests:
     state: merged
     input:
       rapid_pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           interfaces:
             - intf_name: '{{ interface1 }}'
               cost: 11
               port_priority: 51
-        - vlan_id: 2
+        - vlan_id: 302
           hello_time: 3
           max_age: 9
           fwd_delay: 11
@@ -327,7 +327,7 @@ tests:
     state: deleted
     input:
       rapid_pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 7
           max_age: 8
           fwd_delay: 9
@@ -336,7 +336,7 @@ tests:
             - intf_name: '{{ interface1 }}'
               cost: 11
               port_priority: 51
-        - vlan_id: 2
+        - vlan_id: 302
           interfaces:
             - intf_name: '{{ interface2 }}'
             - intf_name: '{{ interface3 }}'
@@ -507,7 +507,7 @@ tests:
           - mst_id: 1
             bridge_priority: 2048
             vlans:
-              - 1
+              - 301
             interfaces:
               - intf_name: '{{ interface1 }}'
                 cost: 60
@@ -515,7 +515,7 @@ tests:
           - mst_id: 2
             bridge_priority: 1024
             vlans:
-              - 2
+              - 302
             interfaces:
               - intf_name: '{{ interface2 }}'
                 cost: 50

--- a/tests/regression/roles/sonic_stp/tasks/preparation_tests.yaml
+++ b/tests/regression/roles/sonic_stp/tasks/preparation_tests.yaml
@@ -19,12 +19,12 @@
 - name: Add VLANs
   sonic_vlans:
     config:
-      - vlan_id: 1
-      - vlan_id: 2
-      - vlan_id: 3
-      - vlan_id: 4
-      - vlan_id: 5
-      - vlan_id: 6
+      - vlan_id: 301
+      - vlan_id: 302
+      - vlan_id: 303
+      - vlan_id: 304
+      - vlan_id: 305
+      - vlan_id: 306
     state: merged
   ignore_errors: yes
 
@@ -34,14 +34,14 @@
       - name: '{{ interface1 }}'
         trunk:
           allowed_vlans:
-            - vlan: 1-3
+            - vlan: 301-303
       - name: '{{ interface2 }}'
         trunk:
           allowed_vlans:
-            - vlan: 1-3
+            - vlan: 301-303
       - name: '{{ interface3 }}'
         trunk:
           allowed_vlans:
-            - vlan: 1-3
+            - vlan: 301-303
     state: merged
   ignore_errors: yes

--- a/tests/unit/modules/network/sonic/fixtures/sonic_stp.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_stp.yaml
@@ -7,7 +7,7 @@ merged_01:
         loop_guard: true
         bpdu_filter: true
         disabled_vlans:
-          - 4-6
+          - 304-306
         hello_time: 5
         max_age: 10
         fwd_delay: 15
@@ -36,7 +36,7 @@ merged_01:
           - mst_id: 1
             bridge_priority: 2048
             vlans:
-              - 1
+              - 301
             interfaces:
               - intf_name: Ethernet20
                 cost: 60
@@ -56,7 +56,7 @@ merged_01:
             loop-guard: True 
             bpdu-filter: True 
             openconfig-spanning-tree-ext:disabled-vlans: 
-              - '4..6' 
+              - '304..306' 
             openconfig-spanning-tree-ext:hello-time: 5 
             openconfig-spanning-tree-ext:max-age: 10 
             openconfig-spanning-tree-ext:forwarding-delay: 15
@@ -98,7 +98,7 @@ merged_01:
                   mst-id: 1
                   bridge-priority: 2048
                   vlan:
-                    - 1
+                    - 301
                 interfaces:
                   interface:
                     - name: Ethernet20
@@ -119,7 +119,7 @@ merged_02:
         fwd_delay: 20
         bridge_priority: 4096
       pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 4
           max_age: 6
           fwd_delay: 8
@@ -152,9 +152,9 @@ merged_02:
       data:
         openconfig-spanning-tree-ext:pvst: 
           vlans: 
-            - vlan-id: 1
+            - vlan-id: 301
               config: 
-                vlan-id: 1 
+                vlan-id: 301 
                 hello-time: 4 
                 max-age: 6 
                 forwarding-delay: 8 
@@ -178,7 +178,7 @@ merged_03:
         fwd_delay: 20
         bridge_priority: 4096
       rapid_pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 4
           max_age: 6
           fwd_delay: 8
@@ -210,9 +210,9 @@ merged_03:
       data:
         openconfig-spanning-tree:rapid-pvst:
           vlan:
-            - vlan-id: 1
+            - vlan-id: 301
               config:
-                vlan-id: 1
+                vlan-id: 301
                 hello-time: 4
                 max-age: 6
                 forwarding-delay: 8
@@ -291,7 +291,7 @@ replaced_02:
                     config:
                       mst-id: 1
                       vlan:
-                        - 1
+                        - 301
                       bridge-priority: 2048
                     interfaces:
                       interface:
@@ -328,7 +328,7 @@ replaced_03:
           - mst_id: 1
             bridge_priority: 1024
             vlans:
-              - 2-3
+              - 302-303
     state: replaced
   existing_stp_config:
     - path: "/data/openconfig-spanning-tree:stp"
@@ -343,7 +343,7 @@ replaced_03:
                     config: 
                       mst-id: 1
                       vlan:
-                        - 1 
+                        - 301 
                       bridge-priority: 2048
   expected_config_requests:
     - path: "data/openconfig-spanning-tree:stp/mstp/mst-instances/mst-instance=1"
@@ -360,17 +360,17 @@ replaced_03:
                   mst-id: 1
                   bridge-priority: 1024 
                   vlan: 
-                    - '2..3'
+                    - '302..303'
 replaced_04:
   module_args:
     config:
       pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 7
           max_age: 8
           fwd_delay: 9
           bridge_priority: 8192
-        - vlan_id: 2
+        - vlan_id: 302
           interfaces:
             - intf_name: Ethernet20
               cost: 2
@@ -384,9 +384,9 @@ replaced_04:
           openconfig-spanning-tree:stp:
             openconfig-spanning-tree-ext:pvst:
               vlans:
-                - vlan-id: 1
+                - vlan-id: 301
                   config:
-                    vlan-id: 1
+                    vlan-id: 301
                     hello-time: 6
                     max-age: 7
                     forwarding-delay: 8
@@ -398,7 +398,7 @@ replaced_04:
                           name: Ethernet24
                           cost: 40
                           port-priority: 45
-                - vlan-id: 2
+                - vlan-id: 302
                   interfaces:
                     interface:
                       - name: Ethernet20
@@ -407,22 +407,22 @@ replaced_04:
                           cost: 1
                           port-priority: 55
   expected_config_requests:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/config/hello-time"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/config/hello-time"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/config/max-age"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/config/max-age"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/config/forwarding-delay"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/config/forwarding-delay"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/config/bridge-priority"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/config/bridge-priority"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/interfaces/interface=Ethernet24"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/interfaces/interface=Ethernet24"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=2/interfaces/interface=Ethernet20"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=302/interfaces/interface=Ethernet20"
       method: "delete"
       data:
     - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst"
@@ -430,14 +430,14 @@ replaced_04:
       data:
         openconfig-spanning-tree-ext:pvst:
           vlans:
-            - vlan-id: 1
+            - vlan-id: 301
               config:
-                vlan-id: 1
+                vlan-id: 301
                 hello-time: 7
                 max-age: 8
                 forwarding-delay: 9
                 bridge-priority: 8192
-            - vlan-id: 2
+            - vlan-id: 302
               interfaces:
                 interface:
                   - name: Ethernet20
@@ -449,12 +449,12 @@ replaced_05:
   module_args:
     config:
       rapid_pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 7
           max_age: 8
           fwd_delay: 9
           bridge_priority: 8192
-        - vlan_id: 2
+        - vlan_id: 302
           interfaces:
             - intf_name: Ethernet20
               cost: 2
@@ -468,9 +468,9 @@ replaced_05:
           openconfig-spanning-tree:stp:
             rapid-pvst:
               vlan:
-                - vlan-id: 1
+                - vlan-id: 301
                   config:
-                    vlan-id: 1
+                    vlan-id: 301
                     hello-time: 6
                     max-age: 7
                     forwarding-delay: 8
@@ -482,7 +482,7 @@ replaced_05:
                           name: Ethernet24
                           cost: 40
                           port-priority: 45
-                - vlan-id: 2
+                - vlan-id: 302
                   interfaces:
                     interface:
                       - name: Ethernet20
@@ -491,22 +491,22 @@ replaced_05:
                           cost: 1
                           port-priority: 55
   expected_config_requests:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/config/hello-time"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/config/hello-time"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/config/max-age"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/config/max-age"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/config/forwarding-delay"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/config/forwarding-delay"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/config/bridge-priority"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/config/bridge-priority"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/interfaces/interface=Ethernet24"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/interfaces/interface=Ethernet24"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=2/interfaces/interface=Ethernet20"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=302/interfaces/interface=Ethernet20"
       method: "delete"
       data:
     - path: "data/openconfig-spanning-tree:stp/rapid-pvst"
@@ -514,16 +514,16 @@ replaced_05:
       data:
         openconfig-spanning-tree:rapid-pvst:
           vlan:
-            - vlan-id: 1
+            - vlan-id: 301
               config:
-                vlan-id: 1
+                vlan-id: 301
                 hello-time: 7
                 max-age: 8
                 forwarding-delay: 9
                 bridge-priority: 8192
-            - vlan-id: 2
+            - vlan-id: 302
               config:
-                vlan-id: 2
+                vlan-id: 302
               interfaces:
                 interface:
                   - name: Ethernet20
@@ -539,7 +539,7 @@ replaced_06:
         loop_guard: true
         bpdu_filter: true
         disabled_vlans:
-          - 4-6
+          - 304-306
         hello_time: 5
         max_age: 10
         fwd_delay: 15
@@ -576,7 +576,7 @@ replaced_06:
             loop-guard: True
             bpdu-filter: True
             openconfig-spanning-tree-ext:disabled-vlans:
-              - '4..6'
+              - '304..306'
             openconfig-spanning-tree-ext:hello-time: 5
             openconfig-spanning-tree-ext:max-age: 10
             openconfig-spanning-tree-ext:bridge-priority: 4096
@@ -649,7 +649,7 @@ overridden_01:
         loop_guard: true
         bpdu_filter: true
         disabled_vlans:
-          - 4-6
+          - 304-306
         hello_time: 5
         max_age: 10
         fwd_delay: 15
@@ -686,7 +686,7 @@ overridden_01:
             loop-guard: True
             bpdu-filter: True
             openconfig-spanning-tree-ext:disabled-vlans:
-              - '4..6'
+              - '304..306'
             openconfig-spanning-tree-ext:hello-time: 5
             openconfig-spanning-tree-ext:max-age: 10
             openconfig-spanning-tree-ext:forwarding-delay: 15
@@ -699,7 +699,7 @@ deleted_01:
         loop_guard: true
         bpdu_filter: true
         disabled_vlans:
-          - 4-6
+          - 304-306
         root_guard_timeout: 25
         portfast: true
         hello_time: 5
@@ -720,7 +720,7 @@ deleted_01:
                 loop-guard: True
                 bpdu-filter: True
                 openconfig-spanning-tree-ext:disabled-vlans:
-                   - 4-6
+                   - 304-306
                 openconfig-spanning-tree-ext:rootguard-timeout: 25
                 openconfig-spanning-tree-ext:portfast: True
                 openconfig-spanning-tree-ext:hello-time: 5
@@ -737,7 +737,7 @@ deleted_01:
     - path: "data/openconfig-spanning-tree:stp/global/config/bpdu-filter"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/global/config/openconfig-spanning-tree-ext:disabled-vlans=4..6"
+    - path: "data/openconfig-spanning-tree:stp/global/config/openconfig-spanning-tree-ext:disabled-vlans=304..306"
       method: "delete"
       data:
     - path: "data/openconfig-spanning-tree:stp/global/config/openconfig-spanning-tree-ext:rootguard-timeout"
@@ -857,7 +857,7 @@ deleted_03:
   module_args:
     config:
       pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 7
           max_age: 8
           fwd_delay: 9
@@ -876,9 +876,9 @@ deleted_03:
           openconfig-spanning-tree:stp:
             openconfig-spanning-tree-ext:pvst:
               vlans:
-                - vlan-id: 1
+                - vlan-id: 301
                   config:
-                    vlan-id: 1
+                    vlan-id: 301
                     hello-time: 7
                     max-age: 8
                     forwarding-delay: 9
@@ -895,7 +895,7 @@ deleted_03:
                           name: Ethernet24
                           cost: 3
                           port-priority: 50
-                - vlan-id: 2
+                - vlan-id: 302
                   interfaces:
                     interface:
                       - name: Ethernet20
@@ -904,32 +904,32 @@ deleted_03:
                           cost: 2
                           port-priority: 60
   expected_config_requests:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/config/hello-time"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/config/hello-time"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/config/max-age"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/config/max-age"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/config/forwarding-delay"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/config/forwarding-delay"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/config/bridge-priority"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/config/bridge-priority"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/interfaces/interface=Ethernet24/config/cost"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/interfaces/interface=Ethernet24/config/cost"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/interfaces/interface=Ethernet24/config/port-priority"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/interfaces/interface=Ethernet24/config/port-priority"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=1/interfaces/interface=Ethernet20"
+    - path: "data/openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans=301/interfaces/interface=Ethernet20"
       method: "delete"
       data:
 deleted_04:
   module_args:
     config:
       rapid_pvst:
-        - vlan_id: 1
+        - vlan_id: 301
           hello_time: 7
           max_age: 8
           fwd_delay: 9
@@ -948,9 +948,9 @@ deleted_04:
           openconfig-spanning-tree:stp:
             rapid-pvst:
               vlan:
-                - vlan-id: 1
+                - vlan-id: 301
                   config:
-                    vlan-id: 1
+                    vlan-id: 301
                     hello-time: 7
                     max-age: 8
                     forwarding-delay: 9
@@ -967,7 +967,7 @@ deleted_04:
                           name: Ethernet24
                           cost: 3
                           port-priority: 50
-                - vlan-id: 2
+                - vlan-id: 302
                   interfaces:
                     interface:
                       - name: Ethernet20
@@ -976,24 +976,24 @@ deleted_04:
                           cost: 2
                           port-priority: 60
   expected_config_requests:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/config/hello-time"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/config/hello-time"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/config/max-age"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/config/max-age"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/config/forwarding-delay"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/config/forwarding-delay"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/config/bridge-priority"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/config/bridge-priority"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/interfaces/interface=Ethernet24/config/cost"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/interfaces/interface=Ethernet24/config/cost"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/interfaces/interface=Ethernet24/config/port-priority"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/interfaces/interface=Ethernet24/config/port-priority"
       method: "delete"
       data:
-    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=1/interfaces/interface=Ethernet20"
+    - path: "data/openconfig-spanning-tree:stp/rapid-pvst/vlan=301/interfaces/interface=Ethernet20"
       method: "delete"
       data:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A utility function used in this resource module for converting incoming vlan IDs and vlan ranges for use in REST APIs used an incorrect criterion for distinguishing an individual vlan ID from a vlan range. It assumed that the length of the incoming "vlan_id" string would be 1 for an individual vlan and longer for a range. As a result, it failed to correctly recognize an individual vlan ID with more than one digit. Because the "problem" cases were all handled by this shared function, a simple fix in this utility function is sufficient for fixing the problem in the cases where it would have occurred.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_stp

##### OUTPUT
<!--- Paste the functionality test result below -->

STP regression test summary:

[STP_multi_digit_vlan_regression_2024_1004.pdf](https://github.com/user-attachments/files/17282133/STP_multi_digit_vlan_regression_2024_1004.pdf)


<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?

- playbooks using each of the allowed forms of vlans in a list
- regression test execution 
