### PR TITLE
fix(sonic_ssh_server): correct replaced example

### DIFF
--- a/changelogs/fragments/639-fix-ssh-server-example.yaml
+++ b/changelogs/fragments/639-fix-ssh-server-example.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sonic_ssh_server - correct the replaced-state example module, options, and server commands.

--- a/docs/dellemc.enterprise_sonic.sonic_ssh_server_module.rst
+++ b/docs/dellemc.enterprise_sonic.sonic_ssh_server_module.rst
@@ -398,26 +398,26 @@ Examples
     # Before state:
     # -------------
     #
-    # sonic# show running-configuration | grep "ip ssh client"
-    # ip ssh client ciphers aes192-ctr,chacha20-poly1305@openssh.com
-    # ip ssh client kexalgorithms curve25519-sha256,diffie-hellman-group16-sha512
-    # ip ssh client macs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+    # sonic# show running-configuration | grep "ip ssh server"
+    # ip ssh server ciphers aes192-ctr,chacha20-poly1305@openssh.com
+    # ip ssh server kexalgorithms curve25519-sha256,diffie-hellman-group16-sha512
+    # ip ssh server macs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com
     # sonic#
 
     - name: Replace SSH configurations
-      dellemc.enterprise_sonic.sonic_ssh:
+      dellemc.enterprise_sonic.sonic_ssh_server:
         config:
           server_globals:
-            cipher: 'aes256-ctr'
-            kex: 'curve25519-sha256,diffie-hellman-group16-sha512'
+            ciphers: 'aes256-ctr'
+            kexalgorithms: 'curve25519-sha256,diffie-hellman-group16-sha512'
         state: replaced
 
     # After state:
     # ------------
     #
-    # sonic# show running-configuration | grep "ip ssh client"
-    # ip ssh client ciphers aes256-ctr
-    # ip ssh client kexalgorithms curve25519-sha256,diffie-hellman-group16-sha512
+    # sonic# show running-configuration | grep "ip ssh server"
+    # ip ssh server ciphers aes256-ctr
+    # ip ssh server kexalgorithms curve25519-sha256,diffie-hellman-group16-sha512
     # sonic#
 
 

--- a/plugins/modules/sonic_ssh_server.py
+++ b/plugins/modules/sonic_ssh_server.py
@@ -164,26 +164,26 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# sonic# show running-configuration | grep "ip ssh client"
-# ip ssh client ciphers aes192-ctr,chacha20-poly1305@openssh.com
-# ip ssh client kexalgorithms curve25519-sha256,diffie-hellman-group16-sha512
-# ip ssh client macs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+# sonic# show running-configuration | grep "ip ssh server"
+# ip ssh server ciphers aes192-ctr,chacha20-poly1305@openssh.com
+# ip ssh server kexalgorithms curve25519-sha256,diffie-hellman-group16-sha512
+# ip ssh server macs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 # sonic#
 
 - name: Replace SSH configurations
-  dellemc.enterprise_sonic.sonic_ssh:
+  dellemc.enterprise_sonic.sonic_ssh_server:
     config:
       server_globals:
-        cipher: 'aes256-ctr'
-        kex: 'curve25519-sha256,diffie-hellman-group16-sha512'
+        ciphers: 'aes256-ctr'
+        kexalgorithms: 'curve25519-sha256,diffie-hellman-group16-sha512'
     state: replaced
 
 # After state:
 # ------------
 #
-# sonic# show running-configuration | grep "ip ssh client"
-# ip ssh client ciphers aes256-ctr
-# ip ssh client kexalgorithms curve25519-sha256,diffie-hellman-group16-sha512
+# sonic# show running-configuration | grep "ip ssh server"
+# ip ssh server ciphers aes256-ctr
+# ip ssh server kexalgorithms curve25519-sha256,diffie-hellman-group16-sha512
 # sonic#
 
 


### PR DESCRIPTION
##### SUMMARY
Correct the replaced-state documentation example to use the `sonic_ssh_server` module, server CLI output, and the valid `ciphers` and `kexalgorithms` options. The generated module documentation and changelog fragment are updated together.

##### GitHub Issues

| GitHub Issue # |
| -------------- |
| #639 |

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
sonic_ssh_server

##### OUTPUT
```
python3 -m py_compile plugins/modules/sonic_ssh_server.py
```

##### ADDITIONAL INFORMATION
The previous example mixed SSH client commands and option names into the SSH server module documentation.

##### Checklist:
- [x] I have performed a self-review of my own code to ensure there are no formatting, linting, or security issues
- [x] I have made corresponding changes to the documentation
- [x] I have provided a summary for this PR in valid fragment file format in the changelogs/fragments directory of this repository branch.

##### How Has This Been Tested?
- [x] `python3 -m py_compile plugins/modules/sonic_ssh_server.py`
- [x] `git diff --check`

Fixes #639