### PR TITLE
Usr/austin.whaley issue-508 sonic logging bugfix for severity attribute

### DIFF
--- a/changelogs/fragments/537-logging-severity-bugfix.yaml
+++ b/changelogs/fragments/537-logging-severity-bugfix.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - sonic_logging - Addressing bug found in https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/508 where a traceback is thrown if the "severity" value does not exist on the device. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/537).
+  - sonic_logging - Addressing bug found in https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/508 where a traceback is thrown if the "severity" value is not specified in the incoming playbook or if the incoming playbook specifies a 'severity' value of None. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/537).

--- a/changelogs/fragments/537-logging-severity-bugfix.yaml
+++ b/changelogs/fragments/537-logging-severity-bugfix.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - sonic_logging - Addressing bug found in https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/508 where a traceback is thrown if the "severity" value does not exist on the device.
+  - sonic_logging - Addressing bug found in https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/508 where a traceback is thrown if the "severity" value does not exist on the device. (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/537).

--- a/changelogs/fragments/537-logging-severity-bugfix.yaml
+++ b/changelogs/fragments/537-logging-severity-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_logging - Addressing bug found in https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/508 where a traceback is thrown if the "severity" value does not exist on the device.

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -139,11 +139,6 @@ class Logging(ConfigBase):
         want = self._module.params['config']
         if want is None:
             want = []
-            # Want is a dict, not a list?
-            #want = {}
-        #else:
-            #want = remove_empties(want)
-        # Insert remove_empties for want here?
 
         have = existing_logging_facts
         resp = self.set_state(want, have)

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -426,7 +426,10 @@ class Logging(ConfigBase):
             if 'message_type' in config:
                 req_config['message-type'] = config['message_type']
             if 'severity' in config:
-                req_config['severity'] = (config['severity'].upper()).replace("INFO", "INFORMATIONAL")
+                if config.get("severity") is not None:
+                    req_config['severity'] = (config.get("severity", "").upper()).replace("INFO", "INFORMATIONAL")
+                else:
+                    req_config['severity'] = None
             if 'remote_port' in config:
                 req_config['remote-port'] = config['remote_port']
             if 'protocol' in config:

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -139,6 +139,11 @@ class Logging(ConfigBase):
         want = self._module.params['config']
         if want is None:
             want = []
+            # Want is a dict, not a list?
+            #want = {}
+        #else:
+            #want = remove_empties(want)
+        # Insert remove_empties for want here?
 
         have = existing_logging_facts
         resp = self.set_state(want, have)
@@ -425,11 +430,8 @@ class Logging(ConfigBase):
                 req_config['source-interface'] = config['source_interface']
             if 'message_type' in config:
                 req_config['message-type'] = config['message_type']
-            if 'severity' in config:
-                if config.get("severity") is not None:
-                    req_config['severity'] = (config.get("severity", "").upper()).replace("INFO", "INFORMATIONAL")
-                else:
-                    req_config['severity'] = None
+            if 'severity' in config and config.get("severity") is not None:
+                req_config['severity'] = (config.get("severity", "").upper()).replace("INFO", "INFORMATIONAL")
             if 'remote_port' in config:
                 req_config['remote-port'] = config['remote_port']
             if 'protocol' in config:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixing issue #508 where if severity was "None" in the sonic_logging attribute the module would throw a traceback error.

##### GitHub Issues
| GitHub Issue #508 |


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_logging

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below
# SEVERITY SET TO NONE
                        "after": {
                            "anycast_address": {
                                "ipv4": true,
                                "ipv6": true,
                                "mac_address": "00:09:5B:EC:EE:F2"
                            },
                            "audit_rules": "BASIC",
                            "auto_breakout": "ENABLE",
                            "concurrent_session_limit": 4,
                            "hostname": "SONIC-ov",
                            "interface_naming": "standard"
                        },
                        "before": {
                            "anycast_address": {
                                "ipv4": true,
                                "ipv6": false
                            },
                            "audit_rules": "DETAIL",
                            "auto_breakout": "DISABLE",
                            "hostname": "sonic",
                            "interface_naming": "native"
                        },
                        "commands": [
                            {
                                "anycast_address": {
                                    "ipv6": false
                                },
                                "state": "deleted"
                            },
                            {
                                "anycast_address": {
                                    "mac_address": "00:09:5B:EC:EE:F2"
                                },
                                "audit_rules": "BASIC",
                                "auto_breakout": "ENABLE",
                                "concurrent_session_limit": 4,
                                "hostname": "SONIC-ov",
                                "interface_naming": "standard",
                                "state": "overridden"
                            }
                        ],
                        "configs": {
                            "anycast_address": {
                                "ipv4": true,
                                "mac_address": "00:09:5B:EC:EE:F2"
                            },
                            "audit_rules": "BASIC",
                            "auto_breakout": "ENABLE",
                            "concurrent_session_limit": 4,
                            "hostname": "SONIC-ov",
                            "interface_naming": "standard"
                        },
                        "module_stderr": "No Error",
                        "status": "Passed"                    
```
##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested the fix by forcing "severity" to None like the issue saw and ensuring the conditional was not ran and no traceback was seen.
        ---
            config['severity'] = None
            if 'severity' in config and config.get("severity") is not None:
                raise Exception("Severity should not be seen.")
                req_config['severity'] = (config.get("severity", "").upper()).replace("INFO", "INFORMATIONAL")
        ---
- [x] Tested again on a s5296f with severity on the device being set and saw the expected attribute behavior and no traceback.
        ---
            Testing if the raw code works and I see severity
            if 'severity' in config and config.get("severity") is not None:
                req_config['severity'] = (config.get("severity", "").upper()).replace("INFO", "INFORMATIONAL")
        ---
- [x] Log of passing sonic_logging regression test after the fix

[sonic-logging_post-fix-issue-108_regression_run_2025-03-28-12h-41m-38s.txt](https://github.com/user-attachments/files/19510436/sonic-logging_post-fix-issue-108_regression_run_2025-03-28-12h-41m-38s.txt)

[sonic-logging_post-fix-issue-108_regression_run_2025-03-28-12h-41m-38s.pdf](https://github.com/user-attachments/files/19510425/sonic-logging_post-fix-issue-108_regression_run_2025-03-28-12h-41m-38s.pdf)


