### PR TITLE
Remove conditional error message for speed configuration in sonic_interfaces

### DIFF
--- a/changelogs/fragments/470-interfaces-speed-bugfix.yaml
+++ b/changelogs/fragments/470-interfaces-speed-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_interfaces - Remove conditional error message for speed configuration (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/470).

--- a/changelogs/fragments/470-interfaces-speed-bugfix.yaml
+++ b/changelogs/fragments/470-interfaces-speed-bugfix.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - sonic_interfaces - Remove conditional error message for speed configuration (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/470).
+  - sonic_interfaces - Remove the restriction preventing configuration of interface speed for port channel member interfaces (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/470).

--- a/plugins/module_utils/network/sonic/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/sonic/config/interfaces/interfaces.py
@@ -448,8 +448,6 @@ class Interfaces(ConfigBase):
         else:
             payload['openconfig-if-ethernet:config'][payload_attr] = c_attr
             if attr == 'speed':
-                if self.is_port_in_port_group(intf_name):
-                    self._module.fail_json(msg='Unable to configure speed in port group member. Please use port group module to change the speed')
                 payload['openconfig-if-ethernet:config'][payload_attr] = 'openconfig-if-ethernet:' + c_attr
             if attr == 'advertised_speed':
                 c_ads = c_attr if c_attr else []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I removed the conditional error message for speed configuration because it was incorrectly restricting speed configuration.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue #467  |
| -------------- |



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_interfaces

##### OUTPUT
<!--- Paste the functionality test result below -->
[regression-2024-10-15-16-12-55.html.pdf](https://github.com/user-attachments/files/17386747/regression-2024-10-15-16-12-55.html.pdf)
Failing playbook before fixing bug:
[failing_playbook.log](https://github.com/user-attachments/files/17386750/failing_playbook.log)
Passing playbook after fixing bug:
[passing_playbook.log](https://github.com/user-attachments/files/17386752/passing_playbook.log)


<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at previous code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)
