### PR TITLE
Modify SONiC 4.4.0 IPv6 feature support code to eliminate failures on older versions of SONiC.

### DIFF
--- a/changelogs/fragments/474-l3_interfaces-ipv6-autoconf-downward-compatibility.yaml
+++ b/changelogs/fragments/474-l3_interfaces-ipv6-autoconf-downward-compatibility.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_l3_interfaces - Eliminate unconditional sending of the new autoconf REST API option during replaced and overridden state handling (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/474).

--- a/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
@@ -451,7 +451,7 @@ class L3_interfaces(ConfigBase):
                 if ipv4 and not ipv4.get('addresses') and not ipv4.get('anycast_addresses'):
                     is_del_ipv4 = True
                 if (ipv6 and not ipv6.get('addresses') and ipv6.get('enabled') is None and
-                    ipv6.get('autoconf') is None and ipv6.get('dad') is None):
+                   ipv6.get('autoconf') is None and ipv6.get('dad') is None):
                     is_del_ipv6 = True
 
             if is_del_ipv4:

--- a/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
@@ -187,7 +187,7 @@ class L3_interfaces(ConfigBase):
         new_have = self.remove_default_entries(new_have)
         new_want = remove_empties_from_list(want)
         new_want = self.remove_default_entries(new_want)
-        get_replace_interfaces_list = self.get_interface_object_for_replaced(new_have, new_want)
+        get_replace_interfaces_list = self.get_interface_object_for_replaced(new_have, want)
 
         diff_del = get_diff(get_replace_interfaces_list, new_want, TEST_KEYS)
         diff_add = get_diff(new_want, get_replace_interfaces_list, TEST_KEYS)

--- a/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
@@ -282,46 +282,46 @@ class L3_interfaces(ConfigBase):
                obj['ipv6'].get('autoconf', None) is not None or
                obj['ipv6'].get('enabled', None) is not None):
 
-                 new_obj['ipv6'] = obj['ipv6'].copy()
+                new_obj['ipv6'] = obj['ipv6'].copy()
 
-                 # The following options have defult values in the device IPv6
-                 # configuration when they have been "deleted":
-                 #
-                 # enable => False,
-                 # dad => "DISABLE",
-                 # autoconf => False
-                 #
-                 # Enable correct handling for all states by filtering out these
-                 # options when they have default values unless one of the
-                 # following conditions is true:
-                 #
-                 # (1) The 'config' parameter to this function represents input commands
-                 # (from the executing user playbook) and the specified target state is a
-                 # value other than 'deleted' ("positive" configuration). This is to
-                 # enable idempotent handling for 'deleted' state when 'deleting' one of
-                 # these options when it is already configured to its default value
-                 # (a no-op that should not generate a request), while preserving the
-                 # ability to 'merge' a default value when that is requested by a playbook
-                 # that specifies a target state of 'merged', 'overridden', or 'replaced'.
-                 #
-                 # or
-                 #
-                 # (2) The 'config' parameter to this function does not represent input
-                 # commands (because it is from the current device configuration) and the
-                 # specified target state is 'merged'. (This exclusion is to enable
-                 # idempotent handling for 'merged' state when 'merging' a default value
-                 # for one of these options.)
-                 #
-                 if ((input_cmds and state == "deleted") or
-                    ((not input_cmds) and state != "merged")):
-                     if new_obj['ipv6'].get('enabled', None) == False:
-                         del new_obj['ipv6']['enabled']
-                     if new_obj['ipv6'].get('dad', None) == "DISABLE":
-                         del new_obj['ipv6']['dad']
-                     if new_obj['ipv6'].get('autoconf', None) == False:
-                         del new_obj['ipv6']['autoconf']
-                     if not input_cmds and new_obj.get('ipv6', None) == {}:
-                         del new_obj['ipv6']
+                # The following options have defult values in the device IPv6
+                # configuration when they have been "deleted":
+                #
+                # enable => False,
+                # dad => "DISABLE",
+                # autoconf => False
+                #
+                # Enable correct handling for all states by filtering out these
+                # options when they have default values unless one of the
+                # following conditions is true:
+                #
+                # (1) The 'config' parameter to this function represents input commands
+                # (from the executing user playbook) and the specified target state is a
+                # value other than 'deleted' ("positive" configuration). This is to
+                # enable idempotent handling for 'deleted' state when 'deleting' one of
+                # these options when it is already configured to its default value
+                # (a no-op that should not generate a request), while preserving the
+                # ability to 'merge' a default value when that is requested by a playbook
+                # that specifies a target state of 'merged', 'overridden', or 'replaced'.
+                #
+                # or
+                #
+                # (2) The 'config' parameter to this function does not represent input
+                # commands (because it is from the current device configuration) and the
+                # specified target state is 'merged'. (This exclusion is to enable
+                # idempotent handling for 'merged' state when 'merging' a default value
+                # for one of these options.)
+                #
+                if ((input_cmds and state == "deleted") or
+                   ((not input_cmds) and state != "merged")):
+                    if new_obj['ipv6'].get('enabled', None) is False:
+                        del new_obj['ipv6']['enabled']
+                    if new_obj['ipv6'].get('dad', None) == "DISABLE":
+                        del new_obj['ipv6']['dad']
+                    if new_obj['ipv6'].get('autoconf', None) is False:
+                        del new_obj['ipv6']['autoconf']
+                    if not input_cmds and new_obj.get('ipv6', None) == {}:
+                        del new_obj['ipv6']
 
             if new_obj:
                 key_set = set(obj.keys())

--- a/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
@@ -185,7 +185,8 @@ class L3_interfaces(ConfigBase):
         commands = list()
         new_have = remove_empties_from_list(have)
         new_have = self.remove_default_entries(new_have)
-        new_want = self.remove_default_entries(want)
+        new_want = remove_empties_from_list(want)
+        new_want = self.remove_default_entries(new_want)
         get_replace_interfaces_list = self.get_interface_object_for_replaced(new_have, new_want)
 
         diff_del = get_diff(get_replace_interfaces_list, new_want, TEST_KEYS)

--- a/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/l3_interfaces/l3_interfaces.py
@@ -195,9 +195,9 @@ class L3_interfaces(ConfigBase):
             delete_l3_interfaces_requests = self.get_delete_all_requests(diff_del)
             ret_requests.extend(delete_l3_interfaces_requests)
             commands.extend(update_states(diff_del, "deleted"))
-            l3_interfaces_to_create_requests = self.get_create_l3_interfaces_requests(want)
+            l3_interfaces_to_create_requests = self.get_create_l3_interfaces_requests(new_want)
             ret_requests.extend(l3_interfaces_to_create_requests)
-            commands.extend(update_states(want, "replaced"))
+            commands.extend(update_states(new_want, "replaced"))
         elif diff_add:
             l3_interfaces_to_create_requests = self.get_create_l3_interfaces_requests(diff_add)
             ret_requests.extend(l3_interfaces_to_create_requests)

--- a/tests/regression/roles/sonic_l3_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_l3_interfaces/defaults/main.yml
@@ -209,6 +209,7 @@ tests:
             addresses:
               - address: 2041::1/128
               - address: 2042::1/128
+            autoconf: True
         - name: PortChannel101
           ipv4:
             addresses:
@@ -296,7 +297,8 @@ tests:
             addresses:
               - address: 105.2.2.2/16
           ipv6:
-            enabled: true
+            enabled: False
+            autoconf: False
             dad: DISABLE_IPV6_ON_FAILURE
             addresses:
               - address: 1050::/64
@@ -336,6 +338,9 @@ tests:
               - address: 152.1.1.1/32
               - address: 153.1.1.1/32
                 secondary: true
+          ipv6:
+            autoconf: False
+            enabled: False
         - name: vlan 100
           ipv4:
             anycast_addresses:

--- a/tests/unit/modules/network/sonic/fixtures/sonic_l3_interfaces.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_l3_interfaces.yaml
@@ -680,11 +680,6 @@ overridden_01:
               openconfig-if-ip:config:
                 ip: 32::1
                 prefix-length: 64.0
-    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f1/subinterfaces/subinterface=0/openconfig-if-ip:ipv6/config"
-      method: "patch"
-      data:
-        config:
-          ipv6_autoconfig: False
     - path: "data/openconfig-interfaces:interfaces/interface=Vlan13/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/openconfig-interfaces-ext:sag-ipv4/config/static-anycast-gateway"
       method: "patch"
       data:

--- a/tests/unit/modules/network/sonic/fixtures/sonic_l3_interfaces.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_l3_interfaces.yaml
@@ -376,8 +376,8 @@ replaced_01:
           anycast_addresses:
             - 11.12.13.14/12
         ipv6:
-          enabled: true
-          autoconf: true
+          enabled: false
+          autoconf: false
           dad: DISABLE_IPV6_ON_FAILURE
       - name: Eth1/1
         ipv4:
@@ -525,16 +525,6 @@ replaced_01:
       method: "patch"
       data:
         config:
-          enabled: True
-    - path: "data/openconfig-interfaces:interfaces/interface=Vlan13/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/config"
-      method: "patch"
-      data:
-        config:
-          ipv6_autoconfig: True
-    - path: "data/openconfig-interfaces:interfaces/interface=Vlan13/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/config"
-      method: "patch"
-      data:
-        config:
           ipv6_dad: DISABLE_IPV6_ON_FAILURE
 
 overridden_01:
@@ -561,6 +551,8 @@ overridden_01:
               eui64: True
             - address: 31::1/64
             - address: 32::1/64
+          enabled: False
+          autoconf: False
   existing_l3_interfaces_config:
     - path: "data/openconfig-interfaces:interfaces/interface"
       response:


### PR DESCRIPTION
##### SUMMARY
Some of the changes made in the l3_interfaces resource module for support of new SONiC 4.4.0 IPv6 features in "https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/374" were implemented in a way that was not downward compatible with older versions of SONiC. These changes resulted in customer playbook failures when using this resource module on older SONiC images (e.g. SONiC 4.1.6). The failures were caused by unnecessary sending of REST APIs containing new SONiC 4.4.0 options with default values in some "replaced" and "overridden" state cases.
##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_l3_interfaces
##### OUTPUT
<!--- Paste the functionality test result below -->
Example of a playbook that generated a failure without the fix:

[l3_ip_addr_then_overriden_ipv6_enabled.txt](https://github.com/user-attachments/files/17470428/l3_ip_addr_then_overriden_ipv6_enabled.txt)

Playbook failure running the playbook against a SONiC 4.1.6 image without the fix:

[l3_intf_ipv6_autoconf_override_failure_on_SONiC_4.1.6.log](https://github.com/user-attachments/files/17470457/l3_intf_ipv6_autoconf_override_failure_on_SONiC_4.1.6.log)

Playbook successful execution running the playbook against a SONiC 4.1.6 image with the fix present:

[l3_intf_ipv6_autoconf_override_fix_on_SONiC_4.1.6.log](https://github.com/user-attachments/files/17470470/l3_intf_ipv6_autoconf_override_fix_on_SONiC_4.1.6.log)

l3_interfaces regression test run on a SONiC 4.4.x image with the fix present:

[l3_intf_downward_compat_PR_regression-2024-10-21-18-55-25.pdf](https://github.com/user-attachments/files/17470618/l3_intf_downward_compat_PR_regression-2024-10-21-18-55-25.pdf)

l3_interfaces regression test run on a SONiC 4.4.x image with the fix present after correcting handling to enable idempotency for defaulted options in replaced and overridden states:


[l3_downward_compat_after_rework_regression-2024-10-25-13-11-49.zip](https://github.com/user-attachments/files/17526151/l3_downward_compat_after_rework_regression-2024-10-25-13-11-49.zip)

Regression test run on a SONiC 4.4.x image after incorporating suggested changes posted on this PR:

[l3_downward_compat_after_PR_comment_updates_regression-2024-10-26-16-32-29.zip](https://github.com/user-attachments/files/17531949/l3_downward_compat_after_PR_comment_updates_regression-2024-10-26-16-32-29.zip)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Develop a playbook to duplicate the failure condition seen by the customer reporting the problem to be fixed.
- [x] Verify that the failure can be generated by running the "test" playbook without the fix against the SONiC version used by the customer discovering the problem.
- [x] Verify that the failure does not occur when  running the "test" playbook with the fix installed against the SONiC version used by the customer discovering the problem.
- [x] Verify that all regression test cases pass with the fix when executing against a recent SONiC (4.4.x) image.
- [x] Verify correct idempotency handling of the "defaulted" options via playbook execution and new UT and regression test cases.
