### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/httpapi/sonic.py
+++ b/plugins/httpapi/sonic.py
@@ -40,10 +40,10 @@ options:
 import json
 import time
 import re
+from urllib.error import HTTPError
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import ConnectionError
-from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.plugins.httpapi import HttpApiBase
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. The only use in this collection is a urllib re-export:

```python
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from urllib.error import HTTPError
```

On Python 3 `six.moves.urllib.error.HTTPError` is the identical class object, so the `isinstance(response, HTTPError)` check in `plugins/httpapi/sonic.py` behaves exactly as before. A changelog fragment is included.

##### GitHub Issues

| GitHub Issue # |
| -------------- |
| N/A |

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

plugins/httpapi/sonic.py

##### OUTPUT

Import-only change. The replaced name resolves to the same object, verified against the vendored six:

```
from ansible.module_utils.six.moves.urllib.error import HTTPError as A
from urllib.error import HTTPError as B
A is B  ->  True
```

##### ADDITIONAL INFORMATION

No behaviour change on Python 3, so no new tests are added and coverage is unchanged.

##### Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A: single import line)
- [ ] I have made corresponding changes to the documentation (N/A: no user-facing change)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A: import-only, no behaviour change)
- [x] I have maintained backward compatibility or have provided any relevant "breaking_changes" descriptions in a "fragment" file in the "changelogs/fragments" directory of this repository.
- [x] I have provided a summary for this PR in valid "fragment" file format in the "changelogs/fragments" directory of this repository branch.
