### PR TITLE
Change redundant order n-squared regression test logging to non-redundant order "n" logging.

### DIFF
--- a/changelogs/fragments/584-test-reports-reduced-logging.yaml
+++ b/changelogs/fragments/584-test-reports-reduced-logging.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - test_reports - Eliminate redundant order n-squared regression test logging by logging all facts only one time (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/584).

--- a/tests/regression/roles/common/tasks/action.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/action.facts.report.yaml
@@ -9,4 +9,3 @@
         'configs': item.input | default('Not defined'),
         }}}, recursive=True) }}"
   no_log: true
-

--- a/tests/regression/roles/common/tasks/action.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/action.facts.report.yaml
@@ -8,3 +8,5 @@
         'commands': action_task_output.commands | default('Not defined'),
         'configs': item.input | default('Not defined'),
         }}}, recursive=True) }}"
+  no_log: true
+

--- a/tests/regression/roles/common/tasks/all.facts.summary.report.yaml
+++ b/tests/regression/roles/common/tasks/all.facts.summary.report.yaml
@@ -1,4 +1,3 @@
 - set_fact:
     ansible_facts:
       test_reports: "{{ ansible_facts['test_reports']| default({})| combine({}, recursive=True) }}"
-

--- a/tests/regression/roles/common/tasks/all.facts.summary.report.yaml
+++ b/tests/regression/roles/common/tasks/all.facts.summary.report.yaml
@@ -1,0 +1,4 @@
+- set_fact:
+    ansible_facts:
+      test_reports: "{{ ansible_facts['test_reports']| default({})| combine({}, recursive=True) }}"
+

--- a/tests/regression/roles/common/tasks/cli.contains.test.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/cli.contains.test.facts.report.yaml
@@ -8,4 +8,3 @@
         'msg': cli_tests_output.msg  | default('Not defined'),
         }}}, recursive=True) }}"
   no_log: true
-

--- a/tests/regression/roles/common/tasks/cli.contains.test.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/cli.contains.test.facts.report.yaml
@@ -7,5 +7,5 @@
         'configs': item.input  | default('Not defined'),
         'msg': cli_tests_output.msg  | default('Not defined'),
         }}}, recursive=True) }}"
-  # no_log: true
-  
+  no_log: true
+

--- a/tests/regression/roles/common/tasks/cli.test.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/cli.test.facts.report.yaml
@@ -8,4 +8,3 @@
         'msg': cli_tests_output.msg  | default('Not defined'),
         }}}, recursive=True) }}"
   no_log: true
-

--- a/tests/regression/roles/common/tasks/cli.test.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/cli.test.facts.report.yaml
@@ -7,5 +7,5 @@
         'configs': item.input  | default('Not defined'),
         'msg': cli_tests_output.msg  | default('Not defined'),
         }}}, recursive=True) }}"
-  # no_log: true
-  
+  no_log: true
+

--- a/tests/regression/roles/common/tasks/idempotent.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/idempotent.facts.report.yaml
@@ -10,4 +10,3 @@
         'msg': idempotent_task_output.msg  | default('Not defined'),
         }}}, recursive=True) }}"
   no_log: true
-

--- a/tests/regression/roles/common/tasks/idempotent.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/idempotent.facts.report.yaml
@@ -9,4 +9,5 @@
         'configs': item.input  | default('Not defined'),
         'msg': idempotent_task_output.msg  | default('Not defined'),
         }}}, recursive=True) }}"
-  # no_log: true
+  no_log: true
+

--- a/tests/regression/roles/common/tasks/single.run.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/single.run.facts.report.yaml
@@ -9,4 +9,3 @@
         'configs': item.input | default('Not defined'),
         }}}, recursive=True) }}"
   no_log: true
-

--- a/tests/regression/roles/common/tasks/single.run.facts.report.yaml
+++ b/tests/regression/roles/common/tasks/single.run.facts.report.yaml
@@ -8,3 +8,5 @@
         'commands': single_run_task_output.commands | default('Not defined'),
         'configs': item.input | default('Not defined'),
         }}}, recursive=True) }}"
+  no_log: true
+

--- a/tests/regression/roles/test_reports/tasks/all_tasks_log_template.yaml
+++ b/tests/regression/roles/test_reports/tasks/all_tasks_log_template.yaml
@@ -1,0 +1,5 @@
+---
+- name: "Display combined facts test report"
+  ansible.builtin.import_role:
+    name: common
+    tasks_from: all.facts.summary.report.yaml

--- a/tests/regression/roles/test_reports/tasks/main.yml
+++ b/tests/regression/roles/test_reports/tasks/main.yml
@@ -1,3 +1,6 @@
+---
+- name: "Report combined action facts"
+  ansible.builtin.include_tasks: all_tasks_log_template.yaml
 - set_fact:
     time: "{{ lookup('pipe', 'date +%H-%M-%S') }}"
     date: "{{ lookup('pipe', 'date +%Y-%m-%d') }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Background:

The current enterprise_sonic Ansible regression logging mechanism generates a huge volume of console log
data because of the order "n-squared" logging algorithm it uses. Each test subsection generates and prints to the console the "set_facts" log for itself plus every test subsection that preceded it. Now that we have 82 modules with an average of ~26+ test sections (including "action" plus "idempotent" sections), the number of test sections is > 2000, and the current "order 4,000,000" log size created by the redundant, "recursive" logging is taking more time and storage space than our test server environment can support. This has reached a critical level where most full regression test runs abort due to insufficient storage space.

Changing the logging algorithm to log the results for all tests just one time (instead of order 2000 times for each of the 2000 tests) significantly reduces the execution time and storage space overhead needed for the regression test suite to a tiny fraction of the current needed space and can be expected to restore the regression test setup to a usable state.

This change set accomplishes order "n" logging by suppressing the logging of all accumulated "facts" at the completion of each test section and, instead, adding a new, one-time "log all results" task to the final "test_reports" regression test "role".

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| |
N/A

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test_reports
##### OUTPUT
<!--- Paste the functionality test result below -->
Size of output log for 2 (of 82) modules with and without the redundant logging reduction:

kerry@opensuse155:~> ls -ltd ~/logs/* | more
-rw-r--r-- 1 kerry users     572568 Aug 22 02:34 /home/kerry/logs/regression_log_reduce_by_set_fact_summary_action_logging_pr.log
-rw-r--r-- 1 kerry users    3635537 Aug 21 19:45 /home/kerry/logs/regression_log_no_reduce_compare_pr.log

Sample console log output implementing the reduced logging scheme:
[regression_log_reduce_by_set_fact_summary_action_logging_pr.log](https://github.com/user-attachments/files/21933367/regression_log_reduce_by_set_fact_summary_action_logging_pr.log)


HTML report for the two modules:

[test_reports_reduced_logging.pdf](https://github.com/user-attachments/files/21933272/test_reports_reduced_logging.pdf)


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Run the regression suite using two selected modules. Check the output with and without the changes.
