### PR TITLE
Add Dell Collection changes for Syslog security profile

### DIFF
--- a/changelogs/fragments/555-Logging-Security-Profile-Ansible-Support.yaml
+++ b/changelogs/fragments/555-Logging-Security-Profile-Ansible-Support.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - sonic_logging - Added Ansible support for the leaf security profile added as part of the Syslog Security Profile feature (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/555).

--- a/changelogs/fragments/555-Logging-Security-Profile-Ansible-Support.yaml
+++ b/changelogs/fragments/555-Logging-Security-Profile-Ansible-Support.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - sonic_logging - Added Ansible support for the leaf security profile added as part of the Syslog Security Profile feature (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/555).
+  - sonic_logging - Add support for 'security_profile' option (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/555).

--- a/plugins/module_utils/network/sonic/argspec/logging/logging.py
+++ b/plugins/module_utils/network/sonic/argspec/logging/logging.py
@@ -56,7 +56,10 @@ class LoggingArgs(object):  # pylint: disable=R0903
                         'vrf': {'type': 'str'}
                     },
                     'type': 'list'
-                }
+                },
+                'security_profile': {
+                    'type': 'str'
+                },
             },
             'type': 'dict'
         },

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -287,10 +287,7 @@ class Logging(ConfigBase):
         commands = []
         requests = []
 
-        if (have['remote_servers'] == want['remote_servers']) and (have['security_profile'] is None):
-            if 'security_profile' not in want:
-                want['security_profile'] = None
-
+        want.setdefault('security_profile', None)
         if have and have != want:
             delete_all = True
             del_requests = self.get_delete_requests(have, delete_all)
@@ -418,7 +415,7 @@ class Logging(ConfigBase):
             if servers_request:
                 requests.extend(servers_request)
 
-        if (configs.get('security_profile') or delete_all) and (configs.get('security_profile') is not None):
+        if configs.get('security_profile'):
             url = 'data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile'
             requests.append({'path': url, 'method': DELETE})
 

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -321,8 +321,8 @@ class Logging(ConfigBase):
         replaced_config = dict()
         replaced_servers = []
 
-        if 'security_profile' in have and 'security_profile' in want:
-            replaced_config['security_profile'] = want['security_profile']
+        if have.get('security_profile') and want.get('security_profile'):
+            replaced_config['security_profile'] = have['security_profile']
 
         if 'remote_servers' in have and 'remote_servers' in want:
             for server in want['remote_servers']:

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -207,7 +207,7 @@ class Logging(ConfigBase):
 
         want_none = {'remote_servers': None, 'security_profile': None}
         want_any = get_diff(want, want_none, TEST_KEYS)
-        # if want_any is none, then delete all NTP configurations
+        # If want_any is none, then delete all logging configuration.
 
         delete_all = False
         if not want_any:

--- a/plugins/module_utils/network/sonic/config/logging/logging.py
+++ b/plugins/module_utils/network/sonic/config/logging/logging.py
@@ -205,7 +205,7 @@ class Logging(ConfigBase):
         # unconfigured servers from the list of "delete" commands to be sent to the switch.
         unconfigured = get_diff(want, have, TEST_KEYS)
 
-        want_none = {'remote_servers': None}
+        want_none = {'remote_servers': None, 'security_profile': None}
         want_any = get_diff(want, want_none, TEST_KEYS)
         # if want_any is none, then delete all NTP configurations
 
@@ -287,9 +287,9 @@ class Logging(ConfigBase):
         commands = []
         requests = []
 
-        if (have['remote_servers'] == want['remote_servers']) and (have['security_profile'] == ""):
+        if (have['remote_servers'] == want['remote_servers']) and (have['security_profile'] is None):
             if 'security_profile' not in want:
-                want['security_profile'] = ""
+                want['security_profile'] = None
 
         if have and have != want:
             delete_all = True
@@ -418,7 +418,7 @@ class Logging(ConfigBase):
             if servers_request:
                 requests.extend(servers_request)
 
-        if ('security_profile' in configs or delete_all) and configs['security_profile'] != "":
+        if (configs.get('security_profile') or delete_all) and (configs.get('security_profile') is not None):
             url = 'data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile'
             requests.append({'path': url, 'method': DELETE})
 

--- a/plugins/module_utils/network/sonic/facts/logging/logging.py
+++ b/plugins/module_utils/network/sonic/facts/logging/logging.py
@@ -122,6 +122,8 @@ class LoggingFacts(object):
         try:
             response = edit_config(self._module, to_request(self._module, request))
         except ConnectionError as exc:
+            if 'Resource not found' in str(exc):
+                return logging_config
             self._module.fail_json(msg=str(exc), code=exc.code)
         if 'openconfig-system-ext:config' in response[0][1]:
             raw_syslog_data = response[0][1]['openconfig-system-ext:config']

--- a/plugins/module_utils/network/sonic/facts/logging/logging.py
+++ b/plugins/module_utils/network/sonic/facts/logging/logging.py
@@ -124,8 +124,6 @@ class LoggingFacts(object):
             response = edit_config(self._module, to_request(self._module, request))
         except ConnectionError as exc:
             self._module.fail_json(msg=str(exc), code=exc.code)
-        #import epdb
-        #epdb.serve(port=33112)
         syslog_data['security_profile'] = ""
         if 'openconfig-system-ext:config' in response[0][1]:
             raw_syslog_data = response[0][1]['openconfig-system-ext:config']

--- a/plugins/module_utils/network/sonic/facts/logging/logging.py
+++ b/plugins/module_utils/network/sonic/facts/logging/logging.py
@@ -119,17 +119,13 @@ class LoggingFacts(object):
 
         """Get the syslog security profile configurations in the device"""
         request = [{"path": "data/openconfig-system:system/openconfig-system-ext:syslog/config", "method": GET}]
-        syslog_data = {}
         try:
             response = edit_config(self._module, to_request(self._module, request))
         except ConnectionError as exc:
             self._module.fail_json(msg=str(exc), code=exc.code)
-        syslog_data['security_profile'] = ""
         if 'openconfig-system-ext:config' in response[0][1]:
             raw_syslog_data = response[0][1]['openconfig-system-ext:config']
-            if 'security-profile' in raw_syslog_data:
-                syslog_data['security_profile'] = raw_syslog_data['security-profile']
-
-        logging_config['security_profile'] = syslog_data['security_profile']
+            if raw_syslog_data.get('security-profile'):
+                logging_config['security_profile'] = raw_syslog_data['security-profile']
 
         return logging_config

--- a/plugins/module_utils/network/sonic/facts/logging/logging.py
+++ b/plugins/module_utils/network/sonic/facts/logging/logging.py
@@ -117,4 +117,21 @@ class LoggingFacts(object):
 
         logging_config['remote_servers'] = logging_servers
 
+        """Get the syslog security profile configurations in the device"""
+        request = [{"path": "data/openconfig-system:system/openconfig-system-ext:syslog/config", "method": GET}]
+        syslog_data = {}
+        try:
+            response = edit_config(self._module, to_request(self._module, request))
+        except ConnectionError as exc:
+            self._module.fail_json(msg=str(exc), code=exc.code)
+        #import epdb
+        #epdb.serve(port=33112)
+        syslog_data['security_profile'] = ""
+        if 'openconfig-system-ext:config' in response[0][1]:
+            raw_syslog_data = response[0][1]['openconfig-system-ext:config']
+            if 'security-profile' in raw_syslog_data:
+                syslog_data['security_profile'] = raw_syslog_data['security-profile']
+
+        logging_config['security_profile'] = syslog_data['security_profile']
+
         return logging_config

--- a/plugins/modules/sonic_logging.py
+++ b/plugins/modules/sonic_logging.py
@@ -84,6 +84,7 @@ options:
               - VRF name used by remote logging server.
       security_profile:
         type: str
+        version_added: 3.1.0
         description:
           - Specifies the security profile name for the global syslog settings.
   state:
@@ -113,7 +114,7 @@ EXAMPLES = """
 # log1.dell.com   6         Ethernet28          -              audit          notice              udp
 # 10.11.1.2       116       Ethernet6           -              log            notice              tls
 #
-# sonic# show running-configuration | grep logg
+# sonic# show running-configuration | grep logging
 # !
 # logging security-profile default
 # !
@@ -142,7 +143,7 @@ EXAMPLES = """
 # 10.11.1.1       616       -                   -              log            notice              udp
 # 10.11.1.2       116       Ethernet6           -              log            notice              tls
 #
-# sonic# show running-configuration | grep logg
+# sonic# show running-configuration | grep logging
 # sonic#
 #
 # Using "merged" state
@@ -156,7 +157,7 @@ EXAMPLES = """
 # ----------------------------------------------------------------------------------------------------------
 # 10.11.1.1       616       Ethernet8           -              log            notice              tcp
 #
-# sonic# show running-configuration | grep logg
+# sonic# show running-configuration | grep logging
 # sonic#
 - name: Merge logging server configuration
   sonic_logging:
@@ -191,7 +192,7 @@ EXAMPLES = """
 # 10.11.0.1       4         Ethernet2           -              log            notice              tls
 # 10.11.1.1       616       Ethernet8           -              log            error               tcp
 # log1.dell.com   6         Ethernet28          -              audit          notice              udp
-# sonic# show running-configuration | grep logg
+# sonic# show running-configuration | grep logging
 # !
 # logging security-profile default
 # !
@@ -210,7 +211,7 @@ EXAMPLES = """
 # 10.11.1.2       626       Ethernet16          -              event          emergency           udp
 # 10.11.1.3       626       Ethernet14          -              log            notice              tls
 #
-# sonic# show running-configuration | grep logg
+# sonic# show running-configuration | grep logging
 # !
 # logging security-profile default
 # !
@@ -233,7 +234,7 @@ EXAMPLES = """
 # HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE   SEVERITY            PROTOCOL
 # ----------------------------------------------------------------------------------------------------------
 # 10.11.1.2       622       Ethernet24          -              audit          alert               tcp
-# sonic# show running-configuration | grep logg
+# sonic# show running-configuration | grep logging
 # sonic#
 #
 # Using "replaced" state
@@ -248,7 +249,7 @@ EXAMPLES = """
 # 10.11.1.1       616       Ethernet8           -              log            notice              tcp
 # 10.11.1.2       626       Ethernet16          -              event          notice              udp
 #
-# sonic# show running-configuration | grep logg
+# sonic# show running-configuration | grep logging
 # sonic#
 - name: Replace logging server configuration
   sonic_logging:
@@ -272,7 +273,7 @@ EXAMPLES = """
 # ----------------------------------------------------------------------------------------------------------
 # 10.11.1.1       616       Ethernet8           -              log            notice              tcp
 # 10.11.1.2       622       -                   -              audit          debug               udp
-# sonic# show running-configuration | grep logg
+# sonic# show running-configuration | grep logging
 # !
 # logging security-profile default
 # !

--- a/plugins/modules/sonic_logging.py
+++ b/plugins/modules/sonic_logging.py
@@ -82,6 +82,10 @@ options:
             type: str
             description:
               - VRF name used by remote logging server.
+      security_profile:
+        type: str
+        description:
+          - Specifies the security profile name for the global syslog settings.
   state:
     description:
       - The state of the configuration after module completion.
@@ -109,6 +113,11 @@ EXAMPLES = """
 # log1.dell.com   6         Ethernet28          -              audit          notice              udp
 # 10.11.1.2       116       Ethernet6           -              log            notice              tls
 #
+# sonic# show running-configuration | grep logg
+# !
+# logging security-profile default
+# !
+
 - name: Delete logging server configuration
   sonic_logging:
     config:
@@ -120,6 +129,7 @@ EXAMPLES = """
           protocol: tcp
           source_interface: Ethernet8
           severity: alert
+      security_profile: "default"
     state: deleted
 
 # After state:
@@ -132,6 +142,8 @@ EXAMPLES = """
 # 10.11.1.1       616       -                   -              log            notice              udp
 # 10.11.1.2       116       Ethernet6           -              log            notice              tls
 #
+# sonic# show running-configuration | grep logg
+# sonic#
 #
 # Using "merged" state
 #
@@ -144,6 +156,8 @@ EXAMPLES = """
 # ----------------------------------------------------------------------------------------------------------
 # 10.11.1.1       616       Ethernet8           -              log            notice              tcp
 #
+# sonic# show running-configuration | grep logg
+# sonic#
 - name: Merge logging server configuration
   sonic_logging:
     config:
@@ -164,6 +178,7 @@ EXAMPLES = """
           protocol: udp
           source_interface: Ethernet28
           message_type: audit
+      security_profile: "default"
     state: merged
 
 # After state:
@@ -176,6 +191,10 @@ EXAMPLES = """
 # 10.11.0.1       4         Ethernet2           -              log            notice              tls
 # 10.11.1.1       616       Ethernet8           -              log            error               tcp
 # log1.dell.com   6         Ethernet28          -              audit          notice              udp
+# sonic# show running-configuration | grep logg
+# !
+# logging security-profile default
+# !
 #
 #
 # Using "overridden" state
@@ -191,6 +210,10 @@ EXAMPLES = """
 # 10.11.1.2       626       Ethernet16          -              event          emergency           udp
 # 10.11.1.3       626       Ethernet14          -              log            notice              tls
 #
+# sonic# show running-configuration | grep logg
+# !
+# logging security-profile default
+# !
 - name: Override logging server configuration
   sonic_logging:
     config:
@@ -210,6 +233,8 @@ EXAMPLES = """
 # HOST            PORT      SOURCE-INTERFACE    VRF            MESSAGE-TYPE   SEVERITY            PROTOCOL
 # ----------------------------------------------------------------------------------------------------------
 # 10.11.1.2       622       Ethernet24          -              audit          alert               tcp
+# sonic# show running-configuration | grep logg
+# sonic#
 #
 # Using "replaced" state
 #
@@ -223,6 +248,8 @@ EXAMPLES = """
 # 10.11.1.1       616       Ethernet8           -              log            notice              tcp
 # 10.11.1.2       626       Ethernet16          -              event          notice              udp
 #
+# sonic# show running-configuration | grep logg
+# sonic#
 - name: Replace logging server configuration
   sonic_logging:
     config:
@@ -232,6 +259,7 @@ EXAMPLES = """
           protocol: UDP
           message_type: audit
           severity: debug
+      security_profile: "default"
     state: replaced
 #
 # After state:
@@ -244,6 +272,10 @@ EXAMPLES = """
 # ----------------------------------------------------------------------------------------------------------
 # 10.11.1.1       616       Ethernet8           -              log            notice              tcp
 # 10.11.1.2       622       -                   -              audit          debug               udp
+# sonic# show running-configuration | grep logg
+# !
+# logging security-profile default
+# !
 #
 """
 

--- a/tests/regression/roles/sonic_logging/defaults/main.yml
+++ b/tests/regression/roles/sonic_logging/defaults/main.yml
@@ -154,7 +154,7 @@ tests:
       security_profile: "spl"
 
   - name: test_case_08
-    description: Delete a single logging remote server's attributes, syslog security profile
+    description: Delete a single logging remote server's attributes
     state: deleted
     input:
       remote_servers:

--- a/tests/regression/roles/sonic_logging/defaults/main.yml
+++ b/tests/regression/roles/sonic_logging/defaults/main.yml
@@ -19,7 +19,7 @@ logging_host_server: logging.dell.com
 
 tests:
   - name: test_case_01
-    description: Create a single logging remote server
+    description: Create a single logging remote server, Syslog security profile
     state: merged
     input:
       remote_servers:
@@ -30,6 +30,7 @@ tests:
           severity: debug
           message_type: event
           vrf: Vrf_logging_1
+      security_profile: "default"
 
   - name: test_case_02
     description: Create several logging remote servers
@@ -65,7 +66,7 @@ tests:
           vrf: Vrf_logging_1
 
   - name: test_case_03
-    description: Replace a single logging remote server
+    description: Replace a single logging remote server, Syslog security profile
     state: replaced
     input:
       remote_servers:
@@ -75,6 +76,7 @@ tests:
           remote_port: 838
           protocol: UDP
           message_type: event
+      security_profile: "spl"
 
   - name: test_case_04
     description: Replace several logging remote servers
@@ -98,7 +100,7 @@ tests:
           message_type: auditd-system
 
   - name: test_case_05
-    description: Override a single logging remote server
+    description: Override a single logging remote server, security profile
     state: overridden
     input:
       remote_servers:
@@ -108,6 +110,7 @@ tests:
           remote_port: 777
           protocol: UDP
           message_type: log
+      security_profile: "default"
 
   - name: test_case_06
     description: Override several logging remote servers
@@ -125,7 +128,7 @@ tests:
           message_type: event
 
   - name: test_case_07
-    description: Modify several created logging remote servers to change or add attributes
+    description: Modify several created logging remote servers to change or add attributes, security profile
     state: merged
     input:
       remote_servers:
@@ -148,9 +151,10 @@ tests:
           source_interface: "{{ lo1 }}"
           message_type: log
           vrf: Vrf_logging_1
+      security_profile: "spl"
 
   - name: test_case_08
-    description: Delete a single logging remote server's attributes
+    description: Delete a single logging remote server's attributes, syslog security profile
     state: deleted
     input:
       remote_servers:

--- a/tests/regression/roles/sonic_logging/tasks/cleanup_tests.yaml
+++ b/tests/regression/roles/sonic_logging/tasks/cleanup_tests.yaml
@@ -26,3 +26,9 @@
       - name: Vrf_logging_2
     state: deleted
   ignore_errors: yes
+
+- name: Delete security profiles
+  sonic_pki:
+    config: {}
+    state: deleted
+  ignore_errors: yes

--- a/tests/regression/roles/sonic_logging/tasks/preparation_tests.yaml
+++ b/tests/regression/roles/sonic_logging/tasks/preparation_tests.yaml
@@ -32,3 +32,10 @@
       - name: Vrf_logging_2
     state: merged
   ignore_errors: yes
+
+- name: Create security profiles
+  sonic_pki:
+    config:
+      security_profiles:
+        - profile_name: default
+        - profile_name: spl

--- a/tests/unit/modules/network/sonic/fixtures/sonic_logging.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_logging.yaml
@@ -21,8 +21,12 @@ merged_01:
           source_interface: Eth1/28
           message_type: audit
           severity: error
+      security_profile: 'default'
   existing_logging_config:
     - path: "data/openconfig-system:system/logging"
+      response:
+        code: 200
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config"
       response:
         code: 200
   expected_config_requests:
@@ -55,6 +59,10 @@ merged_01:
                 message-type: audit
                 protocol: UDP
                 severity: ERROR
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
+      method: "patch"
+      data:
+        openconfig-system-ext:security-profile: 'default'
 
 deleted_01:
   module_args:
@@ -82,8 +90,17 @@ deleted_01:
                     openconfig-system-ext:source-interface: Eth1/28
                     openconfig-system-ext:protocol: UDP
                     openconfig-system-ext:severity: error
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config"
+      response:
+        code: 200
+        value:
+          openconfig-system-ext:config:
+            security-profile: "default"
   expected_config_requests:
     - path: "data/openconfig-system:system/logging/remote-servers"
+      method: "delete"
+      data:
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
       method: "delete"
       data:
 
@@ -93,6 +110,7 @@ deleted_02:
     config:
       remote_servers:
         - host: 10.11.0.2
+      security_profile: 'default'
   existing_logging_config:
     - path: "data/openconfig-system:system/logging"
       response:
@@ -116,8 +134,17 @@ deleted_02:
                     openconfig-system-ext:source-interface: Eth1/28
                     openconfig-system-ext:protocol: UDP
                     openconfig-system-ext:severity: error
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config"
+      response:
+        code: 200
+        value:
+          openconfig-system-ext:config:
+            security-profile: "default"
   expected_config_requests:
     - path: "data/openconfig-system:system/logging/remote-servers/remote-server=10.11.0.2"
+      method: "delete"
+      data:
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
       method: "delete"
       data:
 
@@ -132,6 +159,7 @@ deleted_03:
           severity: error
           source_interface: Eth1/24
           message_type: event
+      security_profile: 'spl'
   existing_logging_config:
     - path: "data/openconfig-system:system/logging"
       response:
@@ -148,6 +176,12 @@ deleted_03:
                     openconfig-system-ext:severity: error
                     openconfig-system-ext:source-interface: Eth1/24
                     openconfig-system-ext:message-type: event
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config"
+      response:
+        code: 200
+        value:
+          openconfig-system-ext:config:
+            security-profile: "spl"
   expected_config_requests:
     - path: "data/openconfig-system:system/logging/remote-servers/remote-server=10.11.0.2/config/openconfig-system-ext:source-interface"
       method: "delete"
@@ -162,6 +196,9 @@ deleted_03:
       method: "delete"
       data:
     - path: "data/openconfig-system:system/logging/remote-servers/remote-server=10.11.0.2/config/openconfig-system-ext:severity"
+      method: "delete"
+      data:
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
       method: "delete"
       data:
 
@@ -182,6 +219,7 @@ replaced_01:
           message_type: log
           protocol: TLS
           severity: alert
+      security_profile: 'spl'
   existing_logging_config:
     - path: "data/openconfig-system:system/logging"
       response:
@@ -205,6 +243,9 @@ replaced_01:
                     openconfig-system-ext:protocol: UDP
                     openconfig-system-ext:severity: debug
                     openconfig-system-ext:source-interface: Eth1/28
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config"
+      response:
+        code: 200
   expected_config_requests:
     - path: "data/openconfig-system:system/logging/remote-servers/remote-server=10.11.0.2/config/remote-port"
       method: "delete"
@@ -244,6 +285,13 @@ replaced_01:
                 protocol: TCP
                 severity: CRITICAL
                 vrf-name:
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
+      method: "delete"
+      data:
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
+      method: "patch"
+      data:
+        openconfig-system-ext:security-profile: 'spl'
 
 overridden_01:
   module_args:
@@ -256,6 +304,7 @@ overridden_01:
           message_type: audit
           protocol: TCP
           severity: error
+      security_profile: 'spl'
   existing_logging_config:
     - path: "data/openconfig-system:system/logging"
       response:
@@ -279,10 +328,23 @@ overridden_01:
                     openconfig-system-ext:source-interface: Eth1/28
                     openconfig-system-ext:protocol: UDP
                     openconfig-system-ext:severity: debug
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config"
+      response:
+        code: 200
+        value:
+          openconfig-system-ext:config:
+            security-profile: "default"
   expected_config_requests:
     - path: "data/openconfig-system:system/logging/remote-servers"
       method: "delete"
       data:
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
+      method: "delete"
+      data:
+    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
+      method: "patch"
+      data:
+        openconfig-system-ext:security-profile: 'spl'
     - path: "data/openconfig-system:system/logging/remote-servers"
       method: "patch"
       data:

--- a/tests/unit/modules/network/sonic/fixtures/sonic_logging.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_logging.yaml
@@ -286,9 +286,6 @@ replaced_01:
                 severity: CRITICAL
                 vrf-name:
     - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
-      method: "delete"
-      data:
-    - path: "data/openconfig-system:system/openconfig-system-ext:syslog/config/security-profile"
       method: "patch"
       data:
         openconfig-system-ext:security-profile: 'spl'

--- a/tests/unit/modules/network/sonic/fixtures/sonic_logging.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_logging.yaml
@@ -8,7 +8,7 @@ merged_01:
           protocol: TCP
           source_interface: Eth1/24
           message_type: event
-          severity: info 
+          severity: info
         - host: 10.11.0.3
           remote_port: 4
           protocol: TLS


### PR DESCRIPTION
##### SUMMARY
Update Enterprise SONiC 'logging' resource module for syslog security profile command:
Provide updated data definitions in 'argspec'.
Implement updated 'facts' to gather facts for the module.
Implement updated 'config' to apply configurations for merged, deleted, replaced and overridden states.
Define updated regression and unit test cases to verify correct functionality of logging security profile for syslog.

Regression LOG:
[SONIC_LOGGING_REGRESSION.pdf](https://github.com/user-attachments/files/20200333/SONIC_LOGGING_REGRESSION.pdf)


##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

GitHub Issue # NA


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- sonic_logging 

##### OUTPUT

**Ansible Lint logs:**
```
(ansible) praneshraagav.s@sncinfra-maa-01:/neteng/ps/PTP_ANSIBLE_new/dellemc.enterprise_sonic> ansible-lint plugins/modules/sonic_logging.py tests/regression/roles/sonic_logging/ tests/unit/modules/network/sonic/fixtures/sonic_logging.yaml
Passed: 0 failure(s), 0 warning(s) on 4 files. Profile 'production' was required, and it passed.
A new release of ansible-lint is available: 24.9.2 → 25.2.1 Upgrade by running: pip install --upgrade ansible-lint
```

**coverage report UT:**
```
(ansible) praneshraagav.s@sncinfra-maa-01:~/.ansible/collections/ansible_collections/dellemc/enterprise_sonic> PYTHONPATH=$HOME/.ansible/collections pytest tests/unit/modules/network/sonic/test_sonic_logging.py --cov-report term --cov=./ | grep logg
tests/unit/modules/network/sonic/test_sonic_logging.py ......            [100%]
plugins/module_utils/network/sonic/argspec/logging/logging.py                               6      1    83%
plugins/module_utils/network/sonic/config/logging/logging.py                              292     27    91%
plugins/module_utils/network/sonic/facts/logging/logging.py                                78     10    87%
plugins/modules/sonic_logging.py                                                           14      1    93%
tests/unit/modules/network/sonic/test_sonic_logging.py                                     67      0   100%
(ansible) praneshraagav.s@sncinfra-maa-01:~/.ansible/collections/ansible_collections/dellemc/enterprise_sonic>

Regression LOGS:
[SONIC_LOGGING_REGRESSION.pdf](https://github.com/user-attachments/files/20200327/SONIC_LOGGING_REGRESSION.pdf)

**UT LOGS:**
```
(ansible) praneshraagav.s@sncinfra-maa-01:~/.ansible/collections/ansible_collections/dellemc/enterprise_sonic> PYTHONPATH=$HOME/.ansible/collections pytest tests/unit/modules/network/sonic/test_sonic_logging.py --cov-report term
========================================================== test session starts ==========================================================
platform linux -- Python 3.10.16, pytest-8.3.3, pluggy-1.5.0
ansible: 2.17.4
rootdir: /home/ps/.ansible/collections/ansible_collections/dellemc/enterprise_sonic
plugins: cov-5.0.0, ansible-24.9.0, xdist-3.6.1, forked-1.6.0
collected 6 items

tests/unit/modules/network/sonic/test_sonic_logging.py ......                                                                     [100%]

=========================================================== 6 passed in 1.31s ===========================================================

```
##### ADDITIONAL INFORMATION

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [ ] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Regression pass logs:

[SONIC_LOGGING_REGRESSION.pdf](https://github.com/user-attachments/files/20200313/SONIC_LOGGING_REGRESSION.pdf)


ZIP:
[Regression logging security profile.zip](https://github.com/user-attachments/files/19972681/Regression.logging.security.profile.zip)
