### PR TITLE
sonic_lag_interfaces - Fix graceful_shutdown not disabled for existing lag interfaces

### DIFF
--- a/changelogs/fragments/617-lag-interfaces-fix-graceful-shutdown.yaml
+++ b/changelogs/fragments/617-lag-interfaces-fix-graceful-shutdown.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - sonic_lag_interfaces - Fix graceful_shutdown not disabled for existing lag interfaces (https://github.com/ansible-collections/dellemc.enterprise_sonic/pull/617).

--- a/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/sonic/config/lag_interfaces/lag_interfaces.py
@@ -625,9 +625,10 @@ class Lag_interfaces(ConfigBase):
     @staticmethod
     def get_diff(base_cfg, compare_cfg):
         compare_cfg = deepcopy(compare_cfg)
-        # Add default values, if not present
+        # Add default values (except graceful_shutdown), if not present
+        # For graceful_shutdown, configure provided value if not present
         for cfg in compare_cfg:
-            for option in ('fallback', 'fast_rate', 'graceful_shutdown', 'min_links'):
+            for option in ('fallback', 'fast_rate', 'min_links'):
                 cfg.setdefault(option, DEFAULT_VALUES[option])
 
             if cfg.get('mode') == 'lacp':

--- a/tests/regression/roles/sonic_lag_interfaces/defaults/main.yml
+++ b/tests/regression/roles/sonic_lag_interfaces/defaults/main.yml
@@ -63,6 +63,8 @@ sonic_lag_interfaces_tests:
         members:
           interfaces:
             - member: "{{ interface7 }}"
+      - name: "{{ sonic_lag_interfaces_test_vars.lag5 }}"
+        graceful_shutdown: false
       - name: "{{ sonic_lag_interfaces_test_vars.lag6 }}"
         speed: 40000
         members:

--- a/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
+++ b/tests/unit/modules/network/sonic/fixtures/sonic_lag_interfaces.yaml
@@ -30,6 +30,8 @@ merged_01:
       - name: PortChannel40
         fallback: true
         fast_rate: true
+      - name: PortChannel50
+        graceful_shutdown: false
       - name: PortChannel90
         speed: 40000
         members:
@@ -51,6 +53,7 @@ merged_01:
                 - name: PortChannel10
                   graceful_shutdown_mode: ENABLE
                   lacp_individual: enable
+                - name: PortChannel50
   expected_config_requests:
     - path: "data/openconfig-interfaces:interfaces"
       method: "patch"
@@ -158,6 +161,11 @@ merged_01:
         openconfig-if-aggregate:config:
           fallback: true
           fast-rate: true
+    - path: "data/openconfig-interfaces:interfaces/interface=PortChannel50/openconfig-if-aggregate:aggregation/config"
+      method: "patch"
+      data:
+        openconfig-if-aggregate:config:
+          graceful-shutdown-mode: DISABLE
     - path: "data/openconfig-interfaces:interfaces/interface=PortChannel90/openconfig-if-aggregate:aggregation/config"
       method: "patch"
       data:
@@ -527,6 +535,8 @@ overridden_01:
         members:
           interfaces:
             - member: Eth1/23
+      - name: PortChannel40
+        graceful_shutdown: false
   existing_lag_interfaces_config:
     - path: "data/sonic-portchannel:sonic-portchannel"
       response:
@@ -544,6 +554,7 @@ overridden_01:
                   fallback: true
                   system_mac: "12:12:12:12:12:12"
                 - name: PortChannel30
+                - name: PortChannel40
             PORTCHANNEL_MEMBER:
               PORTCHANNEL_MEMBER_LIST:
                 - ifname: Eth1/4
@@ -619,3 +630,8 @@ overridden_01:
                 esi: AUTO
                 interface: PortChannel10
                 name: PortChannel10
+    - path: "data/openconfig-interfaces:interfaces/interface=PortChannel40/openconfig-if-aggregate:aggregation/config"
+      method: "patch"
+      data:
+        openconfig-if-aggregate:config:
+          graceful-shutdown-mode: DISABLE


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix graceful_shutdown not disabled for existing lag interfaces

##### GitHub Issues
List the GitHub issues impacted by this PR. If no Github issues are affected, please indicate this with "N/A".

| GitHub Issue # |
| -------------- |
| #612 |


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- sonic_lag_interfaces

##### OUTPUT
<!--- Paste the functionality test result below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!--- Measure the code coverage before and after the change by running the UT and ensure that the "coverage after the change" is not less than the coverage "before the change". Note that the unit testing coverage can be manually executed using the pytest tool or ansible-test tool. -->

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch. Reference : [Ansible Change Log Document](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to)

##### How Has This Been Tested?

UT logs: [lag_graceful_shutdown_ut_logs.txt](https://github.com/user-attachments/files/24595803/lag_graceful_shutdown_ut_logs.txt)
Regression Report: [lag_interfaces_regression-2026-01-13-22-20-48.zip](https://github.com/user-attachments/files/24595806/lag_interfaces_regression-2026-01-13-22-20-48.zip)


