### PR TITLE
Update request method to use post for enabled_protocol

### DIFF
--- a/changelogs/fragments/587-stp-request-bugfix.yaml
+++ b/changelogs/fragments/587-stp-request-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_stp - Update request method to use post for enabled_protocol (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/587).

--- a/tests/unit/modules/network/sonic/fixtures/sonic_stp.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_stp.yaml
@@ -47,12 +47,16 @@ merged_01:
         code: 200
   expected_config_requests:
     - path: "data/openconfig-spanning-tree:stp/global"
+      method: "post"
+      data:
+        openconfig-spanning-tree:config:
+          enabled-protocol:
+            - 'MSTP'
+    - path: "data/openconfig-spanning-tree:stp/global"
       method: "patch"
       data:
         openconfig-spanning-tree:global:
           config:
-            enabled-protocol:
-              - 'MSTP'
             loop-guard: true
             bpdu-filter: true
             openconfig-spanning-tree-ext:disabled-vlans:
@@ -161,11 +165,15 @@ merged_03:
         code: 200
   expected_config_requests:
     - path: "data/openconfig-spanning-tree:stp/global"
+      method: "post"
+      data:
+        openconfig-spanning-tree:config:
+          enabled-protocol: ['PVST']
+    - path: "data/openconfig-spanning-tree:stp/global"
       method: "patch"
       data:
         openconfig-spanning-tree:global:
           config:
-            enabled-protocol: ['PVST']
             bpdu-filter: true
             openconfig-spanning-tree-ext:rootguard-timeout: 25
             openconfig-spanning-tree-ext:portfast: true
@@ -220,11 +228,15 @@ merged_04:
         code: 200
   expected_config_requests:
     - path: "data/openconfig-spanning-tree:stp/global"
+      method: "post"
+      data:
+        openconfig-spanning-tree:config:
+          enabled-protocol: ['RAPID_PVST']
+    - path: "data/openconfig-spanning-tree:stp/global"
       method: "patch"
       data:
         openconfig-spanning-tree:global:
           config:
-            enabled-protocol: ['RAPID_PVST']
             bpdu-filter: true
             openconfig-spanning-tree-ext:rootguard-timeout: 25
             openconfig-spanning-tree-ext:hello-time: 5
@@ -599,12 +611,16 @@ replaced_06:
       method: "delete"
       data:
     - path: "data/openconfig-spanning-tree:stp/global"
+      method: "post"
+      data:
+        openconfig-spanning-tree:config:
+          enabled-protocol:
+              - 'MSTP'
+    - path: "data/openconfig-spanning-tree:stp/global"
       method: "patch"
       data:
         openconfig-spanning-tree:global:
           config:
-            enabled-protocol:
-              - 'MSTP'
             loop-guard: true
             bpdu-filter: true
             openconfig-spanning-tree-ext:disabled-vlans:
@@ -751,12 +767,16 @@ overridden_01:
       method: "delete"
       data:
     - path: "data/openconfig-spanning-tree:stp/global"
+      method: "post"
+      data:
+        openconfig-spanning-tree:config:
+          enabled-protocol:
+            - 'MSTP'
+    - path: "data/openconfig-spanning-tree:stp/global"
       method: "patch"
       data:
         openconfig-spanning-tree:global:
           config:
-            enabled-protocol:
-              - 'MSTP'
             loop-guard: true
             bpdu-filter: true
             openconfig-spanning-tree-ext:disabled-vlans:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I updated the request method for modifying enabled_protocol to use post. This allows the enabled_protocol to be configured alone.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sonic_stp

##### OUTPUT
Failure due to known SONiC issue with rapid-pvst
[regression-2025-09-09-15-50-52.html.pdf](https://github.com/user-attachments/files/22244726/regression-2025-09-09-15-50-52.html.pdf)


##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)