### PR TITLE
Fix ansible_password typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Sample playbooks
 
     # Common parameters for connection type httpapi or network_cli:
     ansible_user: xxxx
-    ansible_pass: xxxx
+    ansible_password: xxxx
     ansible_network_os: dellemc.enterprise_sonic.sonic
 
     # Additional parameters for connection type httpapi:


### PR DESCRIPTION
##### SUMMARY
`ansible_pass` doesn't exist and is a typo for `ansible_password`, as used everywhere else expect in the README.

##### GitHub Issues
N/A

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README.md

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)
