### PR TITLE
Fix VLAN deletion bug for L2 interfaces module

### DIFF
--- a/changelogs/fragments/526-l2-interfaces-bugfix.yaml
+++ b/changelogs/fragments/526-l2-interfaces-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_l2_interfaces - Fix VLAN deletion bug (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/526).

--- a/plugins/modules/sonic_l2_interfaces.py
+++ b/plugins/modules/sonic_l2_interfaces.py
@@ -16,8 +16,8 @@ DOCUMENTATION = """
 module: sonic_l2_interfaces
 version_added: 1.0.0
 notes:
-- Tested against Enterprise SONiC Distribution by Dell Technologies.
-- Supports C(check_mode).
+  - Tested against Enterprise SONiC Distribution by Dell Technologies.
+  - Supports C(check_mode).
 short_description: Configure interface-to-VLAN association that is based on access or trunk mode
 description: Manages Layer 2 interface attributes of Enterprise SONiC Distribution by Dell Technologies.
 author: Niraimadaiselvam M(@niraimadaiselvamm)

--- a/tests/unit/modules/network/sonic/fixtures/sonic_l2_interfaces.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_l2_interfaces.yaml
@@ -173,13 +173,18 @@ deleted_02:
     - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f1/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/access-vlan"
       method: "delete"
       data:
-    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f1/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans=11..13%2C16"
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f1/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans=11..13"
+      method: "delete"
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f1/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans=16"
       method: "delete"
       data:
     - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f2/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/access-vlan"
       method: "delete"
       data:
-    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f2/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans=21..30%2C51"
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f2/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans=21..30"
+      method: "delete"
+      data:
+    - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f2/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans=51"
       method: "delete"
       data:
     - path: "data/openconfig-interfaces:interfaces/interface=Eth1%2f3/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
SONiC doesn't allow specification of a list for trunk-vlans deletion so I updated the module code for l2 interfaces accordingly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_l2_interfaces

##### OUTPUT
<!--- Paste the functionality test result below -->
[regression-2025-03-12-15-08-46.html.pdf](https://github.com/user-attachments/files/19218776/regression-2025-03-12-15-08-46.html.pdf)


<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)