### PR TITLE
Use a permanent instead of "tmp" location for the SONiC image zip file used by the image_managment regression test.

### DIFF
--- a/changelogs/fragments/546-image-management-location_change.yaml
+++ b/changelogs/fragments/546-image-management-location_change.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - sonic_image_management - Change the location of the SONiC image zip file used by this regression test from a "/tmp" directory location to the "permanent" directory "/usr/local/share/script_files" (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/546).

--- a/tests/regression/roles/sonic_image_management/tasks/preparation_tests.yml
+++ b/tests/regression/roles/sonic_image_management/tasks/preparation_tests.yml
@@ -11,7 +11,7 @@
   vars:
     ansible_connection: ssh
   ansible.builtin.copy:
-    src: "/tmp/Enterprise_SONiC_OS_4.2.2_Enterprise_Premium.zip"
+    src: "/usr/local/share/script_files/Enterprise_SONiC_OS_4.2.2_Enterprise_Premium.zip"
     dest: "/home/admin/imageverify"
     checksum: ""
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change the location of the SONiC image zip file used by this regression test from the "/tmp" directory location to the "permanent" directory "/usr/local/share/script_files". This change is being made to avoid aborting of the test suite due to periodic and event-driven erasure of the /tmp directory on the test server.
##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_image_management
##### OUTPUT
<!--- Paste the functionality test result below -->
[image_management_location_change_test_summary.pdf](https://github.com/user-attachments/files/19743402/image_management_location_change_test_summary.pdf)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To test this change, I copied the target ".zip" file from the specified location on the SONiC Ansible test server to an identically named location on my Ansible development server:

On my development server:

`kerry@opensuse155:~> ls -ld /usr/local/share/script_files/*
-rw-r--r-- 1 root root 1212705334 Apr 14 16:09 /usr/local/share/script_files/Enterprise_SONiC_OS_4.2.2_Enterprise_Premium.zip`

On the test server:

`kerry.meyer@ansreg-eqx-01:~$ ls -ld /usr/local/share/script_files/E*
-rw-r--r-- 1 root root 1212705334 Mar 24 20:52 /usr/local/share/script_files/Enterprise_SONiC_OS_4.2.2_Enterprise_Premium.zip`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

I verified that the test suite passes with the test code changes in combination with location of the expected image ".zip" file in the new expected location on the test server.
