### PR TITLE
Ospf area bugfix

### DIFF
--- a/changelogs/fragments/466-ospf-area-bugfix.yaml
+++ b/changelogs/fragments/466-ospf-area-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_ospf_area - Fix OSPF area bug (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/466).

--- a/plugins/module_utils/network/sonic/config/ospf_area/ospf_area.py
+++ b/plugins/module_utils/network/sonic/config/ospf_area/ospf_area.py
@@ -974,10 +974,11 @@ class Ospf_area(ConfigBase):
             # actually clearing stuff means deleting area
             # area having nothing related to stub also ends up in this case. requests will be empty.
             return True, requests, len(requests) > 0
-        elif len(requests) > 0:
-            # clearing some of the settings in stub but not all
-            # commands has to be a subset of have and whatever in it is translated into requests
-            return False, requests, False
+
+        # clearing some of the settings in stub but not all
+        # commands has to be a subset of have and whatever in it is translated into requests or
+        # there are no requests
+        return False, requests, False
 
     def build_area_delete_networks_requests(self, request_root, commands, have):
         if commands is None:

--- a/plugins/module_utils/network/sonic/config/ospf_area/ospf_area.py
+++ b/plugins/module_utils/network/sonic/config/ospf_area/ospf_area.py
@@ -975,9 +975,8 @@ class Ospf_area(ConfigBase):
             # area having nothing related to stub also ends up in this case. requests will be empty.
             return True, requests, len(requests) > 0
 
-        # clearing some of the settings in stub but not all
-        # commands has to be a subset of have and whatever in it is translated into requests or
-        # there are no requests
+        # Not all stub configuration is being deleted. (It is also possible that none of the stub options requested
+        # for deletion match any current configuration. In that case, no stub configuration is being deleted.)
         return False, requests, False
 
     def build_area_delete_networks_requests(self, request_root, commands, have):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed bug in delete method where there was no condition handling the case of no requests to delete.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_ospf_area

##### OUTPUT
failing report:
[regression-2024-10-10-13-44-49.html.pdf](https://github.com/user-attachments/files/17335364/regression-2024-10-10-13-44-49.html.pdf)

<!--- Paste the functionality test result below -->
Passing report after change:
[regression-2024-10-10-14-42-02.html.pdf](https://github.com/user-attachments/files/17334607/regression-2024-10-10-14-42-02.html.pdf)

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained the previous code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)