### PR TITLE
Fix VRFs bug for overridden state

### DIFF
--- a/changelogs/fragments/569-vrfs-bugfix.yaml
+++ b/changelogs/fragments/569-vrfs-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_vrfs - Fix VRFs bug for overridden state (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/569).

--- a/playbooks/common_examples/mgmt_vrf_config.yaml
+++ b/playbooks/common_examples/mgmt_vrf_config.yaml
@@ -26,4 +26,4 @@
           - vlan_id: 12
         state: merged
     - name: Turn off management VRF
-      ansible.builtin.include_tasks: mgmt_vrf_off.yaml          
+      ansible.builtin.include_tasks: mgmt_vrf_off.yaml

--- a/playbooks/common_examples/mgmt_vrf_config.yaml
+++ b/playbooks/common_examples/mgmt_vrf_config.yaml
@@ -25,3 +25,5 @@
           - vlan_id: 11
           - vlan_id: 12
         state: merged
+    - name: Turn off management VRF
+      ansible.builtin.include_tasks: mgmt_vrf_off.yaml          

--- a/playbooks/common_examples/mgmt_vrf_config.yaml
+++ b/playbooks/common_examples/mgmt_vrf_config.yaml
@@ -25,5 +25,3 @@
           - vlan_id: 11
           - vlan_id: 12
         state: merged
-    - name: Turn off management VRF
-      ansible.builtin.include_tasks: mgmt_vrf_off.yaml

--- a/playbooks/common_examples/mgmt_vrf_off.yaml
+++ b/playbooks/common_examples/mgmt_vrf_off.yaml
@@ -1,0 +1,8 @@
+---
+- name: Delete mgmt VRF configuration
+  vars:
+    ansible_connection: network_cli
+  sonic_config:
+    commands:
+      - "no ip vrf mgmt"
+  register: output

--- a/playbooks/common_examples/mgmt_vrf_off.yaml
+++ b/playbooks/common_examples/mgmt_vrf_off.yaml
@@ -1,7 +1,0 @@
----
-- name: Delete mgmt VRF configuration
-  sonic_vrfs:
-    config:
-      - name: mgmt
-    state: deleted
-  ignore_errors: true  # noqa: ignore-errors

--- a/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
+++ b/plugins/module_utils/network/sonic/config/vrfs/vrfs.py
@@ -264,10 +264,9 @@ class Vrfs(ConfigBase):
 
         commands = []
         requests = []
+        want, have = self.preprocess_mgmt_vrf_for_overridden(want, have)
 
         if have and have != want:
-            want, have = self.preprocess_mgmt_vrf_for_overridden(want, have)
-
             self.delete_all_flag = True
             del_requests = self.get_delete_vrf_interface_requests(have, have)
             requests.extend(del_requests)

--- a/plugins/modules/sonic_vrfs.py
+++ b/plugins/modules/sonic_vrfs.py
@@ -18,7 +18,7 @@ version_added: 1.0.0
 notes:
   - Tested against Enterprise SONiC Distribution by Dell Technologies.
   - Supports C(check_mode).
-  - This module does not support the deletion of mgmt VRF. Deletion of mgmt VRF can be done via SONiC CLI or REST API.
+  - This module does not support the deletion of mgmt VRF. Deletion of mgmt VRF can be done using the "sonic_config" resource module as shown in "playbooks/common_examples/mgmt_vrf_off.yaml". It can also be done using the SONiC CLI or by using a standalone REST API.
 short_description: Manage VRFs and associate VRFs to interfaces such as, Eth, LAG, VLAN, and loopback
 description: Manages VRF and VRF interface attributes in Enterprise SONiC Distribution by Dell Technologies.
 author: Abirami N (@abirami-n)

--- a/plugins/modules/sonic_vrfs.py
+++ b/plugins/modules/sonic_vrfs.py
@@ -18,7 +18,9 @@ version_added: 1.0.0
 notes:
   - Tested against Enterprise SONiC Distribution by Dell Technologies.
   - Supports C(check_mode).
-  - This module does not support the deletion of mgmt VRF. Deletion of mgmt VRF can be done using the "sonic_config" resource module as shown in "playbooks/common_examples/mgmt_vrf_off.yaml". It can also be done using the SONiC CLI or by using a standalone REST API.
+  - This module does not support the deletion of mgmt VRF.
+    Deletion of mgmt VRF can be done using the "sonic_config" resource module as shown in "playbooks/common_examples/mgmt_vrf_off.yaml".
+    It can also be done using the SONiC CLI or by using a standalone REST API.
 short_description: Manage VRFs and associate VRFs to interfaces such as, Eth, LAG, VLAN, and loopback
 description: Manages VRF and VRF interface attributes in Enterprise SONiC Distribution by Dell Technologies.
 author: Abirami N (@abirami-n)

--- a/plugins/modules/sonic_vrfs.py
+++ b/plugins/modules/sonic_vrfs.py
@@ -16,9 +16,9 @@ DOCUMENTATION = """
 module: sonic_vrfs
 version_added: 1.0.0
 notes:
-- Tested against Enterprise SONiC Distribution by Dell Technologies.
-- Supports C(check_mode).
-short_description: Manage VRFs and associate VRFs to interfaces such as, Eth, LAG, VLAN, and loopback
+  - Tested against Enterprise SONiC Distribution by Dell Technologies.
+  - Supports C(check_mode).
+  - This module does not support the deletion of mgmt VRF. Deletion of mgmt VRF can be done via SONiC CLI or REST API.
 description: Manages VRF and VRF interface attributes in Enterprise SONiC Distribution by Dell Technologies.
 author: Abirami N (@abirami-n)
 options:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I fixed a  VRFs bug for overridden state.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_vrfs

##### OUTPUT
<!--- Paste the functionality test result below -->
[regression-2025-06-19-10-50-46.html.pdf](https://github.com/user-attachments/files/20823893/regression-2025-06-19-10-50-46.html.pdf)

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)