### PR TITLE
Remove mutual exclusion for BGP 'allowas_in' options.

### DIFF
--- a/changelogs/fragments/586-bgp-allowas_in-option-mutual-exclusion-change.yaml
+++ b/changelogs/fragments/586-bgp-allowas_in-option-mutual-exclusion-change.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - sonic_bgp_neighbors - Remove mutual exclusion for peer_group allowas_in options (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/586).
+  - sonic_bgp_neighbors_af - Remove mutual exclusion for neighbor allowas_in options (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/586).

--- a/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_neighbors/bgp_neighbors.py
@@ -142,7 +142,6 @@ class Bgp_neighborsArgs(object):  # pylint: disable=R0903
                                             'required': True
                                         },
                                         'allowas_in': {
-                                            'mutually_exclusive': [['origin', 'value']],
                                             'options': {
                                                 'origin': {'type': 'bool'},
                                                 'value': {'type': 'int'}

--- a/plugins/module_utils/network/sonic/argspec/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/argspec/bgp_neighbors_af/bgp_neighbors_af.py
@@ -55,7 +55,6 @@ class Bgp_neighbors_afArgs(object):  # pylint: disable=R0903
                                     'type': 'str'
                                 },
                                 'allowas_in': {
-                                    'mutually_exclusive': [['origin', 'value']],
                                     'options': {
                                         'origin': {'type': 'bool'},
                                         'value': {'type': 'int'}

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -452,7 +452,7 @@ class Bgp_neighbors_af(ConfigBase):
                             mat_allowas_in = mat_nei_addr_fam.get('allowas_in', None)
         return mat_allowas_in
 
-    def get_single_neighbors_af_modify_request(self, match, vrf_name, as_val, conf_neighbor_val, conf_neighbor, want):  
+    def get_single_neighbors_af_modify_request(self, match, vrf_name, as_val, conf_neighbor_val, conf_neighbor, want): 
         requests = []
         conf_nei_addr_fams = conf_neighbor.get('address_family', [])
         conf_nbr_val = conf_neighbor_val.replace('/', '%2f')

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -279,7 +279,7 @@ class Bgp_neighbors_af(ConfigBase):
                 commands.extend(update_states(del_config, "deleted"))
 
         if add_config:
-            mod_requests = self.get_modify_bgp_neighbors_af_requests(add_config, have)
+            mod_requests = self.get_modify_bgp_neighbors_af_requests(add_config, have, want)
 
             if len(mod_requests) > 0:
                 requests.extend(mod_requests)
@@ -309,7 +309,7 @@ class Bgp_neighbors_af(ConfigBase):
             if len(del_requests) > 0:
                 requests.extend(del_requests)
                 commands.extend(update_states(have, "deleted"))
-            mod_requests = self.get_modify_bgp_neighbors_af_requests(new_want, [])
+            mod_requests = self.get_modify_bgp_neighbors_af_requests(new_want, [], new_want)
             if len(mod_requests) > 0:
                 requests.extend(mod_requests)
                 commands.extend(update_states(want, "overridden"))
@@ -327,7 +327,7 @@ class Bgp_neighbors_af(ConfigBase):
         """
         commands = diff
         validate_bgps(self._module, want, have)
-        requests = self.get_modify_bgp_neighbors_af_requests(commands, have)
+        requests = self.get_modify_bgp_neighbors_af_requests(commands, have, want)
         if commands and len(requests) > 0:
             commands = update_states(commands, "merged")
         else:
@@ -452,7 +452,7 @@ class Bgp_neighbors_af(ConfigBase):
                             mat_allowas_in = mat_nei_addr_fam.get('allowas_in', None)
         return mat_allowas_in
 
-    def get_single_neighbors_af_modify_request(self, match, vrf_name, conf_neighbor_val, conf_neighbor):
+    def get_single_neighbors_af_modify_request(self, match, vrf_name, as_val, conf_neighbor_val, conf_neighbor, want):  
         requests = []
         conf_nei_addr_fams = conf_neighbor.get('address_family', [])
         conf_nbr_val = conf_neighbor_val.replace('/', '%2f')
@@ -529,22 +529,36 @@ class Bgp_neighbors_af(ConfigBase):
                 allowas_in_cfg = {}
                 conf_allowas_in = conf_nei_addr_fam.get('allowas_in', None)
                 if conf_allowas_in:
-                    mat_allowas_in = self.get_allowas_in(match, conf_neighbor_val, conf_afi, conf_safi)
                     origin = conf_allowas_in.get('origin', None)
+                    value = conf_allowas_in.get('value', None)
+
+                    # Check for a conflict between input allowas_in 'origin' configuration and input allowas_in 'value' configuration.
+                    want_bgp_instance = next((cfg for cfg in want if (cfg['vrf_name'] == vrf_name and (cfg['bgp_as'] == as_val))), None)
+                    want_allowas_in = self.get_allowas_in(want_bgp_instance, conf_neighbor_val, conf_afi, conf_safi)
+                    want_origin = want_allowas_in.get('origin')
+                    want_value = want_allowas_in.get('value')
+                    if want_origin is True and want_value is not None:
+                        self._module.fail_json(msg="No allowas_in 'value' can be configured when setting allowas_in 'origin' to 'true'.")
+
+                    # Remove any existing configuration that conflicts with the input 'allowas_in' configuration before applying
+                    # the new requested 'allowas_in' configuration.
+                    mat_allowas_in = self.get_allowas_in(match, conf_neighbor_val, conf_afi, conf_safi)
+
                     if origin is not None:
-                        if mat_allowas_in:
+                        if origin is True and mat_allowas_in:
                             mat_value = mat_allowas_in.get('value', None)
                             if mat_value:
                                 self.append_delete_request(requests, mat_value, mat_allowas_in, 'value', del_url, self.allowas_value_path)
+
                         allowas_in_cfg['origin'] = origin
-                    else:
-                        value = conf_allowas_in.get('value', None)
-                        if value is not None:
-                            if mat_allowas_in:
-                                mat_origin = mat_allowas_in.get('origin', None)
-                                if mat_origin:
-                                    self.append_delete_request(requests, mat_origin, mat_allowas_in, 'origin', del_url, self.allowas_origin_path)
-                            allowas_in_cfg['as-count'] = value
+
+                    if value is not None:
+                        if mat_allowas_in:
+                            mat_origin = mat_allowas_in.get('origin', None)
+                            if mat_origin:
+                                self.append_delete_request(requests, mat_origin, mat_allowas_in, 'origin', del_url, self.allowas_origin_path)
+
+                        allowas_in_cfg['as-count'] = value
                 if allowas_in_cfg:
                     allowas_in_cfg['enabled'] = True
                     afi_safi['allow-own-as'] = {'config': allowas_in_cfg}
@@ -569,15 +583,15 @@ class Bgp_neighbors_af(ConfigBase):
             requests.append({'path': url, 'method': DELETE})
         return requests
 
-    def get_all_neighbors_af_modify_requests(self, match, conf_neighbors, vrf_name):
+    def get_all_neighbors_af_modify_requests(self, match, conf_neighbors, vrf_name, as_val, want):
         requests = []
         for conf_neighbor in conf_neighbors:
             conf_neighbor_val = conf_neighbor.get('neighbor', None)
             if conf_neighbor_val:
-                requests.extend(self.get_single_neighbors_af_modify_request(match, vrf_name, conf_neighbor_val, conf_neighbor))
+                requests.extend(self.get_single_neighbors_af_modify_request(match, vrf_name, as_val, conf_neighbor_val, conf_neighbor, want))
         return requests
 
-    def get_modify_requests(self, conf, match, vrf_name):
+    def get_modify_requests(self, conf, match, vrf_name, as_val, want):
         requests = []
         conf_neighbors = conf.get('neighbors', [])
         mat_neighbors = []
@@ -622,10 +636,10 @@ class Bgp_neighbors_af(ConfigBase):
                     if del_routes:
                         requests.extend(self.get_delete_neighbor_af_routemaps_requests(vrf_name, conf_neighbor_val, afi, safi, del_routes))
 
-            requests.extend(self.get_all_neighbors_af_modify_requests(match, conf_neighbors, vrf_name))
+            requests.extend(self.get_all_neighbors_af_modify_requests(match, conf_neighbors, vrf_name, as_val, want))
         return requests
 
-    def get_modify_bgp_neighbors_af_requests(self, commands, have):
+    def get_modify_bgp_neighbors_af_requests(self, commands, have, want):
         requests = []
         if not commands:
             return requests
@@ -636,7 +650,7 @@ class Bgp_neighbors_af(ConfigBase):
             as_val = conf['bgp_as']
 
             match = next((cfg for cfg in have if (cfg['vrf_name'] == vrf_name and (cfg['bgp_as'] == as_val))), None)
-            modify_reqs = self.get_modify_requests(conf, match, vrf_name)
+            modify_reqs = self.get_modify_requests(conf, match, vrf_name, as_val, want)
             if modify_reqs:
                 requests.extend(modify_reqs)
 
@@ -645,7 +659,7 @@ class Bgp_neighbors_af(ConfigBase):
     def append_delete_request(self, requests, cur_var, mat_var, key, url, path):
         ret_value = False
         request = None
-        if cur_var is not None and mat_var.get(key, None):
+        if cur_var is not None and mat_var.get(key, None) == cur_var:
             requests.append({'path': url + path, 'method': DELETE})
             ret_value = True
         return ret_value
@@ -690,7 +704,7 @@ class Bgp_neighbors_af(ConfigBase):
             mat_nei_addr_fam = next((e_af for e_af in matched_nei_addr_fams if (e_af['afi'] == conf_afi and e_af['safi'] == conf_safi)), None)
 
         if mat_nei_addr_fam:
-            conf_alllowas_in = conf_nei_addr_fam.get('allowas_in')
+            conf_allowas_in = conf_nei_addr_fam.get('allowas_in')
             conf_activate = conf_nei_addr_fam.get('activate')
             conf_fabric_external = conf_nei_addr_fam.get('fabric_external')
             conf_route_map = conf_nei_addr_fam.get('route_map')
@@ -701,7 +715,7 @@ class Bgp_neighbors_af(ConfigBase):
             conf_ip_afi = conf_nei_addr_fam.get('ip_afi')
             conf_prefix_limit = conf_nei_addr_fam.get('prefix_limit')
 
-            var_list = [conf_alllowas_in, conf_activate, conf_fabric_external, conf_route_map, conf_route_reflector_client, conf_route_server_client,
+            var_list = [conf_allowas_in, conf_activate, conf_fabric_external, conf_route_map, conf_route_reflector_client, conf_route_server_client,
                         conf_prefix_list_in, conf_prefix_list_out, conf_ip_afi, conf_prefix_limit]
             if len(list(filter(lambda var: (var is None), var_list))) == len(var_list):
                 requests.append({'path': url, 'method': DELETE})
@@ -722,17 +736,16 @@ class Bgp_neighbors_af(ConfigBase):
                 self.append_delete_request(requests, conf_prefix_list_in, mat_nei_addr_fam, 'prefix_list_in', url, self.prefix_list_in_path)
                 self.append_delete_request(requests, conf_prefix_list_out, mat_nei_addr_fam, 'prefix_list_out', url, self.prefix_list_out_path)
 
-                mat_alllowas_in = mat_nei_addr_fam.get('allowas_in', None)
-                if conf_alllowas_in is not None and mat_alllowas_in:
-                    origin = conf_alllowas_in.get('origin', None)
+                mat_allowas_in = mat_nei_addr_fam.get('allowas_in', None)
+                if conf_allowas_in is not None and mat_allowas_in:
+                    origin = conf_allowas_in.get('origin', None)
+                    value = conf_allowas_in.get('value', None)
                     if origin is not None:
-                        if self.append_delete_request(requests, origin, mat_alllowas_in, 'origin', url, self.allowas_origin_path):
+                        if self.append_delete_request(requests, origin, mat_allowas_in, 'origin', url, self.allowas_origin_path):
                             self.append_delete_request(requests, True, {'enabled': True}, 'enabled', url, self.allowas_enabled_path)
-                    else:
-                        value = conf_alllowas_in.get('value', None)
-                        if value is not None:
-                            if self.append_delete_request(requests, value, mat_alllowas_in, 'value', url, self.allowas_value_path):
-                                self.append_delete_request(requests, True, {'enabled': True}, 'enabled', url, self.allowas_enabled_path)
+                    if value is not None:
+                        if self.append_delete_request(requests, value, mat_allowas_in, 'value', url, self.allowas_value_path):
+                            self.append_delete_request(requests, True, {'enabled': True}, 'enabled', url, self.allowas_enabled_path)
 
                 mat_ip_afi = mat_nei_addr_fam.get('ip_afi', None)
                 mat_prefix_limit = mat_nei_addr_fam.get('prefix_limit', None)

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -740,23 +740,23 @@ class Bgp_neighbors_af(ConfigBase):
                 if conf_allowas_in is not None and mat_allowas_in:
                     origin = conf_allowas_in.get('origin', None)
                     value = conf_allowas_in.get('value', None)
-                    mat_allowas_in_list = []
+                    mat_allowas_in_options = {}
                     mat_origin = mat_allowas_in.get('origin', None)
                     if mat_origin is not None:
-                        mat_allowas_in_list.append({'origin': mat_origin})
+                        mat_allowas_in_options.update({'origin': mat_origin})
                     mat_value = mat_allowas_in.get('value', None)
                     if mat_value is not None:
-                        mat_allowas_in_list.append({'value': mat_value})
+                        mat_allowas_in_options.update({'value': mat_value})
 
                     if origin is not None:
                         if self.append_delete_request(requests, origin, mat_allowas_in, 'origin', url, self.allowas_origin_path):
-                            if mat_allowas_in_list.get('origin') is not None:
-                                del (mat_allowas_in_list['origin'])
+                            if mat_allowas_in_options.get('origin') is not None:
+                                del (mat_allowas_in_options['origin'])
                     if value is not None:
                         if self.append_delete_request(requests, value, mat_allowas_in, 'value', url, self.allowas_value_path):
-                            if mat_allowas_in_list.get('value') is not None:
-                                del (mat_allowas_in_list['value'])
-                    if not mat_allowas_in_list:
+                            if mat_allowas_in_options.get('value') is not None:
+                                del (mat_allowas_in_options['value'])
+                    if not mat_allowas_in_options:
                         self.append_delete_request(requests, True, {'enabled': True}, 'enabled', url, self.allowas_enabled_path)
 
                 mat_ip_afi = mat_nei_addr_fam.get('ip_afi', None)

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -740,12 +740,24 @@ class Bgp_neighbors_af(ConfigBase):
                 if conf_allowas_in is not None and mat_allowas_in:
                     origin = conf_allowas_in.get('origin', None)
                     value = conf_allowas_in.get('value', None)
+                    mat_allowas_in_list = []
+                    mat_origin = mat_allowas_in.get('origin', None)
+                    if mat_origin is not None:
+                        mat_allowas_in_list.append({'origin': mat_origin})
+                    mat_value = mat_allowas_in.get('value', None)
+                    if mat_value is not None:
+                        mat_allowas_in_list.append({'value': mat_value})
+
                     if origin is not None:
                         if self.append_delete_request(requests, origin, mat_allowas_in, 'origin', url, self.allowas_origin_path):
-                            self.append_delete_request(requests, True, {'enabled': True}, 'enabled', url, self.allowas_enabled_path)
+                            if mat_allowas_in_list.get('origin') is not None:
+                                del(mat_allowas_in_list['origin'])
                     if value is not None:
                         if self.append_delete_request(requests, value, mat_allowas_in, 'value', url, self.allowas_value_path):
-                            self.append_delete_request(requests, True, {'enabled': True}, 'enabled', url, self.allowas_enabled_path)
+                            if mat_allowas_in_list.get('value') is not None:
+                                del(mat_allowas_in_list['value'])
+                    if not mat_allowas_in_list:
+                        self.append_delete_request(requests, True, {'enabled': True}, 'enabled', url, self.allowas_enabled_path)
 
                 mat_ip_afi = mat_nei_addr_fam.get('ip_afi', None)
                 mat_prefix_limit = mat_nei_addr_fam.get('prefix_limit', None)

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -751,11 +751,11 @@ class Bgp_neighbors_af(ConfigBase):
                     if origin is not None:
                         if self.append_delete_request(requests, origin, mat_allowas_in, 'origin', url, self.allowas_origin_path):
                             if mat_allowas_in_list.get('origin') is not None:
-                                del(mat_allowas_in_list['origin'])
+                                del (mat_allowas_in_list['origin'])
                     if value is not None:
                         if self.append_delete_request(requests, value, mat_allowas_in, 'value', url, self.allowas_value_path):
                             if mat_allowas_in_list.get('value') is not None:
-                                del(mat_allowas_in_list['value'])
+                                del (mat_allowas_in_list['value'])
                     if not mat_allowas_in_list:
                         self.append_delete_request(requests, True, {'enabled': True}, 'enabled', url, self.allowas_enabled_path)
 

--- a/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
+++ b/plugins/module_utils/network/sonic/config/bgp_neighbors_af/bgp_neighbors_af.py
@@ -452,7 +452,7 @@ class Bgp_neighbors_af(ConfigBase):
                             mat_allowas_in = mat_nei_addr_fam.get('allowas_in', None)
         return mat_allowas_in
 
-    def get_single_neighbors_af_modify_request(self, match, vrf_name, as_val, conf_neighbor_val, conf_neighbor, want): 
+    def get_single_neighbors_af_modify_request(self, match, vrf_name, as_val, conf_neighbor_val, conf_neighbor, want):
         requests = []
         conf_nei_addr_fams = conf_neighbor.get('address_family', [])
         conf_nbr_val = conf_neighbor_val.replace('/', '%2f')

--- a/plugins/module_utils/network/sonic/utils/bgp_utils.py
+++ b/plugins/module_utils/network/sonic/utils/bgp_utils.py
@@ -345,9 +345,9 @@ def get_peergroups(module, vrf_name):
                         if 'allow-own-as' in each and 'config' in each['allow-own-as']:
                             allowas_in = {}
                             allowas_conf = each['allow-own-as']['config']
-                            if 'origin' in allowas_conf and allowas_conf['origin']:
+                            if 'origin' in allowas_conf and allowas_conf['origin'] is not None:
                                 allowas_in.update({'origin': allowas_conf['origin']})
-                            elif 'as-count' in allowas_conf and allowas_conf['as-count']:
+                            if 'as-count' in allowas_conf and allowas_conf['as-count']:
                                 allowas_in.update({'value': allowas_conf['as-count']})
                             if allowas_in:
                                 samp.update({'allowas_in': allowas_in})

--- a/plugins/module_utils/network/sonic/utils/utils.py
+++ b/plugins/module_utils/network/sonic/utils/utils.py
@@ -17,6 +17,7 @@ import sys
 from copy import copy
 from itertools import (count, groupby)
 if sys.version_info >= (3, 13):
+    import six
     from six import iteritems
 else:
     from ansible.module_utils.six import iteritems

--- a/plugins/module_utils/network/sonic/utils/utils.py
+++ b/plugins/module_utils/network/sonic/utils/utils.py
@@ -13,14 +13,8 @@ __metaclass__ = type
 import re
 import json
 import ast
-import sys
 from copy import copy
 from itertools import (count, groupby)
-if sys.version_info >= (3, 13):
-    import six
-    from six import iteritems
-else:
-    from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_empties
 )
@@ -255,28 +249,28 @@ def dict_to_set(sample_dict):
     # Generate a set with passed dictionary for comparison
     test_dict = dict()
     if isinstance(sample_dict, dict):
-        for k, v in iteritems(sample_dict):
+        for k, v in sample_dict.items():
             if v is not None:
                 if isinstance(v, list):
                     if isinstance(v[0], dict):
                         li = []
                         for each in v:
-                            for key, value in iteritems(each):
+                            for key, value in each.items():
                                 if isinstance(value, list):
                                     each[key] = tuple(value)
-                            li.append(tuple(iteritems(each)))
+                            li.append(tuple(each.items()))
                         v = tuple(li)
                     else:
                         v = tuple(v)
                 elif isinstance(v, dict):
                     li = []
-                    for key, value in iteritems(v):
+                    for key, value in v.items():
                         if isinstance(value, list):
                             v[key] = tuple(value)
-                    li.extend(tuple(iteritems(v)))
+                    li.extend(tuple(v.items()))
                     v = tuple(li)
                 test_dict.update({k: v})
-        return_set = set(tuple(iteritems(test_dict)))
+        return_set = set(tuple(test_dict.items()))
     else:
         return_set = set(sample_dict)
     return return_set

--- a/plugins/module_utils/network/sonic/utils/utils.py
+++ b/plugins/module_utils/network/sonic/utils/utils.py
@@ -13,9 +13,13 @@ __metaclass__ = type
 import re
 import json
 import ast
+import sys
 from copy import copy
 from itertools import (count, groupby)
-from ansible.module_utils.six import iteritems
+if sys.version_info >= (3, 13):
+    from six import iteritems
+else:
+    from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_empties
 )

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -251,9 +251,9 @@ options:
                     type: bool
                   allowas_in:
                     description:
-                      - Criterion for accepting received advertisements containing this BGP router
-                      - instance's AS number in the AS-PATH of received advertisements:
-                      - O(origin) can not be set to V(true) when a O(value) is set.
+                      - Criterion for accepting received advertisements containing the AS number
+                      - of this BGP router intance in the AS PATH of received advertisements:
+                      - The 'origin' option can not be set to true when a 'value' is set.
                     type: dict
                     suboptions:
                       origin:

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -251,17 +251,20 @@ options:
                     type: bool
                   allowas_in:
                     description:
-                      - Holds AS value.
-                      - The origin and value are mutually exclusive.
+                      - Criterion for accepting received advertisements containing this BGP router
+                      - instance's AS number in the AS-PATH of received advertisements:
+                      - O(origin) can not be set to V(true) when a O(value) is set.
                     type: dict
                     suboptions:
                       origin:
                         description:
-                          - Set AS as the origin.
+                          - Accept this BGP router instance's set AS as the origin.
                         type: bool
                       value:
                         description:
-                          - Holds AS number in the range 1-10.
+                          - Accept up to this number of occurrences of this BGP router's
+                          - set AS in the AS-PATH of received advertisements.
+                          - (Specify a number in the range 1-10.)
                         type: int
                   ip_afi:
                     description:

--- a/plugins/modules/sonic_bgp_neighbors.py
+++ b/plugins/modules/sonic_bgp_neighbors.py
@@ -252,7 +252,7 @@ options:
                   allowas_in:
                     description:
                       - Criterion for accepting received advertisements containing the AS number
-                      - of this BGP router intance in the AS PATH of received advertisements:
+                      - of this BGP router intance in the AS PATH of received advertisements.
                       - The 'origin' option can not be set to true when a 'value' is set.
                     type: dict
                     suboptions:

--- a/plugins/modules/sonic_bgp_neighbors_af.py
+++ b/plugins/modules/sonic_bgp_neighbors_af.py
@@ -82,17 +82,21 @@ options:
                 type: bool
               allowas_in:
                 description:
-                  - Specifies the allowas in values.
+                  - Criterion for accepting received advertisements containing this BGP router
+                  - instance's AS number in the AS-PATH of received advertisements:
+                  - O(origin) can not be set to V(true) when a O(value) is set.
                 type: dict
                 suboptions:
-                  value:
-                    description:
-                      - Specifies the value of the allowas in.
-                    type: int
                   origin:
                     description:
-                      - Specifies the origin value.
+                      - Accept this BGP router instance's set AS as the origin.
                     type: bool
+                  value:
+                    description:
+                      - Accept up to this number of occurrences of this BGP router's
+                      - set AS in the AS-PATH of received advertisements.
+                      - (Specify a number in the range 1-10.)
+                    type: int
               fabric_external:
                 description:
                   - Configure a neighbor as fabric-external.

--- a/plugins/modules/sonic_bgp_neighbors_af.py
+++ b/plugins/modules/sonic_bgp_neighbors_af.py
@@ -83,7 +83,7 @@ options:
               allowas_in:
                 description:
                   - Criterion for accepting received advertisements containing this BGP router
-                  - instance's AS number in the AS-PATH of received advertisements:
+                  - instance's AS number in the AS-PATH of received advertisements.
                   - O(origin) can not be set to V(true) when a O(value) is set.
                 type: dict
                 suboptions:

--- a/plugins/modules/sonic_bgp_neighbors_af.py
+++ b/plugins/modules/sonic_bgp_neighbors_af.py
@@ -82,9 +82,9 @@ options:
                 type: bool
               allowas_in:
                 description:
-                  - Criterion for accepting received advertisements containing this BGP router
-                  - instance's AS number in the AS-PATH of received advertisements.
-                  - 'origin' can not be set to V(true) when a 'value' is set.
+                  - Criterion for accepting received advertisements containing the AS number
+                  - of this BGP router intance in the AS PATH of received advertisements.
+                  - The 'origin' option can not be set to true when a 'value' is set.
                 type: dict
                 suboptions:
                   origin:

--- a/plugins/modules/sonic_bgp_neighbors_af.py
+++ b/plugins/modules/sonic_bgp_neighbors_af.py
@@ -84,7 +84,7 @@ options:
                 description:
                   - Criterion for accepting received advertisements containing this BGP router
                   - instance's AS number in the AS-PATH of received advertisements.
-                  - O(origin) can not be set to V(true) when a O(value) is set.
+                  - 'origin' can not be set to V(true) when a 'value' is set.
                 type: dict
                 suboptions:
                   origin:

--- a/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors/defaults/main.yml
@@ -156,6 +156,7 @@ deleted_tests:
                   safi: unicast
                   allowas_in:
                     origin: false
+                    value: 4
         neighbors:
           - neighbor: "{{ interface1 }}"
             remote_as:
@@ -721,6 +722,13 @@ merged_tests:
           - name: SPINE
             remote_as:
               peer_type: internal
+            address_family:
+              afis:
+                - afi: ipv4
+                  safi: unicast
+                  allowas_in:
+                    origin: false
+                    value: 4
         neighbors:
           - neighbor: "{{ interface1 }}"
             remote_as:
@@ -742,6 +750,7 @@ merged_tests:
                 - afi: l2vpn
                   safi: evpn
                   allowas_in:
+                    origin: false
                     value: 4
         neighbors:
           - neighbor: "{{ interface1 }}"

--- a/tests/regression/roles/sonic_bgp_neighbors_af/defaults/main.yml
+++ b/tests/regression/roles/sonic_bgp_neighbors_af/defaults/main.yml
@@ -329,6 +329,7 @@ tests:
                 safi: unicast
                 allowas_in:
                   value: 7
+                  origin: false
                 route_map:
                   - name: rmap_reg1
                     direction: out
@@ -458,7 +459,7 @@ tests:
                 prefix_list_in: p2
                 prefix_list_out: p1
   - name: test_case_del_01
-    description: Delete BGP neighbor prefix-list attributes
+    description: Delete prefix-list and other selected BGP neighbor attributes
     state: deleted
     input:
       - bgp_as: "{{bgp_as_1}}"
@@ -493,6 +494,13 @@ tests:
                 safi: evpn
                 prefix_list_in: p2
                 prefix_list_out: p1
+          - neighbor: 12.1.1.1
+            address_family:
+              - afi: ipv4
+                safi: unicast
+                allowas_in:
+                  value: 7
+                  origin: false
   - name: test_case_del_02
     description: Delete entire neighbor address family with attributes
     state: deleted

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -8,7 +8,10 @@ import json
 
 import pytest
 
-from ansible.module_utils.six import string_types
+if sys.version_info >= (3, 13):
+    from six import string_types
+else:
+    from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -7,8 +7,10 @@ __metaclass__ = type
 import json
 
 import pytest
+import sys
 
 if sys.version_info >= (3, 13):
+    import six
     from six import string_types
 else:
     from ansible.module_utils.six import string_types

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -7,20 +7,14 @@ __metaclass__ = type
 import json
 
 import pytest
-import sys
 
-if sys.version_info >= (3, 13):
-    import six
-    from six import string_types
-else:
-    from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):
-    if isinstance(request.param, string_types):
+    if isinstance(request.param, str):
         args = request.param
     elif isinstance(request.param, MutableMapping):
         if 'ANSIBLE_MODULE_ARGS' not in request.param:

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors.yaml
@@ -866,6 +866,7 @@ merged_03:
                   activate: true
                   allowas_in:
                     value: 5
+                    origin: false
         neighbors:
           - neighbor: Eth1/3
             remote_as:
@@ -1056,6 +1057,7 @@ merged_03:
                       enabled: True
                     allow-own-as:
                       config:
+                        origin: False
                         as-count: 5
                         enabled: True
               config:
@@ -1307,6 +1309,7 @@ deleted_02:
                   activate: true
                   allowas_in:
                     value: 8
+                    origin: false
                   ip_afi:
                     send_default_route: true
                 - afi: ipv6
@@ -1453,6 +1456,7 @@ deleted_02:
                       allow-own-as:
                         config:
                           as-count: 8
+                          origin: false
                       config:
                         afi-safi-name: openconfig-bgp-types:IPV4_UNICAST
                       ipv4-unicast:
@@ -1572,6 +1576,10 @@ deleted_02:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/as-count"
       method: "delete"
       data:
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
+      method: "delete"
+      data:
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/ipv4-unicast/config/send-default-route"
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/ipv4-unicast/config/send-default-route"
       method: "delete"
       data:

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors.yaml
@@ -1580,7 +1580,6 @@ deleted_02:
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/ipv4-unicast/config/send-default-route"
-    - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/ipv4-unicast/config/send-default-route"
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV6_UNICAST/allow-own-as/config/origin"

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors.yaml
@@ -1308,8 +1308,8 @@ deleted_02:
                   safi: unicast
                   activate: true
                   allowas_in:
-                    value: 8
                     origin: false
+                    value: 8
                   ip_afi:
                     send_default_route: true
                 - afi: ipv6
@@ -1455,8 +1455,8 @@ deleted_02:
                     - afi-safi-name: openconfig-bgp-types:IPV4_UNICAST
                       allow-own-as:
                         config:
-                          as-count: 8
                           origin: false
+                          as-count: 8
                       config:
                         afi-safi-name: openconfig-bgp-types:IPV4_UNICAST
                       ipv4-unicast:
@@ -1573,10 +1573,10 @@ deleted_02:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f3/"
       method: "delete"
       data:
-    - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/as-count"
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
       method: "delete"
       data:
-    - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/as-count"
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/peer-groups/peer-group=SPINETEST1/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/ipv4-unicast/config/send-default-route"

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
@@ -36,7 +36,6 @@ merged_01:
               - afi: ipv6
                 safi: unicast
                 allowas_in:
-                  origin: false
                   value: 55
                 ip_afi:
                   default_policy_name: rmap_reg2
@@ -116,7 +115,6 @@ merged_01:
                 config:
                   as-count: 55
                   enabled: true
-                  origin: false
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=2.2.2.2/afi-safis"
       method: "patch"
       data:
@@ -652,8 +650,7 @@ deleted_04:
               - afi: ipv4
                 safi: unicast
                 allowas_in:
-                  origin: false
-                  value: 3
+                  origin: true
                 ip_afi:
                   default_policy_name: rmap_reg1
                   send_default_route: true
@@ -728,8 +725,7 @@ deleted_04:
                             warning-threshold-pct: 99
                       allow-own-as:
                         config:
-                          origin: false
-                          as-count: 3
+                          origin: true
                           enabled: true
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/neighbors"
       response:
@@ -756,13 +752,10 @@ deleted_04:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=IPV4_UNICAST/apply-policy/config/import-policy"
       method: "delete"
       data:
-    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
-      method: "delete"
-      data:
-    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/as-count"
-      method: "delete"
-      data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/enabled"
+      method: "delete"
+      data:
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/config/route-reflector-client"

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
@@ -36,8 +36,8 @@ merged_01:
               - afi: ipv6
                 safi: unicast
                 allowas_in:
-                  value: 55
                   origin: false
+                  value: 55
                 ip_afi:
                   default_policy_name: rmap_reg2
                   send_default_route: true

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
@@ -36,6 +36,7 @@ merged_01:
               - afi: ipv6
                 safi: unicast
                 allowas_in:
+                  origin: false
                   value: 55
                 ip_afi:
                   default_policy_name: rmap_reg2
@@ -115,6 +116,7 @@ merged_01:
                 config:
                   as-count: 55
                   enabled: true
+                  origin: false
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=2.2.2.2/afi-safis"
       method: "patch"
       data:
@@ -650,7 +652,8 @@ deleted_04:
               - afi: ipv4
                 safi: unicast
                 allowas_in:
-                  origin: true
+                  origin: false
+                  value: 3
                 ip_afi:
                   default_policy_name: rmap_reg1
                   send_default_route: true
@@ -725,7 +728,8 @@ deleted_04:
                             warning-threshold-pct: 99
                       allow-own-as:
                         config:
-                          origin: true
+                          origin: false
+                          as-count: 3
                           enabled: true
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/neighbors"
       response:
@@ -752,10 +756,13 @@ deleted_04:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=IPV4_UNICAST/apply-policy/config/import-policy"
       method: "delete"
       data:
-    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/enabled"
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
       method: "delete"
       data:
-    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/as-count"
+      method: "delete"
+      data:
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/enabled"
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/config/route-reflector-client"

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
@@ -756,13 +756,13 @@ deleted_04:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=IPV4_UNICAST/apply-policy/config/import-policy"
       method: "delete"
       data:
-    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/enabled"
-      method: "delete"
-      data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/value"
+      method: "delete"
+      data:
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/enabled"
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/config/route-reflector-client"

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
@@ -114,9 +114,9 @@ merged_01:
                     discard-extra: false
               allow-own-as:
                 config:
-                  origin: false
                   as-count: 55
                   enabled: true
+                  origin: false
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=2.2.2.2/afi-safis"
       method: "patch"
       data:
@@ -729,7 +729,7 @@ deleted_04:
                       allow-own-as:
                         config:
                           origin: false
-                          value: 3
+                          as-count: 3
                           enabled: true
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/neighbors"
       response:
@@ -759,7 +759,7 @@ deleted_04:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
       method: "delete"
       data:
-    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/value"
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/as-count"
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/enabled"

--- a/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_bgp_neighbors_af.yaml
@@ -37,6 +37,7 @@ merged_01:
                 safi: unicast
                 allowas_in:
                   value: 55
+                  origin: false
                 ip_afi:
                   default_policy_name: rmap_reg2
                   send_default_route: true
@@ -113,6 +114,7 @@ merged_01:
                     discard-extra: false
               allow-own-as:
                 config:
+                  origin: false
                   as-count: 55
                   enabled: true
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=2.2.2.2/afi-safis"
@@ -650,7 +652,8 @@ deleted_04:
               - afi: ipv4
                 safi: unicast
                 allowas_in:
-                  origin: true
+                  origin: false
+                  value: 3
                 ip_afi:
                   default_policy_name: rmap_reg1
                   send_default_route: true
@@ -725,7 +728,8 @@ deleted_04:
                             warning-threshold-pct: 99
                       allow-own-as:
                         config:
-                          origin: true
+                          origin: false
+                          value: 3
                           enabled: true
     - path: "/data/openconfig-network-instance:network-instances/network-instance=VrfReg1/protocols/protocol=BGP,bgp/bgp/neighbors"
       response:
@@ -756,6 +760,9 @@ deleted_04:
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/origin"
+      method: "delete"
+      data:
+    - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/allow-own-as/config/value"
       method: "delete"
       data:
     - path: "/data/openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=BGP,bgp/bgp/neighbors/neighbor=Eth1%2f2/afi-safis/afi-safi=openconfig-bgp-types:IPV4_UNICAST/config/route-reflector-client"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In response to customer requests, this change set removes the overly strict mutual exclusion between the two defined options for the BGP neighbor and peer_group address family "allowas_in" dictionary. For the two options, an 'origin' option value of "false" is, with this change set, permitted at the same time as a non-null 'value' option. (A "true" value for the 'origin' option remains incompatible with specifying a 'value' because only one of these two conflicting criteria can be configured. An 'origin' value of "true" allows only one occurrence of the AS for "this" BGP instance; as the origin of the route, while a 'value', instead, allows up to a specified number of occurrences of this AS in the AS_PATH.)

This change set make the following changes for the affected BGP files:

- argspec files: Remove the "hard" mutual exclusion between the two allowas_in options.
- module files: Revise the description for the allowas_in options in accordance with this change.
- bgp_neighbors config file: (modified support for peer_group allowas_in configuration)
- bgp_neighbors_af config file: (modified support for neighbor allowas_in configuration)
- bgp_utils: (modified support for facts gathering for allowas_in configuration)

The changes in the "config" file generate a playbook abort with an error message if the input playbook specifies the conflicting allowas_in option values of "'origin': true" and "'value': <integer value>", but the changed criteria allow "'origin': false in conjunction with a 'value'. The changed handling also avoids removing existing allowas_in configuration that does not conflict with the new configuration under the new criteria. (Existing allowas_in configuration that does present a conflict with new allowas_in configuration under the new criteria is still removed, as it was previously, prior to sending "patch" requests for the new configuration.)

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue #564 |
| -------------- |
| |



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
-bgp_neighbors
-bgp_neighbors_af

##### OUTPUT
- Test cases verified:
[Test cases for BGP allow_as in fix.pdf](https://github.com/user-attachments/files/22204248/Test.cases.for.BGP.allow_as.in.fix.pdf)
- Playbook execution logs for the tested cases:
[playbook_logs.zip](https://github.com/user-attachments/files/22204271/playbook_logs.zip)

- Regression test results for the affected resource modules (including new test cases for the proposed changes)


[allowas_in_options_fix_regression_summary_bgp_neighbors_af.pdf](https://github.com/user-attachments/files/22227283/allowas_in_options_fix_regression_summary_bgp_neighbors_af.pdf)

(Added separately; combined results are too big for Github)
[allowas_in_options_fix_regression_summary_bgp_neighbors_part_1.pdf](https://github.com/user-attachments/files/22232403/allowas_in_options_fix_regression_summary_bgp_neighbors_part_1.pdf)
[allowas_in_options_fix_regression_summary_bgp_neighbors_part_2.pdf](https://github.com/user-attachments/files/22232400/allowas_in_options_fix_regression_summary_bgp_neighbors_part_2.pdf)
[allowas_in_options_fix_regression_summary_bgp_neighbors_part_3.pdf](https://github.com/user-attachments/files/22232406/allowas_in_options_fix_regression_summary_bgp_neighbors_part_3.pdf)
[allowas_in_options_fix_regression_summary_bgp_neighbors_part_4.pdf](https://github.com/user-attachments/files/22232405/allowas_in_options_fix_regression_summary_bgp_neighbors_part_4.pdf)


##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Run the test cases listed above and verify that the expected results are achieved.
