### PR TITLE
Add preparation tasks for LDAP security profile

### DIFF
--- a/changelogs/fragments/494-LDAP-security-profile-task.yaml
+++ b/changelogs/fragments/494-LDAP-security-profile-task.yaml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
-  - sonic_ldap - Add prerequisite task for LDAP security profile (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/494).
+trivial:
+  - sonic_ldap - Add prerequisite task for LDAP security profile tests (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/494).

--- a/changelogs/fragments/494-LDAP-security-profile-task.yaml
+++ b/changelogs/fragments/494-LDAP-security-profile-task.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - sonic_ldap - Add prerequisite task for LDAP security profile (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/494).
+bugfixes:
+  - sonic_ldap - Add prerequisite task for LDAP security profile (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/494).

--- a/changelogs/fragments/494-LDAP-security-profile-task.yaml
+++ b/changelogs/fragments/494-LDAP-security-profile-task.yaml
@@ -1,5 +1,3 @@
 ---
-minor_changes:
-  - sonic_ldap - Add prerequisite task for LDAP security profile (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/494).
 bugfixes:
   - sonic_ldap - Add prerequisite task for LDAP security profile (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/494).

--- a/tests/regression/roles/sonic_ldap/defaults/main.yml
+++ b/tests/regression/roles/sonic_ldap/defaults/main.yml
@@ -111,7 +111,7 @@ tests:
         retry: 3
         scope: one
       - name: global
-        security_profile: "default"
+        security_profile: '{{ secprofile }}'
         map:
           map_remote_groups_to_sonic_roles:
             - remote_group: "user1"
@@ -123,7 +123,7 @@ tests:
     state: deleted
     input:
       - name: global
-        security_profile: "default"
+        security_profile: '{{ secprofile }}'
         vrf: '{{ vrf2 }}'
         map:
           map_remote_groups_to_sonic_roles:
@@ -200,7 +200,7 @@ tests:
             ssl: 'start_tls'
         binddn: "CN=example.com"
         source_interface: "{{ interface5 }}"
-        security_profile: "default"
+        security_profile: '{{ secprofile }}'
         map:
           default_attribute:
             - from: "attr1"
@@ -266,7 +266,7 @@ tests:
     state: overridden
     input:
       - name: global
-        security_profile: "default"
+        security_profile: '{{ secprofile }}'
         servers:
           - address: 89.0.142.85
             ssl: 'off'

--- a/tests/regression/roles/sonic_ldap/defaults/main.yml
+++ b/tests/regression/roles/sonic_ldap/defaults/main.yml
@@ -4,11 +4,13 @@ module_name: ldap
 
 vrf1: "VrfReg1"
 vrf2: "VrfReg2"
+secprofile: "default"
 
 preparations_tests:
   vrfs:
     - name: '{{ vrf1 }}'
     - name: '{{ vrf2 }}'
+  crypto_profile: '{{ secprofile }}'
 
 tests:
   - name: test_case_01

--- a/tests/regression/roles/sonic_ldap/tasks/cleanup_tests.yaml
+++ b/tests/regression/roles/sonic_ldap/tasks/cleanup_tests.yaml
@@ -10,3 +10,10 @@
     config: "{{ preparations_tests.vrfs }}"
     state: deleted
   ignore_errors: yes
+
+- name: Delete crypto security profile
+  vars:
+    ansible_connection: network_cli
+  dellemc.enterprise_sonic.sonic_config:
+    commands: "no crypto security-profile {{ preparations_tests.crypto_profile }}"
+  failed_when: false

--- a/tests/regression/roles/sonic_ldap/tasks/preparation_tests.yaml
+++ b/tests/regression/roles/sonic_ldap/tasks/preparation_tests.yaml
@@ -10,3 +10,10 @@
     config: "{{ preparations_tests.vrfs }}"
     state: merged
   ignore_errors: yes
+
+- name: Create crypto security profile
+  vars:
+    ansible_connection: network_cli
+  dellemc.enterprise_sonic.sonic_config:
+    commands: "crypto security-profile {{ preparations_tests.crypto_profile }}"
+  failed_when: false


### PR DESCRIPTION
##### SUMMARY
Crypto security-profile is required before configuring ldap security-profile.
Added a new preparation task to configure crypto security profile.

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| N/A |


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- sonic_ldap
##### OUTPUT
**Regression report:**
[regression-2024-12-18-14-03-07.pdf](https://github.com/user-attachments/files/18177390/regression-2024-12-18-14-03-07.pdf)

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
