### PR TITLE
Add support for SPEED_200GB

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/sonic/argspec/interfaces/interfaces.py
@@ -57,6 +57,7 @@ class InterfacesArgs(object):  # pylint: disable=R0903
                                       "SPEED_40GB",
                                       "SPEED_50GB",
                                       "SPEED_100GB",
+                                      "SPEED_200GB",                                     
                                       "SPEED_400GB"]},
                 "auto_negotiate": {"type": "bool"},
                 "advertised_speed": {"type": "list", "elements": "str"},

--- a/plugins/module_utils/network/sonic/argspec/port_group/port_group.py
+++ b/plugins/module_utils/network/sonic/argspec/port_group/port_group.py
@@ -53,6 +53,7 @@ class Port_groupArgs(object):  # pylint: disable=R0903
                                       'SPEED_40GB',
                                       'SPEED_50GB',
                                       'SPEED_100GB',
+                                      "SPEED_200GB",
                                       'SPEED_400GB'],
                           'type': 'str'}
             },

--- a/plugins/modules/sonic_interfaces.py
+++ b/plugins/modules/sonic_interfaces.py
@@ -82,6 +82,7 @@ options:
         - SPEED_40GB
         - SPEED_50GB
         - SPEED_100GB
+        - SPEED_200GB
         - SPEED_400GB
       auto_negotiate:
         description:

--- a/plugins/modules/sonic_port_group.py
+++ b/plugins/modules/sonic_port_group.py
@@ -70,6 +70,7 @@ options:
           - SPEED_40GB
           - SPEED_50GB
           - SPEED_100GB
+          - SPEED_200GB
           - SPEED_400GB
   state:
     description:


### PR DESCRIPTION
##### SUMMARY
Add support for SPEED_200GB.

##### ADDITIONAL INFORMATION
I came across the following error while using this plugin to configure my Dell switch.
```
{"changed": false, "msg": "value of speed must be one of: SPEED_10MB, SPEED_100MB, SPEED_1GB, SPEED_2500MB, SPEED_5GB, SPEED_10GB, SPEED_20GB, SPEED_25GB, SPEED_40GB, SPEED_50GB, SPEED_100GB, SPEED_400GB, got: SPEED_200GB found in config"}
```

##### How Has This Been Tested?