### PR TITLE
update qos wred ansible for yellow red colors

### DIFF
--- a/plugins/module_utils/network/sonic/argspec/qos_wred/qos_wred.py
+++ b/plugins/module_utils/network/sonic/argspec/qos_wred/qos_wred.py
@@ -40,7 +40,7 @@ class Qos_wredArgs(object):  # pylint: disable=R0903
         'config': {
             'elements': 'dict',
             'options': {
-                'ecn': {'choices': ['green'], 'type': 'str'},
+                'ecn': {'choices': ['ALL', 'NONE'], 'type': 'str'},
                 'green': {
                     'options': {
                         'drop_probability': {'type': 'int'},
@@ -49,6 +49,27 @@ class Qos_wredArgs(object):  # pylint: disable=R0903
                         'min_threshold': {'type': 'int'}
                     },
                     'type': 'dict'
+                },
+                'red':
+                {
+                    'options': {
+                        'drop_probability': {'type': 'int'},
+                        'enable': {'type': 'bool'},
+                        'max_threshold': {'type': 'int'},
+                        'min_threshold': {'type': 'int'}
+                    },
+                    'type': 'dict'
+                },
+                'yellow':
+                {
+                    'options': {
+                        'drop_probability': {'type': 'int'},
+                        'enable': {'type': 'bool'},
+                        'max_threshold': {'type': 'int'},
+                        'min_threshold': {'type': 'int'}
+                    },
+                    'type': 'dict'
+
                 },
                 'name': {'required': True, 'type': 'str'}
             },

--- a/plugins/module_utils/network/sonic/config/qos_wred/qos_wred.py
+++ b/plugins/module_utils/network/sonic/config/qos_wred/qos_wred.py
@@ -261,7 +261,7 @@ class Qos_wred(ConfigBase):
 
     def get_modify_qos_wred_request(self, commands):
         request = None
-        lookup_dict = {'green': 'ECN_GREEN'}
+        lookup_dict = {'ALL': 'ECN_ALL'}
 
         if commands:
             wred_list = []
@@ -270,6 +270,8 @@ class Qos_wred(ConfigBase):
                 name = wred.get('name')
                 ecn = wred.get('ecn')
                 green = wred.get('green')
+                red = wred.get('red')
+                yellow = wred.get('yellow')
                 if green:
                     enable = green.get('enable')
                     min_threshold = green.get('min_threshold')
@@ -284,6 +286,34 @@ class Qos_wred(ConfigBase):
                         config_dict['green-max-threshold'] = str(max_threshold)
                     if drop_probability is not None:
                         config_dict['green-drop-probability'] = str(drop_probability)
+                if red:
+                    enable = red.get('enable')
+                    min_threshold = red.get('min_threshold')
+                    max_threshold = red.get('max_threshold')
+                    drop_probability = red.get('drop_probability')
+
+                    if enable is not None:
+                        config_dict['wred-red-enable'] = enable
+                    if min_threshold:
+                        config_dict['red-min-threshold'] = str(min_threshold)
+                    if max_threshold:
+                        config_dict['red-max-threshold'] = str(max_threshold)
+                    if drop_probability is not None:
+                        config_dict['red-drop-probability'] = str(drop_probability)
+                if yellow:
+                    enable = yellow.get('enable')
+                    min_threshold = yellow.get('min_threshold')
+                    max_threshold = yellow.get('max_threshold')
+                    drop_probability = yellow.get('drop_probability')
+
+                    if enable is not None:
+                        config_dict['wred-yellow-enable'] = enable
+                    if min_threshold:
+                        config_dict['yellow-min-threshold'] = str(min_threshold)
+                    if max_threshold:
+                        config_dict['yellow-max-threshold'] = str(max_threshold)
+                    if drop_probability is not None:
+                        config_dict['yellow-drop-probability'] = str(drop_probability)
                 if ecn:
                     config_dict['ecn'] = lookup_dict[ecn]
                 if name:
@@ -310,10 +340,14 @@ class Qos_wred(ConfigBase):
             name = wred.get('name')
             ecn = wred.get('ecn')
             green = wred.get('green')
+            red = wred.get('red')
+            yellow = wred.get('yellow')
             for cfg_wred in have:
                 cfg_name = cfg_wred.get('name')
                 cfg_ecn = cfg_wred.get('ecn')
                 cfg_green = cfg_wred.get('green')
+                cfg_red = cfg_wred.get('red')
+                cfg_yellow = cfg_wred.get('yellow')
 
                 if name == cfg_name:
                     wred_dict = {}
@@ -347,6 +381,62 @@ class Qos_wred(ConfigBase):
                                 green_dict['drop_probability'] = drop_probability
                             if green_dict:
                                 wred_dict.update({'name': name, 'green': green_dict})
+                    if red:
+                        enable = red.get('enable')
+                        min_threshold = red.get('min_threshold')
+                        max_threshold = red.get('max_threshold')
+                        drop_probability = red.get('drop_probability')
+
+                        if cfg_red:
+                            red_dict = {}
+                            cfg_enable = cfg_red.get('enable')
+                            cfg_min_threshold = cfg_red.get('min_threshold')
+                            cfg_max_threshold = cfg_red.get('max_threshold')
+                            cfg_drop_probability = cfg_red.get('drop_probability')
+
+                            if enable is not None and enable == cfg_enable:
+                                requests.append(self.get_delete_wred_cfg_attr(name, 'wred-red-enable'))
+                                red_dict['enable'] = enable
+                            if min_threshold and min_threshold == cfg_min_threshold:
+                                requests.append(self.get_delete_wred_cfg_attr(name, 'red-min-threshold'))
+                                red_dict['min_threshold'] = min_threshold
+                            if max_threshold and max_threshold == cfg_max_threshold:
+                                requests.append(self.get_delete_wred_cfg_attr(name, 'red-max-threshold'))
+                                red_dict['max_threshold'] = max_threshold
+                            if drop_probability is not None and drop_probability == cfg_drop_probability:
+                                requests.append(self.get_delete_wred_cfg_attr(name, 'red-drop-probability'))
+                                red_dict['drop_probability'] = drop_probability
+                            if red_dict:
+                                wred_dict.update({'name': name, 'red': red_dict})
+
+                    if yellow:
+                        enable = yellow.get('enable')
+                        min_threshold = yellow.get('min_threshold')
+                        max_threshold = yellow.get('max_threshold')
+                        drop_probability = yellow.get('drop_probability')
+
+                        if cfg_yellow:
+                            yellow_dict = {}
+                            cfg_enable = cfg_yellow.get('enable')
+                            cfg_min_threshold = cfg_yellow.get('min_threshold')
+                            cfg_max_threshold = cfg_yellow.get('max_threshold')
+                            cfg_drop_probability = cfg_yellow.get('drop_probability')
+
+                            if enable is not None and enable == cfg_enable:
+                                requests.append(self.get_delete_wred_cfg_attr(name, 'wred-yellow-enable'))
+                                yellow_dict['enable'] = enable
+                            if min_threshold and min_threshold == cfg_min_threshold:
+                                requests.append(self.get_delete_wred_cfg_attr(name, 'yellow-min-threshold'))
+                                yellow_dict['min_threshold'] = min_threshold
+                            if max_threshold and max_threshold == cfg_max_threshold:
+                                requests.append(self.get_delete_wred_cfg_attr(name, 'yellow-max-threshold'))
+                                yellow_dict['max_threshold'] = max_threshold
+                            if drop_probability is not None and drop_probability == cfg_drop_probability:
+                                requests.append(self.get_delete_wred_cfg_attr(name, 'yellow-drop-probability'))
+                                yellow_dict['drop_probability'] = drop_probability
+                            if yellow_dict:
+                                wred_dict.update({'name': name, 'yellow': yellow_dict})
+
                     # Deletion my WRED profile name
                     if not ecn and not green:
                         url = '%s=%s' % (QOS_WRED_PATH, name)

--- a/plugins/module_utils/network/sonic/facts/qos_wred/qos_wred.py
+++ b/plugins/module_utils/network/sonic/facts/qos_wred/qos_wred.py
@@ -69,7 +69,7 @@ class Qos_wredFacts(object):
 
     def update_qos_wred(self, cfg):
         config_list = []
-        lookup_dict = {'ECN_GREEN': 'green'}
+        lookup_dict = {'ECN_ALL': 'ALL', 'ECN_NONE' : 'NONE'}
 
         if cfg:
             wred_profiles = cfg.get('wred-profile')
@@ -80,12 +80,21 @@ class Qos_wredFacts(object):
                     config = profile.get('config')
                     if config:
                         green_dict = {}
+                        red_dict = {}
+                        yellow_dict = {}
                         ecn = config.get('ecn')
                         wred_green_enable = config.get('wred-green-enable')
                         green_min_threshold = config.get('green-min-threshold')
                         green_max_threshold = config.get('green-max-threshold')
                         green_drop_probability = config.get('green-drop-probability')
-
+                        wred_red_enable = config.get('wred-red-enable')
+                        red_min_threshold = config.get('red-min-threshold')
+                        red_max_threshold = config.get('red-max-threshold')
+                        red_drop_probability = config.get('red-drop-probability')
+                        wred_yellow_enable = config.get('wred-yellow-enable')
+                        yellow_min_threshold = config.get('yellow-min-threshold')
+                        yellow_max_threshold = config.get('yellow-max-threshold')
+                        yellow_drop_probability = config.get('yellow-drop-probability')
                         if ecn:
                             wred_dict['ecn'] = lookup_dict[ecn]
                         if wred_green_enable is not None:
@@ -98,6 +107,28 @@ class Qos_wredFacts(object):
                             green_dict['drop_probability'] = green_drop_probability
                         if green_dict:
                             wred_dict['green'] = green_dict
+                        if wred_red_enable is not None:
+                            red_dict['enable'] = wred_red_enable
+                        if red_min_threshold:
+                            red_dict['min_threshold'] = red_min_threshold
+                        if red_max_threshold:
+                            red_dict['max_threshold'] = red_max_threshold
+                        if red_drop_probability:
+                            red_dict['drop_probability'] = red_drop_probability
+                        if red_dict:
+                            wred_dict['red'] = red_dict
+
+                        if wred_yellow_enable is not None:
+                            yellow_dict['enable'] = wred_yellow_enable
+                        if yellow_min_threshold:
+                            yellow_dict['min_threshold'] = yellow_min_threshold
+                        if yellow_max_threshold:
+                            yellow_dict['max_threshold'] = yellow_max_threshold
+                        if yellow_drop_probability:
+                            yellow_dict['drop_probability'] = yellow_drop_probability
+                        if yellow_dict:
+                            wred_dict['yellow'] = yellow_dict
+
                     if name:
                         wred_dict['name'] = name
                     if wred_dict:

--- a/plugins/modules/sonic_qos_wred.py
+++ b/plugins/modules/sonic_qos_wred.py
@@ -39,7 +39,8 @@ options:
           - ECN setting for colored packets
         type: str
         choices:
-          - green
+          - 'ALL'
+          - 'NONE'
       green:
         description:
           - WRED configuration for green packets
@@ -62,6 +63,54 @@ options:
           drop_probability:
             description:
               - Drop probablity percentage rate for green packets
+              - Range 0-100
+            type: int
+      yellow:
+        description:
+          - WRED configuration for yellow packets
+        type: dict
+        suboptions:
+          enable:
+            description:
+              - Enable or disable WRED for yellow packets
+            type: bool
+          min_threshold:
+            description:
+              - Minimum threshold set for yellow packets in bytes
+              - Range 1000-12480000
+            type: int
+          max_threshold:
+            description:
+              - Maximum threshold set for yellow packets in bytes
+              - Range 1000-12480000
+            type: int
+          drop_probability:
+            description:
+              - Drop probablity percentage rate for yellow packets
+              - Range 0-100
+            type: int
+      red:
+        description:
+          - WRED configuration for red packets
+        type: dict
+        suboptions:
+          enable:
+            description:
+              - Enable or disable WRED for red packets
+            type: bool
+          min_threshold:
+            description:
+              - Minimum threshold set for red packets in bytes
+              - Range 1000-12480000
+            type: int
+          max_threshold:
+            description:
+              - Maximum threshold set for red packets in bytes
+              - Range 1000-12480000
+            type: int
+          drop_probability:
+            description:
+              - Drop probablity percentage rate for red packets
               - Range 0-100
             type: int
   state:
@@ -95,6 +144,16 @@ EXAMPLES = """
           min_threshold: 1000
           max_threshold: 5000
           drop_probability: 25
+        red:
+          enable: true
+          min_threshold: 1000
+          max_threshold: 5000
+          drop_probability: 25
+        yellow:
+          enable: true
+          min_threshold: 1000
+          max_threshold: 5000
+          drop_probability: 25
     state: merged
 
 # After state:
@@ -104,10 +163,16 @@ EXAMPLES = """
 # ---------------------------------------------------
 # Policy                 : profile1
 # ---------------------------------------------------
-# ecn                    : ecn_green
+# ecn                    : ecn_all
 # green-min-threshold    : 1           KBytes
 # green-max-threshold    : 5           KBytes
 # green-drop-probability : 25
+# red-min-threshold    : 1           KBytes
+# red-max-threshold    : 5           KBytes
+# red-drop-probability : 25
+# yellow-min-threshold    : 1           KBytes
+# yellow-max-threshold    : 5           KBytes
+# yellow-drop-probability : 25
 #
 #
 # Using "replaced" state
@@ -119,10 +184,17 @@ EXAMPLES = """
 # ---------------------------------------------------
 # Policy                 : profile1
 # ---------------------------------------------------
-# ecn                    : ecn_green
+# ecn                    : ecn_all
 # green-min-threshold    : 1           KBytes
 # green-max-threshold    : 5           KBytes
 # green-drop-probability : 25
+# red-min-threshold    : 1           KBytes
+# red-max-threshold    : 5           KBytes
+# red-drop-probability : 25
+# yellow-min-threshold    : 1           KBytes
+# yellow-max-threshold    : 5           KBytes
+# yellow-drop-probability : 25
+
 
 - name: Replace QoS WRED policy configuration
   dellemc.enterprise_sonic.sonic_qos_wred:
@@ -150,10 +222,16 @@ EXAMPLES = """
 # ---------------------------------------------------
 # Policy                 : profile1
 # ---------------------------------------------------
-# ecn                    : ecn_green
+# ecn                    : ecn_all
 # green-min-threshold    : 1           KBytes
 # green-max-threshold    : 5           KBytes
 # green-drop-probability : 25
+# red-min-threshold    : 1           KBytes
+# red-max-threshold    : 5           KBytes
+# red-drop-probability : 25
+# yellow-min-threshold    : 1           KBytes
+# yellow-max-threshold    : 5           KBytes
+# yellow-drop-probability : 25
 
 - name: Override QoS WRED policy configuration
   dellemc.enterprise_sonic.sonic_qos_wred:
@@ -174,10 +252,16 @@ EXAMPLES = """
 # ---------------------------------------------------
 # Policy                 : profile2
 # ---------------------------------------------------
-# ecn                    : ecn_green
+# ecn                    : ecn_all
 # green-min-threshold    : 3           KBytes
 # green-max-threshold    : 9           KBytes
 # green-drop-probability : 75
+# red-min-threshold    : 1           KBytes
+# red-max-threshold    : 5           KBytes
+# red-drop-probability : 25
+# yellow-min-threshold    : 1           KBytes
+# yellow-max-threshold    : 5           KBytes
+# yellow-drop-probability : 25
 #
 #
 # Using "deleted" state
@@ -189,17 +273,29 @@ EXAMPLES = """
 # ---------------------------------------------------
 # Policy                 : profile1
 # ---------------------------------------------------
-# ecn                    : ecn_green
+# ecn                    : ecn_all
 # green-min-threshold    : 1           KBytes
 # green-max-threshold    : 5           KBytes
 # green-drop-probability : 25
+# red-min-threshold    : 1           KBytes
+# red-max-threshold    : 5           KBytes
+# red-drop-probability : 25
+# yellow-min-threshold    : 1           KBytes
+# yellow-max-threshold    : 5           KBytes
+# yellow-drop-probability : 25
 # ---------------------------------------------------
 # Policy                 : profile2
 # ---------------------------------------------------
-# ecn                    : ecn_green
+# ecn                    : ecn_all
 # green-min-threshold    : 3           KBytes
 # green-max-threshold    : 9           KBytes
 # green-drop-probability : 75
+# red-min-threshold    : 1           KBytes
+# red-max-threshold    : 5           KBytes
+# red-drop-probability : 25
+# yellow-min-threshold    : 1           KBytes
+# yellow-max-threshold    : 5           KBytes
+# yellow-drop-probability : 25
 
 - name: Delete QoS WRED policy configuration
   dellemc.enterprise_sonic.sonic_qos_wred:
@@ -219,8 +315,14 @@ EXAMPLES = """
 # ---------------------------------------------------
 # Policy                 : profile2
 # ---------------------------------------------------
-# ecn                    : ecn_green
+# ecn                    : ecn_all
 # green-drop-probability : 75
+# red-min-threshold    : 1           KBytes
+# red-max-threshold    : 5           KBytes
+# red-drop-probability : 25
+# yellow-min-threshold    : 1           KBytes
+# yellow-max-threshold    : 5           KBytes
+# yellow-drop-probability : 25
 """
 
 RETURN = """

--- a/tests/regression/roles/sonic_qos_wred/defaults/main.yml
+++ b/tests/regression/roles/sonic_qos_wred/defaults/main.yml
@@ -8,20 +8,39 @@ tests:
     state: merged
     input:
       - name: profile1
-        ecn: green
+        ecn: ALL
         green:
           enable: True
           min_threshold: 1000
           max_threshold: 5000
           drop_probability: 25
+        red:
+          enable: True
+          min_threshold: 1000
+          max_threshold: 5000
+          drop_probability: 25
+        yellow:
+          enable: True
+          min_threshold: 1000
+          max_threshold: 5000
+          drop_probability: 25
       - name: profile2
-        ecn: green
+        ecn: ALL
         green:
           enable: True
           min_threshold: 12000
           max_threshold: 48000
           drop_probability: 50
-
+        red:
+          enable: True
+          min_threshold: 12000
+          max_threshold: 48000
+          drop_probability: 50
+        yellow:
+          enable: True
+          min_threshold: 12000
+          max_threshold: 48000
+          drop_probability: 50
   - name: test_case_02
     description: Update WRED profiles configuration
     state: merged
@@ -32,43 +51,70 @@ tests:
           min_threshold: 1500
           max_threshold: 6500
           drop_probability: 78
+        yellow:
+          enable: False
+          min_threshold: 2500
+          max_threshold: 6000
+          drop_probability: 78
       - name: profile3
-        ecn: green
+        ecn: ALL
         green:
           enable: True
           min_threshold: 3000
           max_threshold: 9000
           drop_probability: 10
-
+        red:
+          enable: True
+          min_threshold: 1500
+          max_threshold: 6500
+          drop_probability: 78
   - name: test_case_03
     description: Replace WRED profiles configuration
     state: replaced
     input:
       - name: profile1
-        ecn: green
+        ecn: ALL
       - name: profile3
         green:
           enable: False
           min_threshold: 4000
-
+        red:
+          enable: False
+          min_threshold: 1000
+          max_threshold: 5000
   - name: test_case_04
     description: Override WRED profiles configuration
     state: overridden
     input:
       - name: profile4
-        ecn: green
+        ecn: ALL
         green:
           enable: True
           min_threshold: 7000
           max_threshold: 40000
           drop_probability: 13
+        red:
+          enable: True
+          min_threshold: 7000
+          max_threshold: 40000
+          drop_probability: 25
+        yellow:
+          enable: True
+          min_threshold: 7000
+          max_threshold: 40000
+          drop_probability: 30
       - name: profile5
-        ecn: green
+        ecn: ALL
         green:
           enable: False
           min_threshold: 1000
           max_threshold: 2000
           drop_probability: 99
+        red:
+          enable: False
+          min_threshold: 1000
+          max_threshold: 3000
+          drop_probability: 50
       - name: profile6
 
   - name: test_case_05
@@ -77,13 +123,17 @@ tests:
     input:
       - name: profile4
       - name: profile5
-        ecn: green
+        ecn: ALL
         green:
           enable: False
           min_threshold: 1000
           max_threshold: 2000
           drop_probability: 99
- 
+        red:
+          enable: False
+          min_threshold: 1000
+          max_threshold: 3000
+          drop_probability: 50
   - name: test_case_06
     description: Delete all WRED profiles configuration
     state: deleted

--- a/tests/unit/modules/network/sonic/fixtures/sonic_qos_wred.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_qos_wred.yaml
@@ -2,12 +2,22 @@ merged_01:
   module_args:
     config:
       - name: profile1
-        ecn: green
+        ecn: ALL
         green:
           enable: True
           min_threshold: 1000
           max_threshold: 5000
           drop_probability: 25
+        red:
+          enable: True
+          min_threshold: 1000
+          max_threshold: 5000
+          drop_probability: 50
+        yellow:
+          enable: True
+          min_threshold: 1000
+          max_threshold: 5000
+          drop_probability: 30
   existing_qos_wred_config:
     - path: '/data/openconfig-qos:qos/wred-profiles'
       response:
@@ -21,10 +31,18 @@ merged_01:
             config:
               name: profile1
               green-min-threshold: '1000'
+              yellow-min-threshold: '1000'
+              red-min-threshold: '1000'
               green-max-threshold: '5000'
-              ecn: ECN_GREEN
+              yellow-max-threshold: '5000'
+              red-max-threshold: '5000'
+              ecn: ECN_ALL
               wred-green-enable: true
+              wred-yellow-enable: true
+              wred-red-enable: true
               green-drop-probability: '25'
+              yellow-drop-probability: '30'
+              red-drop-probability: '50'
 
 replaced_01:
   module_args:
@@ -33,6 +51,9 @@ replaced_01:
         green:
           enable: False
           drop_probability: 80
+        yellow:
+          enable: False
+          drop_probability: 100
     state: replaced
   existing_qos_wred_config:
     - path: '/data/openconfig-qos:qos/wred-profiles'
@@ -45,10 +66,19 @@ replaced_01:
                 config:
                   name: profile1
                   green-min-threshold: '1000'
+                  yellow-min-threshold: '1000'
+                  red-min-threshold: '1000'
                   green-max-threshold: '5000'
-                  ecn: ECN_GREEN
+                  yellow-max-threshold: '5000'
+                  red-max-threshold: '5000'
+                  ecn: ECN_ALL
                   wred-green-enable: true
+                  wred-yellow-enable: true
+                  wred-red-enable: true
                   green-drop-probability: '25'
+                  yellow-drop-probability: '30'
+                  red-drop-probability: '50'
+
   expected_config_requests:
     - path: '/data/openconfig-qos:qos/wred-profiles/wred-profile=profile1'
       method: 'delete'
@@ -62,13 +92,25 @@ replaced_01:
               name: profile1
               wred-green-enable: False
               green-drop-probability: '80'
+              wred-yellow-enable: False
+              yellow-drop-probability: '100'
 
 overridden_01:
   module_args:
     config:
       - name: profile2
-        ecn: green
+        ecn: ALL
         green:
+          enable: True
+          min_threshold: 3000
+          max_threshold: 9000
+          drop_probability: 75
+        red:
+          enable: True
+          min_threshold: 4000
+          max_threshold: 10000
+          drop_probability: 75
+        yellow:
           enable: True
           min_threshold: 3000
           max_threshold: 9000
@@ -85,10 +127,18 @@ overridden_01:
                 config:
                   name: profile1
                   green-min-threshold: '1000'
+                  yellow-min-threshold: '1000'
+                  red-min-threshold: '1000'
                   green-max-threshold: '5000'
-                  ecn: ECN_GREEN
+                  yellow-max-threshold: '5000'
+                  red-max-threshold: '5000'
+                  ecn: ECN_ALL
                   wred-green-enable: true
+                  wred-yellow-enable: true
+                  wred-red-enable: true
                   green-drop-probability: '25'
+                  yellow-drop-probability: '30'
+                  red-drop-probability: '50'
   expected_config_requests:
     - path: '/data/openconfig-qos:qos/wred-profiles/wred-profile'
       method: 'delete'
@@ -101,21 +151,34 @@ overridden_01:
             config:
               name: profile2
               green-min-threshold: '3000'
+              yellow-min-threshold: '3000'
+              red-min-threshold: '4000'
               green-max-threshold: '9000'
-              ecn: ECN_GREEN
+              yellow-max-threshold: '9000'
+              red-max-threshold: '10000'
+              ecn: ECN_ALL
               wred-green-enable: true
+              wred-yellow-enable: true
+              wred-red-enable: true
               green-drop-probability: '75'
+              yellow-drop-probability: '75'
+              red-drop-probability: '75'
 
 deleted_01:
   module_args:
     config:
       - name: profile1
       - name: profile2
-        ecn: green
+        ecn: ALL
         green:
           enable: True
           min_threshold: 3000
           max_threshold: 9000
+          drop_probability: 75
+        red:
+          enable: True
+          min_threshold: 4000
+          max_threshold: 10000
           drop_probability: 75
     state: deleted
   existing_qos_wred_config:
@@ -130,7 +193,7 @@ deleted_01:
                   name: profile1
                   green-min-threshold: '1000'
                   green-max-threshold: '5000'
-                  ecn: ECN_GREEN
+                  ecn: ECN_ALL
                   wred-green-enable: true
                   green-drop-probability: '25'
               - name: profile2
@@ -138,8 +201,8 @@ deleted_01:
                   name: profile2
                   green-min-threshold: '3000'
                   green-max-threshold: '9000'
-                  ecn: ECN_GREEN
-                  wred-green-enable: true     
+                  ecn: ECN_ALL
+                  wred-green-enable: true
                   green-drop-probability: '75'
   expected_config_requests:
     - path: '/data/openconfig-qos:qos/wred-profiles/wred-profile=profile1'


### PR DESCRIPTION
##### SUMMARY
Added Qos WRED ECN  support for yellow and red colors.


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
sonic_qos_wred

##### OUTPUT
[wred_ecn_regression_report.pdf](https://github.com/user-attachments/files/21248593/wred_ecn_regression_report.pdf)

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

