### PR TITLE
Fix mirroring regression test failures

### DIFF
--- a/changelogs/fragments/577-mirroring-regression-test-fix.yaml
+++ b/changelogs/fragments/577-mirroring-regression-test-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sonic_mirroring - Fix mirroring regression test failures (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/577).

--- a/changelogs/fragments/577-mirroring-regression-test-fix.yaml
+++ b/changelogs/fragments/577-mirroring-regression-test-fix.yaml
@@ -1,2 +1,3 @@
+---
 bugfixes:
   - sonic_mirroring - Fix mirroring regression test failures (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/577).

--- a/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
@@ -1,69 +1,68 @@
 ---
 ansible_connection: httpapi
-module_name: l2_interfaces
 
 preparations_tests:
-    add_vlans_input:
-        - vlan_id: 500
-        - vlan_id: 501
-        - vlan_id: 502
-        - vlan_id: 503
-        - vlan_id: 504
-        - vlan_id: 505
-        - vlan_id: 400
-        - vlan_id: 401
-        - vlan_id: 402
-        - vlan_id: 605
-        - vlan_id: 606
-        - vlan_id: 607
-        - vlan_id: 609
-        - vlan_id: 610
-        - vlan_id: 611
-        - vlan_id: 612
-        - vlan_id: 613
-        - vlan_id: 615
-        - vlan_id: 616
-        - vlan_id: 617
-        - vlan_id: 619
-        - vlan_id: 620
-        - vlan_id: 621
-        - vlan_id: 622
-        - vlan_id: 624
-        - vlan_id: 625
-        - vlan_id: 626
-        - vlan_id: 627
-        - vlan_id: 628
-        - vlan_id: 629
-        - vlan_id: 634
-        - vlan_id: 635
-        - vlan_id: 636
-        - vlan_id: 637
-        - vlan_id: 639
-        - vlan_id: 640
-        - vlan_id: 642
-        - vlan_id: 643
-        - vlan_id: 644
-        - vlan_id: 646
-        - vlan_id: 647
-        - vlan_id: 649
-        - vlan_id: 650
-        - vlan_id: 651
-        - vlan_id: 653
-        - vlan_id: 654
-        - vlan_id: 655
-        - vlan_id: 656
-        - vlan_id: 658
-        - vlan_id: 659
-        - vlan_id: 660
-    delete_port_configurations:
-          - name: "{{ interface1 }}"
-          - name: "{{ interface2 }}"
-          - name: "{{ interface3 }}"
-    add_lag_interfaces:
-      - name: PortChannel100
-      - name: PortChannel101
+  add_vlans_input:
+    - vlan_id: 500
+    - vlan_id: 501
+    - vlan_id: 502
+    - vlan_id: 503
+    - vlan_id: 504
+    - vlan_id: 505
+    - vlan_id: 400
+    - vlan_id: 401
+    - vlan_id: 402
+    - vlan_id: 605
+    - vlan_id: 606
+    - vlan_id: 607
+    - vlan_id: 609
+    - vlan_id: 610
+    - vlan_id: 611
+    - vlan_id: 612
+    - vlan_id: 613
+    - vlan_id: 615
+    - vlan_id: 616
+    - vlan_id: 617
+    - vlan_id: 619
+    - vlan_id: 620
+    - vlan_id: 621
+    - vlan_id: 622
+    - vlan_id: 624
+    - vlan_id: 625
+    - vlan_id: 626
+    - vlan_id: 627
+    - vlan_id: 628
+    - vlan_id: 629
+    - vlan_id: 634
+    - vlan_id: 635
+    - vlan_id: 636
+    - vlan_id: 637
+    - vlan_id: 639
+    - vlan_id: 640
+    - vlan_id: 642
+    - vlan_id: 643
+    - vlan_id: 644
+    - vlan_id: 646
+    - vlan_id: 647
+    - vlan_id: 649
+    - vlan_id: 650
+    - vlan_id: 651
+    - vlan_id: 653
+    - vlan_id: 654
+    - vlan_id: 655
+    - vlan_id: 656
+    - vlan_id: 658
+    - vlan_id: 659
+    - vlan_id: 660
+  delete_port_configurations:
+    - name: "{{ interface1 }}"
+    - name: "{{ interface2 }}"
+    - name: "{{ interface3 }}"
+  add_lag_interfaces:
+    - name: PortChannel100
+    - name: PortChannel101
 
-tests:
+sonic_l2_interfaces_tests:
   # merge test cases started
   - name: test_case_01
     description: Add access and trunk VLANs
@@ -104,7 +103,7 @@ tests:
         access:
           vlan: 402
   - name: test_case_03
-    description: Add trunk vlan range base config
+    description: Add trunk VLAN range base config
     state: merged
     input:
       - name: "{{ interface5 }}"
@@ -125,7 +124,7 @@ tests:
         access:
           vlan: 611
   - name: test_case_04
-    description: Add trunk vlan range overlay lower half
+    description: Add trunk VLAN range overlay lower half
     state: merged
     input:
       - name: "{{ interface5 }}"
@@ -141,7 +140,7 @@ tests:
         access:
           vlan: 611
   - name: test_case_05
-    description: Add trunk vlan range overlay all
+    description: Add trunk VLAN range overlay all
     state: merged
     input:
       - name: "{{ interface5 }}"
@@ -163,14 +162,14 @@ tests:
           vlan: 611
   # delete test cases started
   - name: test_case_06
-    description: Delete Access VLAN
+    description: Delete access VLANs from specified interface
     state: deleted
     input:
       - name: "{{ interface1 }}"
         access:
           vlan:
   - name: test_case_07
-    description: Delete specific trunk VLANs
+    description: Delete specified trunk VLAN
     state: deleted
     input:
       - name: "{{ interface3 }}"
@@ -178,7 +177,7 @@ tests:
           allowed_vlans:
             - vlan: 502
   - name: test_case_08
-    description: Delete access VLANs from both associations
+    description: Delete access VLANs from specified interface
     state: deleted
     input:
       - name: "{{ interface3 }}"
@@ -192,12 +191,12 @@ tests:
         trunk:
           allowed_vlans:
   - name: test_case_10
-    description: Delete all associations in specific interface
+    description: Delete L2 configuration for specified interface
     state: deleted
     input:
       - name: "{{ interface2 }}"
   - name: test_case_11
-    description: Delete trunk vlan range overlay base
+    description: Delete trunk VLAN range overlay base
     state: deleted
     input:
       - name: "{{ interface5 }}"
@@ -218,7 +217,7 @@ tests:
         access:
           vlan: 611
   - name: test_case_12
-    description: Delete trunk vlan range overlay lower half
+    description: Delete trunk VLAN range overlay lower half
     state: deleted
     input:
       - name: "{{ interface5 }}"
@@ -234,7 +233,7 @@ tests:
         access:
           vlan: 611
   - name: test_case_13
-    description: Delete trunk vlan range overlay all
+    description: Delete trunk VLAN range overlay all
     state: deleted
     input:
       - name: "{{ interface5 }}"
@@ -318,6 +317,6 @@ tests:
             - vlan: 600
             - vlan: 605
   - name: test_case_17
-    description: Delete All associations in all interfaces
+    description: Delete all L2 interfaces configuration
     state: deleted
     input: []

--- a/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
@@ -162,7 +162,7 @@ sonic_l2_interfaces_tests:
           vlan: 611
   # delete test cases started
   - name: test_case_06
-    description: Delete access VLANs from specified interface
+    description: Delete the access VLAN from the specified interface
     state: deleted
     input:
       - name: "{{ interface1 }}"

--- a/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
@@ -191,7 +191,7 @@ sonic_l2_interfaces_tests:
         trunk:
           allowed_vlans:
   - name: test_case_10
-    description: Delete L2 configuration for specified interface
+    description: Delete L2 configuration for the specified interface
     state: deleted
     input:
       - name: "{{ interface2 }}"

--- a/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
@@ -177,7 +177,7 @@ sonic_l2_interfaces_tests:
           allowed_vlans:
             - vlan: 502
   - name: test_case_08
-    description: Delete access VLANs from specified interface
+    description: Delete access VLANs from the specified interface
     state: deleted
     input:
       - name: "{{ interface3 }}"

--- a/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_l2_interfaces/defaults/main.yml
@@ -184,7 +184,7 @@ sonic_l2_interfaces_tests:
         access:
           vlan:
   - name: test_case_09
-    description: Delete all trunk VLANs
+    description: Delete all trunk VLANs for the specified interface
     state: deleted
     input:
       - name: "{{ interface3 }}"

--- a/tests/regression/roles/sonic_l2_interfaces/meta/main.yaml
+++ b/tests/regression/roles/sonic_l2_interfaces/meta/main.yaml
@@ -2,4 +2,4 @@
 collections:
   - dellemc.enterprise_sonic
 dependencies:
-  - { role: common }  
+  - { role: common }

--- a/tests/regression/roles/sonic_l2_interfaces/tasks/cleanup.yaml
+++ b/tests/regression/roles/sonic_l2_interfaces/tasks/cleanup.yaml
@@ -1,8 +1,11 @@
 ---
 - name: Delete LAG interfaces
   sonic_lag_interfaces:
-    config:
-      - name: Portchannel100
-      - name: Portchannel101
+    config: "{{ preparations_tests.add_lag_interfaces }}"
+    state: deleted
+  failed_when: false
+- name: Delete VLAN interfaces
+  sonic_vlans:
+    config: "{{ preparations_tests.add_vlans_input }}"
     state: deleted
   failed_when: false

--- a/tests/regression/roles/sonic_l2_interfaces/tasks/cleanup.yaml
+++ b/tests/regression/roles/sonic_l2_interfaces/tasks/cleanup.yaml
@@ -3,6 +3,6 @@
   sonic_lag_interfaces:
     config:
       - name: Portchannel100
-      - name: Portchannel200
+      - name: Portchannel101
     state: deleted
   failed_when: false

--- a/tests/regression/roles/sonic_l2_interfaces/tasks/main.yml
+++ b/tests/regression/roles/sonic_l2_interfaces/tasks/main.yml
@@ -1,8 +1,10 @@
-- debug: msg="sonic_l2_interfaces Test started ..."
+---
+- name: "Preparations for test"
+  ansible.builtin.include_tasks: preparation_tests.yaml
 
-- name: Preparations test, creates VLANs
-  include_tasks: preparation_tests.yaml
+- name: "Test started ..."
+  ansible.builtin.include_tasks: tasks_template.yaml
+  loop: "{{ sonic_l2_interfaces_tests }}"
 
-- name: "Test {{ module_name }} started ..."
-  include_tasks: tasks_template.yaml
-  loop: "{{ tests }}"
+- name: "Cleanup for test"
+  ansible.builtin.include_tasks: cleanup.yaml

--- a/tests/regression/roles/sonic_l2_interfaces/tasks/preparation_tests.yaml
+++ b/tests/regression/roles/sonic_l2_interfaces/tasks/preparation_tests.yaml
@@ -1,35 +1,40 @@
 ---
-- name: Delete existing mclag
+- name: Delete existing MCLAGs
   sonic_mclag:
-    config: 
+    config:
     state: deleted
-  ignore_errors: yes
-- name: Deletes old vxlans
+  failed_when: false
+
+- name: Delete existing VXLANs
   sonic_vxlans:
     config: []
     state: deleted
-  ignore_errors: yes
-- name: "initialize default interfaces"
+  failed_when: false
+
+- name: Initialize default interfaces
   vars:
     ansible_connection: network_cli
   sonic_config:
     commands: "{{ default_interface_cli }}"
   register: output
-  ignore_errors: yes
-- name: create sonic_lag_interfaces "merged" state
+  failed_when: false
+
+- name: Create LAG interfaces
   sonic_lag_interfaces:
     config: "{{ preparations_tests.add_lag_interfaces }}"
     state: merged
-  ignore_errors: yes 
-- name: Delete VLANs Inputs
+  failed_when: false
+
+- name: Delete existing VLANs
   sonic_vlans:
-   config: "{{ preparations_tests.add_vlans_input }}"
-   state: deleted
+    config: "{{ preparations_tests.add_vlans_input }}"
+    state: deleted
   register: merge_vlans_output
-  ignore_errors: yes
-- name: create VLANs 
+  failed_when: false
+
+- name: Create VLANs
   sonic_vlans:
-   config: "{{ preparations_tests.add_vlans_input }}"
-   state: merged
+    config: "{{ preparations_tests.add_vlans_input }}"
+    state: merged
   register: merge_vlans_output
-  ignore_errors: yes
+  failed_when: false

--- a/tests/regression/roles/sonic_l2_interfaces/tasks/tasks_template.yaml
+++ b/tests/regression/roles/sonic_l2_interfaces/tasks/tasks_template.yaml
@@ -1,21 +1,24 @@
-- name: "{{ item.name}} , {{ item.description}}"
+---
+- name: "{{ item.name ~ ' , ' ~ item.description }}"
   sonic_l2_interfaces:
     config: "{{ item.input }}"
     state: "{{ item.state }}"
   register: action_task_output
-  ignore_errors: yes
+  ignore_errors: true
 
-- import_role:
+- name: "Update test report"
+  ansible.builtin.import_role:
     name: common
     tasks_from: action.facts.report.yaml
-  
-- name: "{{ item.name}} , {{ item.description}} Idempotent"
+
+- name: "{{ item.name ~ ' , ' ~ item.description ~ ' Idempotent' }}"
   sonic_l2_interfaces:
     config: "{{ item.input }}"
     state: "{{ item.state }}"
   register: idempotent_task_output
-  ignore_errors: yes
+  ignore_errors: true
 
-- import_role:
+- name: "Update test report"
+  ansible.builtin.import_role:
     name: common
     tasks_from: idempotent.facts.report.yaml

--- a/tests/regression/roles/sonic_mirroring/tasks/preparation_tests.yaml
+++ b/tests/regression/roles/sonic_mirroring/tasks/preparation_tests.yaml
@@ -5,15 +5,15 @@
     state: deleted
   failed_when: false
 
-- name: Initialize interfaces
+- name: Initialize LAG interfaces
   sonic_lag_interfaces:
     config:
       - name: Portchannel100
         members:
           interfaces:
-            - member: Ethernet4
+            - member: "{{ interface3 }}"
       - name: Portchannel200
         members:
           interfaces:
-            - member: Ethernet8
+            - member: "{{ interface4 }}"
   failed_when: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I fixed the mirroring regression test failures. I also added cleanup for L2 interfaces as well as resolved ansible-lint errors for L2 interfaces


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_mirroring
sonic_l2_interfaces

##### OUTPUT
<!--- Paste the functionality test result below -->
Native interface naming mode test report:
[regression-2025-08-05-13-17-06.html.pdf](https://github.com/user-attachments/files/21607519/regression-2025-08-05-13-17-06.html.pdf)

Standard interface naming mode test report:
[regression-2025-08-05-13-31-18.html.pdf](https://github.com/user-attachments/files/21607535/regression-2025-08-05-13-31-18.html.pdf)

Updated report:
[regression-2025-08-07-12-25-51.html.pdf](https://github.com/user-attachments/files/21671872/regression-2025-08-07-12-25-51.html.pdf)


##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [] I have maintained at least 90% code coverage
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)