### PR TITLE
Add sleep to allow TACACS server config updates to apply to SONiC PAM modules

### DIFF
--- a/changelogs/fragments/508-tacacs-server-bugfix.yaml
+++ b/changelogs/fragments/508-tacacs-server-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_tacacs_server - Add sleep to allow TACACS server config updates to apply to SONiC PAM modules (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/508).

--- a/changelogs/fragments/508-tacacs-server-bugfix.yaml
+++ b/changelogs/fragments/508-tacacs-server-bugfix.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - sonic_tacacs_server - Add sleep to allow TACACS server config updates to apply to SONiC PAM modules (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/508).

--- a/changelogs/fragments/509-tacacs-server-bugfix.yaml
+++ b/changelogs/fragments/509-tacacs-server-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_tacacs_server - Add sleep to allow TACACS server config updates to apply to SONiC PAM modules (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/509).

--- a/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
+++ b/plugins/module_utils/network/sonic/config/tacacs_server/tacacs_server.py
@@ -1,6 +1,6 @@
 #
 # -*- coding: utf-8 -*-
-# Copyright 2019 Red Hat
+# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """
@@ -12,6 +12,7 @@ created
 """
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
+from time import sleep
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )
@@ -91,6 +92,8 @@ class Tacacs_server(ConfigBase):
             if not self._module.check_mode:
                 try:
                     edit_config(self._module, to_request(self._module, requests))
+                    # Wait for config updates to be applied to PAM modules
+                    sleep(4)
                 except ConnectionError as exc:
                     self._module.fail_json(msg=str(exc), code=exc.code)
             result['changed'] = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added a sleep in the config file to allow TACACS server config updates to apply to SONiC PAM modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_tacacs_server

##### OUTPUT
Failing regression report before change:
[regression-2025-02-17-13-46-50.html.pdf](https://github.com/user-attachments/files/18833448/regression-2025-02-17-13-46-50.html.pdf)

Passing regression report after change:
[regression-2025-02-17-13-52-45.html.pdf](https://github.com/user-attachments/files/18833451/regression-2025-02-17-13-52-45.html.pdf)

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained previous code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)