### PR TITLE
Fix typos in configuration examples for BGP neighbors AF

### DIFF
--- a/changelogs/fragments/561-bgp-nbr-af-documentation.yaml
+++ b/changelogs/fragments/561-bgp-nbr-af-documentation.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - sonic_bgp_neighbors_af - Fix typos in configuration examples (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/561).

--- a/plugins/modules/sonic_bgp_neighbors_af.py
+++ b/plugins/modules/sonic_bgp_neighbors_af.py
@@ -181,180 +181,50 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
+# sonic# show running-configuration bgp neighbor vrf default
 # !
-# router bgp 4
-#  !
-#  neighbor interface Eth1/3
-#   !
-#   address-family ipv4 unicast
-#    activate
-#    allowas-in 4
-#    route-map aa in
-#    route-map aa out
-#    route-reflector-client
-#    route-server-client
-#    send-community both
-# !
-#
-- name: Deletes neighbors address-family with specific values
-  dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
-     config:
-        - bgp_as: 4
-          neighbors:
-             - neighbor: Eth1/3
-               address_family:
-                  - afi: ipv4
-                    safi: unicast
-                    allowas_in:
-                       value: 4
-                    route_map:
-                       - name: aa
-                         direction: in
-                       - name: aa
-                         direction: out
-                    route_reflector_client: true
-                    route_server_client: true
-     state: deleted
-
-# After state:
-# ------------
-# !
-# router bgp 4
-#  !
-#  neighbor interface Eth1/3
-#   !
-#   address-family ipv4 unicast
-#    send-community both
-# !
-
-
-# Using "deleted" state
-#
-# Before state:
-# -------------
-#
-# !
-# router bgp 4
-#  !
-#  neighbor interface Eth1/3
-#   !
-#   address-family ipv4 unicast
-#    activate
-#    allowas-in 4
-#    route-map aa in
-#    route-map aa out
-#    route-reflector-client
-#    route-server-client
-#    send-community both
-# !
-#  neighbor interface Eth1/5
-#   !
-#   address-family ipv4 unicast
-#    activate
-#    allowas-in origin
-#    send-community both
-# !
-#
-- name: Deletes neighbors address-family with specific values
-  dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
-     config:
-     state: deleted
-
-# After state:
-# ------------
-# !
-# router bgp 4
-# !
-
-
-# Using "deleted" state
-#
-# Before state:
-# -------------
-#
-# !
-# router bgp 4
-#  !
-#  neighbor interface Eth1/3
-# !
-#
-- name: Merges neighbors address-family with specific values
-  dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
-     config:
-        - bgp_as: 4
-          neighbors:
-             - neighbor: Eth1/3
-               address_family:
-                  - afi: ipv4
-                    safi: unicast
-                    allowas_in:
-                       value: 4
-                    route_map:
-                       - name: aa
-                         direction: in
-                       - name: aa
-                         direction: out
-                    route_reflector_client: true
-                    route_server_client: true
-     state: merged
-
-# After state:
-# ------------
-# !
-# router bgp 4
-#  !
-#  neighbor interface Eth1/3
-#   !
-#   address-family ipv4 unicast
-#    activate
-#    allowas-in 4
-#    route-map aa in
-#    route-map aa out
-#    route-reflector-client
-#    route-server-client
-#    send-community both
-# !
-
-
-# Using "merged" state
-#
-# Before state:
-# -------------
-#
-# sonic# show running-configuration bgp neighbor vrf default 1.1.1.1
-# (No bgp neighbor configuration present)
-- name: "Configure BGP neighbor prefix-list attributes"
-  dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
-     config:
-        - bgp_as: 51
-          neighbors:
-             - neighbor: 1.1.1.1
-               address_family:
-                  - afi: ipv4
-                    safi: unicast
-                    ip_afi:
-                       default_policy_name: rmap_reg1
-                       send_default_route: true
-                    prefix_limit:
-                       max_prefixes: 1
-                       prevent_teardown: true
-                       warning_threshold: 80
-                    prefix_list_in: p1
-                    prefix_list_out: p2
-     state: merged
-# After state:
-# ------------
-#
-# sonic# show running-configuration bgp neighbor vrf default 1.1.1.1
-# !
-# neighbor 1.1.1.1
+# neighbor interface Eth1/3
 #  !
 #  address-family ipv4 unicast
-#   default-originate route-map rmap_reg1
-#   prefix-list p1 in
-#   prefix-list p2 out
+#   activate
+#   allowas-in 4
+#   route-map aa in
+#   route-map aa out
+#   route-reflector-client
+#   route-server-client
 #   send-community both
-#   maximum-prefix 1 80 warning-only
+# !
+
+- name: Delete specific BGP neighbors AF attributes
+  dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
+     config:
+        - bgp_as: 4
+          neighbors:
+             - neighbor: Eth1/3
+               address_family:
+                  - afi: ipv4
+                    safi: unicast
+                    allowas_in:
+                       value: 4
+                    route_map:
+                       - name: aa
+                         direction: in
+                       - name: aa
+                         direction: out
+                    route_reflector_client: true
+                    route_server_client: true
+     state: deleted
+
+# After state:
+# ------------
+#
+# sonic# show running-configuration bgp neighbor vrf default
+# !
+# neighbor interface Eth1/3
+#  !
+#  address-family ipv4 unicast
+#   send-community both
+# !
 
 
 # Using "deleted" state
@@ -362,7 +232,7 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# sonic# show running-configuration bgp neighbor vrf default 1.1.1.1
+# sonic# show running-configuration bgp neighbor vrf default
 # !
 # neighbor 1.1.1.1
 #  !
@@ -372,7 +242,8 @@ EXAMPLES = """
 #   prefix-list p2 out
 #   send-community both
 #   maximum-prefix 5 90 restart 2
-- name: "Delete BGP neighbor prefix-list attributes"
+
+- name: Delete BGP neighbors AF prefix-list attributes
   dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
      config:
         - bgp_as: 51
@@ -391,15 +262,152 @@ EXAMPLES = """
                     prefix_list_in: p1
                     prefix_list_out: p2
      state: deleted
-# sonic# show running-configuration bgp neighbor vrf default 1.1.1.1
+
+# After state:
+# ------------
+#
+# sonic# show running-configuration bgp neighbor vrf default
+# !
+# neighbor 1.1.1.1
+# !
+
+
+# Using "deleted" state
+#
+# Before state:
+# -------------
+#
+# sonic# show running-configuration bgp neighbor vrf default
+# !
+# neighbor interface Eth1/3
+#  !
+#  address-family ipv4 unicast
+#   activate
+#   allowas-in 4
+#   route-map aa in
+#   route-map aa out
+#   route-reflector-client
+#   route-server-client
+#   send-community both
+# !
+# neighbor interface Eth1/5
+#  !
+#  address-family ipv4 unicast
+#   activate
+#   allowas-in origin
+#   send-community both
+# !
+
+- name: Delete all BGP neighbors AF configuration
+  dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
+     config:
+     state: deleted
+
+# After state:
+# ------------
+#
+# sonic# show running-configuration bgp neighbor vrf default
 # (No bgp neighbor configuration present)
+
+
+# Using "merged" state
+#
+# Before state:
+# -------------
+#
+# sonic# show running-configuration bgp neighbor vrf default
+# !
+# neighbor interface Eth1/3
+# !
+
+- name: Merge BGP neighbors AF configuration
+  dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
+     config:
+        - bgp_as: 4
+          neighbors:
+             - neighbor: Eth1/3
+               address_family:
+                  - afi: ipv4
+                    safi: unicast
+                    allowas_in:
+                       value: 4
+                    route_map:
+                       - name: aa
+                         direction: in
+                       - name: aa
+                         direction: out
+                    route_reflector_client: true
+                    route_server_client: true
+     state: merged
+
+# After state:
+# ------------
+#
+# sonic# show running-configuration bgp neighbor vrf default
+# !
+# neighbor interface Eth1/3
+#  !
+#  address-family ipv4 unicast
+#   activate
+#   allowas-in 4
+#   route-map aa in
+#   route-map aa out
+#   route-reflector-client
+#   route-server-client
+#   send-community both
+# !
+
+
+# Using "merged" state
+#
+# Before state:
+# -------------
+#
+# sonic# show running-configuration bgp neighbor vrf default
+# (No bgp neighbor configuration present)
+
+- name: Configure BGP neighbors AF prefix-list attributes
+  dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
+     config:
+        - bgp_as: 51
+          neighbors:
+             - neighbor: 1.1.1.1
+               address_family:
+                  - afi: ipv4
+                    safi: unicast
+                    ip_afi:
+                       default_policy_name: rmap_reg1
+                       send_default_route: true
+                    prefix_limit:
+                       max_prefixes: 1
+                       prevent_teardown: true
+                       warning_threshold: 80
+                    prefix_list_in: p1
+                    prefix_list_out: p2
+     state: merged
+
+# After state:
+# ------------
+#
+# sonic# show running-configuration bgp neighbor vrf default
+# !
+# neighbor 1.1.1.1
+#  !
+#  address-family ipv4 unicast
+#   default-originate route-map rmap_reg1
+#   prefix-list p1 in
+#   prefix-list p2 out
+#   send-community both
+#   maximum-prefix 1 80 warning-only
+# !
+
 
 # Using "replaced" state
 #
 # Before state:
 # -------------
 #
-# sonic# show running-configuration bgp neighbor vrf default 1.1.1.1
+# sonic# show running-configuration bgp neighbor vrf default
 # !
 # neighbor 1.1.1.1
 #  !
@@ -409,7 +417,9 @@ EXAMPLES = """
 #   prefix-list p2 out
 #   send-community both
 #   maximum-prefix 5 90 restart 2
-- name: "Replace BGP neighbor address-family attributes"
+# !
+
+- name: Replace BGP neighbors AF attributes
   dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
      config:
         - bgp_as: 51
@@ -428,10 +438,11 @@ EXAMPLES = """
                     prefix_list_in: p1
                     prefix_list_out: p2
      state: replaced
+
 # After state:
 # ------------
 #
-# sonic# show running-configuration bgp neighbor vrf default 1.1.1.1
+# sonic# show running-configuration bgp neighbor vrf default
 # !
 # neighbor 1.1.1.1
 #  !
@@ -441,14 +452,15 @@ EXAMPLES = """
 #   prefix-list p2 out
 #   send-community both
 #   maximum-prefix 1 80 warning-only
-#
-#
+# !
+
+
 # Using "overridden" state
 #
 # Before state:
 # -------------
 #
-# sonic# show running-configuration bgp neighbor vrf default 1.1.1.1
+# sonic# show running-configuration bgp neighbor vrf default
 # !
 # neighbor 1.1.1.1
 #  !
@@ -458,7 +470,9 @@ EXAMPLES = """
 #   prefix-list p2 out
 #   send-community both
 #   maximum-prefix 5 90 restart 2
-- name: "Override BGP neighbors"
+# !
+
+- name: Override BGP neighbors AF configuration
   dellemc.enterprise_sonic.sonic_bgp_neighbors_af:
      config:
         - bgp_as: 51
@@ -476,13 +490,14 @@ EXAMPLES = """
                        warning_threshold: 80
                     prefix_list_in: p1
                     prefix_list_out: p2
-     state: replaced
+     state: overridden
+
 # After state:
 # ------------
 #
-# sonic# show running-configuration bgp neighbor vrf default 1.1.1.1
+# sonic# show running-configuration bgp neighbor vrf default
 # !
-# neighbor 1.1.1.1
+# neighbor 2.2.2.2
 #  !
 #  address-family ipv4 unicast
 #   default-originate route-map rmap_reg1
@@ -490,6 +505,7 @@ EXAMPLES = """
 #   prefix-list p2 out
 #   send-community both
 #   maximum-prefix 1 80 warning-only
+# !
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I fixed typos in the configuration examples for BGP neighbors AF.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_bgp_neighbors_af

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)