### PR TITLE
Add support for host certificate deletion, display  and installation

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/pki/pki.py
+++ b/plugins/module_utils/network/sonic/argspec/pki/pki.py
@@ -66,6 +66,16 @@ class PkiArgs(object):  # pylint: disable=R0903
                         'name': {'required': True, 'type': 'str'}
                     },
                     'type': 'list'
+                },
+                'host_cert': {
+                    'elements': 'dict',
+                    'options': {
+                        'file_path': {'type': 'str'},
+                        'file_name': {'type': 'str'},
+                        'fips_cert': {'type': 'bool', 'default': False},
+                        'key_path': {'type': 'str'}
+                    },
+                    'type': 'list'
                 }
             },
             'type': 'dict'

--- a/tests/regression/roles/sonic_pki/defaults/main.yml
+++ b/tests/regression/roles/sonic_pki/defaults/main.yml
@@ -116,7 +116,29 @@ tests:
         - name: newts
           ca_name: CA
 
-test_delete_all:
   - name: test_case_09
+    description: Merge parameter of host cert install
+    state: merged
+    input:
+      host_cert:
+        - file_path: "home://cert1.crt"
+          key_path: "home://cert1.key"
+          fips_cert: true
+        - file_path: "home://cert2.crt"
+          key_path: "home://cert2.key"
+          fips_cert: false
+
+  - name: test_case_10
+    description: Delete parameter of host cert delete
+    state: deleted
+    input:
+      host_cert:
+        - file_name: "cert1"
+          fips_cert: true
+        - file_name: "cert2"
+          fips_cert: false
+
+test_delete_all:
+  - name: test_case_11
     description: Delete all PKI configurations
     state: deleted


### PR DESCRIPTION
SUMMARY
Add ansible support for SONiC PKI host certificates install, delete and display.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
|N/A |


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
sonic_pki

##### OUTPUT
Regression Run Output
[regression_sonic_pki_tasks_result.txt](https://github.com/user-attachments/files/17822890/regression_sonic_pki_tasks_result.txt)





##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Regression test with updated testcases.
